### PR TITLE
feature/BYU-186-mvvm-phase-1

### DIFF
--- a/app/lib/core/view_model/auth_view_model.dart
+++ b/app/lib/core/view_model/auth_view_model.dart
@@ -1,0 +1,187 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:book_golas/core/view_model/base_view_model.dart';
+import 'package:book_golas/data/repositories/auth_repository.dart';
+import 'package:book_golas/domain/models/user_model.dart';
+
+class AuthViewModel extends BaseViewModel {
+  final AuthRepository _authRepository;
+  StreamSubscription<AuthState>? _authSubscription;
+
+  UserModel? _currentUser;
+
+  UserModel? get currentUser => _currentUser;
+  bool get isAuthenticated => _currentUser != null;
+
+  AuthViewModel(this._authRepository) {
+    _init();
+  }
+
+  void _init() {
+    _currentUser = _authRepository.currentUser;
+
+    _authSubscription =
+        Supabase.instance.client.auth.onAuthStateChange.listen((data) {
+      final AuthChangeEvent event = data.event;
+      final Session? session = data.session;
+
+      switch (event) {
+        case AuthChangeEvent.signedIn:
+          if (session?.user != null) {
+            _currentUser = UserModel.fromUser(session!.user);
+            notifyListeners();
+          }
+          break;
+        case AuthChangeEvent.signedOut:
+          _currentUser = null;
+          notifyListeners();
+          break;
+        default:
+          break;
+      }
+    });
+  }
+
+  Future<String?> signUpWithEmail({
+    required String email,
+    required String password,
+    String? name,
+  }) async {
+    setLoading(true);
+    clearError();
+    try {
+      final error = await _authRepository.signUpWithEmail(
+        email: email,
+        password: password,
+        name: name,
+      );
+      if (error != null) {
+        setError(error);
+      }
+      return error;
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  Future<String?> signInWithEmail({
+    required String email,
+    required String password,
+  }) async {
+    setLoading(true);
+    clearError();
+    try {
+      final error = await _authRepository.signInWithEmail(
+        email: email,
+        password: password,
+      );
+      if (error != null) {
+        setError(error);
+      }
+      return error;
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  Future<String?> signInWithKakao() async {
+    setLoading(true);
+    clearError();
+    try {
+      final error = await _authRepository.signInWithKakao();
+      if (error != null) {
+        setError(error);
+      }
+      return error;
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  Future<String?> signInWithGoogle() async {
+    setLoading(true);
+    clearError();
+    try {
+      final error = await _authRepository.signInWithGoogle();
+      if (error != null) {
+        setError(error);
+      }
+      return error;
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  Future<String?> signOut() async {
+    final error = await _authRepository.signOut();
+    if (error == null) {
+      _currentUser = null;
+      notifyListeners();
+    }
+    return error;
+  }
+
+  Future<String?> resetPassword(String email) async {
+    setLoading(true);
+    clearError();
+    try {
+      final error = await _authRepository.resetPassword(email);
+      if (error != null) {
+        setError(error);
+      }
+      return error;
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  Future<UserModel?> fetchCurrentUser() async {
+    final user = await _authRepository.fetchCurrentUser();
+    if (user != null) {
+      _currentUser = user;
+      notifyListeners();
+    }
+    return user;
+  }
+
+  Future<void> updateNickname(String nickname) async {
+    await runAsync(() async {
+      await _authRepository.updateNickname(nickname);
+      await fetchCurrentUser();
+    });
+  }
+
+  Future<void> uploadAvatar(File file) async {
+    await runAsync(() async {
+      await _authRepository.uploadAvatar(file);
+      await fetchCurrentUser();
+    });
+  }
+
+  Future<UserModel?> getCurrentUser() async {
+    final user = await _authRepository.getCurrentUser();
+    if (user != null) {
+      _currentUser = user;
+      notifyListeners();
+    }
+    return user;
+  }
+
+  Future<bool> deleteAccount() async {
+    final result = await _authRepository.deleteAccount();
+    if (result) {
+      _currentUser = null;
+      notifyListeners();
+    }
+    return result;
+  }
+
+  @override
+  void dispose() {
+    _authSubscription?.cancel();
+    super.dispose();
+  }
+}

--- a/app/lib/core/view_model/base_view_model.dart
+++ b/app/lib/core/view_model/base_view_model.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/foundation.dart';
+
+abstract class BaseViewModel extends ChangeNotifier {
+  bool _isLoading = false;
+  String? _errorMessage;
+  bool _isDisposed = false;
+
+  bool get isLoading => _isLoading;
+  String? get errorMessage => _errorMessage;
+  bool get hasError => _errorMessage != null;
+
+  @protected
+  void setLoading(bool value) {
+    if (_isDisposed) return;
+    _isLoading = value;
+    notifyListeners();
+  }
+
+  @protected
+  void setError(String? message) {
+    if (_isDisposed) return;
+    _errorMessage = message;
+    notifyListeners();
+  }
+
+  @protected
+  void clearError() {
+    if (_isDisposed) return;
+    _errorMessage = null;
+    notifyListeners();
+  }
+
+  @protected
+  Future<T?> runAsync<T>(Future<T> Function() action) async {
+    if (_isDisposed) return null;
+    setLoading(true);
+    clearError();
+    try {
+      final result = await action();
+      if (!_isDisposed) {
+        setLoading(false);
+      }
+      return result;
+    } catch (e) {
+      if (!_isDisposed) {
+        setError(e.toString());
+        setLoading(false);
+      }
+      return null;
+    }
+  }
+
+  @override
+  void notifyListeners() {
+    if (!_isDisposed) {
+      super.notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    super.dispose();
+  }
+}

--- a/app/lib/data/repositories/auth_repository.dart
+++ b/app/lib/data/repositories/auth_repository.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+import 'package:book_golas/data/services/auth_service.dart';
+import 'package:book_golas/domain/models/user_model.dart';
+
+abstract class AuthRepository {
+  UserModel? get currentUser;
+
+  Future<String?> signUpWithEmail({
+    required String email,
+    required String password,
+    String? name,
+  });
+
+  Future<String?> signInWithEmail({
+    required String email,
+    required String password,
+  });
+
+  Future<String?> signInWithKakao();
+
+  Future<String?> signInWithGoogle();
+
+  Future<String?> signOut();
+
+  Future<String?> resetPassword(String email);
+
+  Future<UserModel?> fetchCurrentUser();
+
+  Future<void> updateNickname(String nickname);
+
+  Future<void> uploadAvatar(File file);
+
+  Future<UserModel?> getCurrentUser();
+
+  Future<bool> deleteAccount();
+}
+
+class AuthRepositoryImpl implements AuthRepository {
+  final AuthService _authService;
+
+  AuthRepositoryImpl(this._authService);
+
+  @override
+  UserModel? get currentUser => _authService.currentUser;
+
+  @override
+  Future<String?> signUpWithEmail({
+    required String email,
+    required String password,
+    String? name,
+  }) =>
+      _authService.signUpWithEmail(
+        email: email,
+        password: password,
+        name: name,
+      );
+
+  @override
+  Future<String?> signInWithEmail({
+    required String email,
+    required String password,
+  }) =>
+      _authService.signInWithEmail(
+        email: email,
+        password: password,
+      );
+
+  @override
+  Future<String?> signInWithKakao() => _authService.signInWithKakao();
+
+  @override
+  Future<String?> signInWithGoogle() => _authService.signInWithGoogle();
+
+  @override
+  Future<String?> signOut() => _authService.signOut();
+
+  @override
+  Future<String?> resetPassword(String email) =>
+      _authService.resetPassword(email);
+
+  @override
+  Future<UserModel?> fetchCurrentUser() => _authService.fetchCurrentUser();
+
+  @override
+  Future<void> updateNickname(String nickname) =>
+      _authService.updateNickname(nickname);
+
+  @override
+  Future<void> uploadAvatar(File file) => _authService.uploadAvatar(file);
+
+  @override
+  Future<UserModel?> getCurrentUser() => _authService.getCurrentUser();
+
+  @override
+  Future<bool> deleteAccount() => _authService.deleteAccount();
+}

--- a/app/lib/features/auth/widgets/my_page_screen.dart
+++ b/app/lib/features/auth/widgets/my_page_screen.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 
-import 'package:book_golas/data/services/auth_service.dart';
+import 'package:book_golas/core/view_model/auth_view_model.dart';
 import 'package:book_golas/data/services/fcm_service.dart';
 import 'package:book_golas/data/services/notification_settings_service.dart';
 import 'package:book_golas/core/view_model/theme_view_model.dart';
@@ -27,7 +27,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final user = context.watch<AuthService>().currentUser;
+    final user = context.watch<AuthViewModel>().currentUser;
     _nicknameController = TextEditingController(text: user?.nickname ?? '');
   }
 
@@ -41,7 +41,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
   void initState() {
     super.initState();
     Future.microtask(() {
-      context.read<AuthService>().fetchCurrentUser();
+      context.read<AuthViewModel>().fetchCurrentUser();
       context.read<NotificationSettingsService>().loadSettings();
     });
   }
@@ -79,8 +79,8 @@ class _MyPageScreenState extends State<MyPageScreen> {
 
   Future<void> _deleteAccount() async {
     try {
-      final authService = context.read<AuthService>();
-      final success = await authService.deleteAccount();
+      final authViewModel = context.read<AuthViewModel>();
+      final success = await authViewModel.deleteAccount();
 
       if (success && mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -330,8 +330,8 @@ class _MyPageScreenState extends State<MyPageScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final authService = context.watch<AuthService>();
-    final user = authService.currentUser;
+    final authViewModel = context.watch<AuthViewModel>();
+    final user = authViewModel.currentUser;
 
     return Scaffold(
       appBar: AppBar(
@@ -347,7 +347,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
       ),
       body: RefreshIndicator(
         onRefresh: () async {
-          await authService.fetchCurrentUser();
+          await authViewModel.fetchCurrentUser();
 
           setState(() {});
         },
@@ -461,9 +461,9 @@ class _MyPageScreenState extends State<MyPageScreen> {
                               ElevatedButton(
                                 onPressed: () async {
                                   if (_pendingAvatarFile != null) {
-                                    print(
+                                    debugPrint(
                                         '_pendingAvatarFile: $_pendingAvatarFile');
-                                    await authService
+                                    await authViewModel
                                         .uploadAvatar(_pendingAvatarFile!);
                                     setState(() {
                                       _pendingAvatarFile = null;
@@ -504,7 +504,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
                             const SizedBox(width: 8),
                             ElevatedButton(
                               onPressed: () async {
-                                await authService
+                                await authViewModel
                                     .updateNickname(_nicknameController.text);
                                 setState(() {
                                   _isEditingNickname = false;
@@ -618,7 +618,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
                     children: [
                       ElevatedButton(
                         onPressed: () async {
-                          await context.read<AuthService>().signOut();
+                          await context.read<AuthViewModel>().signOut();
                           if (context.mounted) {
                             Navigator.of(context).pushAndRemoveUntil(
                               MaterialPageRoute(


### PR DESCRIPTION
## Summary
AuthService를 순수 서비스, Repository, ViewModel로 분리하여 MVVM 패턴 적용

## 📋 Changes

- `lib/core/view_model/base_view_model.dart` 신규 생성
  - 공통 isLoading, errorMessage, runAsync 패턴 제공
  - dispose 시 안전한 notifyListeners 처리
- `lib/data/repositories/auth_repository.dart` 신규 생성
  - AuthRepository 인터페이스 정의
  - AuthRepositoryImpl 구현체 생성
- `lib/core/view_model/auth_view_model.dart` 신규 생성
  - AuthRepository 의존성 주입
  - Supabase auth state 구독 관리
- `lib/data/services/auth_service.dart` 수정
  - ChangeNotifier 상속 제거
  - 순수 서비스 클래스로 변환
- `lib/main.dart` 수정
  - Service → Repository → ViewModel Provider 체인 구성
  - AuthWrapper에서 AuthViewModel 사용
- `lib/features/auth/widgets/my_page_screen.dart` 수정
  - AuthService → AuthViewModel으로 마이그레이션

## 🧠 Context & Background

BYU-186 MVVM 패턴 전면 적용 계획의 Phase 1입니다.
기존에 ChangeNotifier를 상속받던 AuthService를 순수 서비스로 분리하고,
MVVM 패턴에 맞게 Repository와 ViewModel 레이어를 추가했습니다.

## ✅ How to Test

1. 앱 실행 후 로그인/로그아웃 기능 확인
2. 마이페이지에서 닉네임 변경, 아바타 업로드 기능 확인
3. 계정 삭제 기능 확인

## 🔗 Related Issues

- Related: BYU-186 MVVM 패턴 전면 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)