### PR TITLE
feature/BYU-186-mvvm-phase-2

### DIFF
--- a/app/lib/core/view_model/notification_settings_view_model.dart
+++ b/app/lib/core/view_model/notification_settings_view_model.dart
@@ -1,0 +1,80 @@
+import 'package:book_golas/core/view_model/base_view_model.dart';
+import 'package:book_golas/data/repositories/notification_settings_repository.dart';
+import 'package:book_golas/data/services/notification_settings_service.dart';
+
+class NotificationSettingsViewModel extends BaseViewModel {
+  final NotificationSettingsRepository _repository;
+
+  NotificationSettings _settings = NotificationSettings(
+    preferredHour: 9,
+    notificationEnabled: true,
+  );
+
+  NotificationSettings get settings => _settings;
+
+  NotificationSettingsViewModel(this._repository);
+
+  Future<void> loadSettings() async {
+    setLoading(true);
+    clearError();
+    try {
+      final loadedSettings = await _repository.loadSettings();
+      if (loadedSettings != null) {
+        _settings = loadedSettings;
+      }
+    } catch (e) {
+      setError(e.toString());
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  Future<bool> updatePreferredHour(int hour) async {
+    if (hour < 0 || hour > 23) {
+      setError('Invalid hour: must be 0-23');
+      return false;
+    }
+
+    setLoading(true);
+    clearError();
+    try {
+      final success = await _repository.updatePreferredHour(hour);
+      if (success) {
+        _settings = _settings.copyWith(preferredHour: hour);
+        notifyListeners();
+      }
+      return success;
+    } catch (e) {
+      setError(e.toString());
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  Future<bool> updateNotificationEnabled(bool enabled) async {
+    setLoading(true);
+    clearError();
+    try {
+      final success = await _repository.updateNotificationEnabled(enabled);
+      if (success) {
+        _settings = _settings.copyWith(notificationEnabled: enabled);
+        notifyListeners();
+      }
+      return success;
+    } catch (e) {
+      setError(e.toString());
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  String getFormattedTime() {
+    final hour = _settings.preferredHour;
+    if (hour == 0) return '오전 12시';
+    if (hour < 12) return '오전 $hour시';
+    if (hour == 12) return '오후 12시';
+    return '오후 ${hour - 12}시';
+  }
+}

--- a/app/lib/data/repositories/notification_settings_repository.dart
+++ b/app/lib/data/repositories/notification_settings_repository.dart
@@ -1,0 +1,32 @@
+import 'package:book_golas/data/services/notification_settings_service.dart';
+
+abstract class NotificationSettingsRepository {
+  NotificationSettings get settings;
+
+  Future<NotificationSettings?> loadSettings();
+
+  Future<bool> updatePreferredHour(int hour);
+
+  Future<bool> updateNotificationEnabled(bool enabled);
+}
+
+class NotificationSettingsRepositoryImpl
+    implements NotificationSettingsRepository {
+  final NotificationSettingsService _service;
+
+  NotificationSettingsRepositoryImpl(this._service);
+
+  @override
+  NotificationSettings get settings => _service.settings;
+
+  @override
+  Future<NotificationSettings?> loadSettings() => _service.loadSettings();
+
+  @override
+  Future<bool> updatePreferredHour(int hour) =>
+      _service.updatePreferredHour(hour);
+
+  @override
+  Future<bool> updateNotificationEnabled(bool enabled) =>
+      _service.updateNotificationEnabled(enabled);
+}

--- a/app/lib/features/auth/widgets/my_page_screen.dart
+++ b/app/lib/features/auth/widgets/my_page_screen.dart
@@ -6,6 +6,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 
 import 'package:book_golas/core/view_model/auth_view_model.dart';
+import 'package:book_golas/core/view_model/notification_settings_view_model.dart';
 import 'package:book_golas/data/services/fcm_service.dart';
 import 'package:book_golas/data/services/notification_settings_service.dart';
 import 'package:book_golas/core/view_model/theme_view_model.dart';
@@ -42,7 +43,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
     super.initState();
     Future.microtask(() {
       context.read<AuthViewModel>().fetchCurrentUser();
-      context.read<NotificationSettingsService>().loadSettings();
+      context.read<NotificationSettingsViewModel>().loadSettings();
     });
   }
 
@@ -210,10 +211,10 @@ class _MyPageScreenState extends State<MyPageScreen> {
   }
 
   Widget _buildNotificationSettings() {
-    return Consumer<NotificationSettingsService>(
-      builder: (context, settingsService, child) {
-        final settings = settingsService.settings;
-        final isLoading = settingsService.isLoading;
+    return Consumer<NotificationSettingsViewModel>(
+      builder: (context, settingsViewModel, child) {
+        final settings = settingsViewModel.settings;
+        final isLoading = settingsViewModel.isLoading;
 
         return Column(
           children: [
@@ -222,7 +223,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
               title: const Text('매일 독서 목표 알림'),
               subtitle: Text(
                 settings.notificationEnabled
-                    ? '매일 ${settingsService.getFormattedTime()}에 알림을 받습니다'
+                    ? '매일 ${settingsViewModel.getFormattedTime()}에 알림을 받습니다'
                     : '알림을 받지 않습니다',
               ),
               trailing: isLoading
@@ -234,7 +235,8 @@ class _MyPageScreenState extends State<MyPageScreen> {
                   : Switch(
                       value: settings.notificationEnabled,
                       onChanged: (value) async {
-                        final success = await settingsService.updateNotificationEnabled(value);
+                        final success =
+                            await settingsViewModel.updateNotificationEnabled(value);
 
                         if (success) {
                           if (value) {
@@ -260,7 +262,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
                               content: Text(
-                                settingsService.error ?? '알림 설정 변경에 실패했습니다',
+                                settingsViewModel.errorMessage ?? '알림 설정 변경에 실패했습니다',
                               ),
                               backgroundColor: Colors.red,
                             ),
@@ -283,7 +285,8 @@ class _MyPageScreenState extends State<MyPageScreen> {
                           );
 
                           if (selectedHour != null) {
-                            final success = await settingsService.updatePreferredHour(selectedHour);
+                            final success =
+                                await settingsViewModel.updatePreferredHour(selectedHour);
 
                             if (success) {
                               await FCMService().scheduleDailyNotification(
@@ -295,7 +298,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
                                 ScaffoldMessenger.of(context).showSnackBar(
                                   SnackBar(
                                     content: Text(
-                                      '알림 시간이 ${settingsService.getFormattedTime()}으로 변경되었습니다',
+                                      '알림 시간이 ${settingsViewModel.getFormattedTime()}으로 변경되었습니다',
                                     ),
                                     backgroundColor: Colors.green,
                                   ),
@@ -305,7 +308,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
                               ScaffoldMessenger.of(context).showSnackBar(
                                 SnackBar(
                                   content: Text(
-                                    settingsService.error ?? '알림 시간 변경에 실패했습니다',
+                                    settingsViewModel.errorMessage ?? '알림 시간 변경에 실패했습니다',
                                   ),
                                   backgroundColor: Colors.red,
                                 ),
@@ -314,7 +317,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
                           }
                         },
                   child: Text(
-                    settingsService.getFormattedTime(),
+                    settingsViewModel.getFormattedTime(),
                     style: const TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.bold,

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -10,10 +10,12 @@ import 'package:book_golas/features/reading_start/widgets/reading_start_screen.d
 import 'package:book_golas/config/app_config.dart';
 import 'package:book_golas/data/repositories/book_repository.dart';
 import 'package:book_golas/data/repositories/auth_repository.dart';
+import 'package:book_golas/data/repositories/notification_settings_repository.dart';
 import 'package:book_golas/data/services/book_service.dart';
 import 'package:book_golas/features/home/view_model/home_view_model.dart';
 import 'package:book_golas/core/view_model/theme_view_model.dart';
 import 'package:book_golas/core/view_model/auth_view_model.dart';
+import 'package:book_golas/core/view_model/notification_settings_view_model.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'firebase_options.dart';
@@ -181,6 +183,9 @@ class MyApp extends StatelessWidget {
         Provider<AuthService>(
           create: (_) => AuthService(),
         ),
+        Provider<NotificationSettingsService>(
+          create: (_) => NotificationSettingsService(),
+        ),
         Provider<ReadingProgressService>(
           create: (_) => ReadingProgressService(),
         ),
@@ -195,6 +200,11 @@ class MyApp extends StatelessWidget {
             context.read<AuthService>(),
           ),
         ),
+        Provider<NotificationSettingsRepository>(
+          create: (context) => NotificationSettingsRepositoryImpl(
+            context.read<NotificationSettingsService>(),
+          ),
+        ),
         // === ViewModels ===
         ChangeNotifierProvider<HomeViewModel>(
           create: (context) => HomeViewModel(
@@ -206,8 +216,12 @@ class MyApp extends StatelessWidget {
             context.read<AuthRepository>(),
           ),
         ),
+        ChangeNotifierProvider<NotificationSettingsViewModel>(
+          create: (context) => NotificationSettingsViewModel(
+            context.read<NotificationSettingsRepository>(),
+          ),
+        ),
         ChangeNotifierProvider(create: (_) => ThemeViewModel()),
-        ChangeNotifierProvider(create: (_) => NotificationSettingsService()),
       ],
       child: Consumer<ThemeViewModel>(
         builder: (context, themeViewModel, child) {


### PR DESCRIPTION
## Summary
NotificationSettingsService를 순수 서비스, Repository, ViewModel로 분리하여 MVVM 패턴 적용

## 📋 Changes

- `lib/data/repositories/notification_settings_repository.dart` 신규 생성
  - NotificationSettingsRepository 인터페이스 정의
  - NotificationSettingsRepositoryImpl 구현체 생성
- `lib/core/view_model/notification_settings_view_model.dart` 신규 생성
  - BaseViewModel 상속
  - 알림 설정 상태 관리
- `lib/data/services/notification_settings_service.dart` 수정
  - ChangeNotifier 상속 제거
  - 순수 서비스 클래스로 변환
- `lib/main.dart` 수정
  - NotificationSettingsService → Repository → ViewModel Provider 체인 구성
- `lib/features/auth/widgets/my_page_screen.dart` 수정
  - NotificationSettingsService → NotificationSettingsViewModel 마이그레이션

## 🧠 Context & Background

BYU-186 MVVM 패턴 전면 적용 계획의 Phase 2입니다.
Phase 1에서 생성한 BaseViewModel을 상속받아 NotificationSettingsViewModel을 구현했습니다.

## ✅ How to Test

1. 앱 실행 후 마이페이지 진입
2. 알림 설정 토글 기능 확인
3. 알림 시간 변경 기능 확인

## 🔗 Related Issues

- Related: BYU-186 MVVM 패턴 전면 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)