### PR TITLE
fix(ci): resolve iOS provisioning profile installation issue

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -69,10 +69,12 @@ jobs:
 
           security import $CERTIFICATE_PATH -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH login.keychain-db
 
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp $PROVISIONING_PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/
+          PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< $(/usr/bin/security cms -D -i $PROVISIONING_PROFILE_PATH))
+          cp $PROVISIONING_PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/$PROFILE_UUID.mobileprovision
+          echo "Installed provisioning profile with UUID: $PROFILE_UUID"
 
       - name: Build Flutter iOS
         run: |

--- a/app/ios/fastlane/Fastfile
+++ b/app/ios/fastlane/Fastfile
@@ -3,8 +3,6 @@ default_platform(:ios)
 platform :ios do
   desc "Build and upload to TestFlight"
   lane :beta do
-    setup_ci if ENV['CI']
-
     api_key = app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],


### PR DESCRIPTION
- Provisioning profile을 UUID 파일명으로 저장하여 Xcode가 인식할 수 있도록 수정
- Keychain 목록에 login.keychain-db 유지하여 certificate 접근 보장
- Fastlane setup_ci 제거로 keychain 충돌 방지