### PR TITLE
ci: iOS App Store Production 배포 자동화

### DIFF
--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -1,0 +1,114 @@
+name: iOS App Store Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.35.0'
+          channel: 'stable'
+          cache: true
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install Ruby dependencies
+        run: |
+          cd app/ios
+          bundle install
+
+      - name: Flutter pub get
+        run: |
+          cd app
+          flutter pub get
+
+      - name: Install CocoaPods
+        run: |
+          cd app/ios
+          bundle exec pod install --repo-update
+
+      - name: Create .env file
+        run: |
+          cd app
+          echo "ALADIN_TTB_KEY=${{ secrets.ALADIN_TTB_KEY }}" >> .env
+          echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" >> .env
+          echo "SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}" >> .env
+          echo "ENVIRONMENT=production" >> .env
+
+      - name: Install Certificate and Provisioning Profile
+        id: install-cert
+        env:
+          CERTIFICATE_P12_BASE64: ${{ secrets.CERTIFICATE_P12_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
+          KEYCHAIN_PASSWORD: ${{ github.run_id }}
+        run: |
+          CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
+          PROVISIONING_PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          echo -n "$CERTIFICATE_P12_BASE64" | base64 --decode > $CERTIFICATE_PATH
+          echo -n "$PROVISIONING_PROFILE_BASE64" | base64 --decode > $PROVISIONING_PROFILE_PATH
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          security import $CERTIFICATE_PATH -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH login.keychain-db
+
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+
+          PROFILE_PLIST=$(/usr/bin/security cms -D -i $PROVISIONING_PROFILE_PATH)
+          PROFILE_UUID=$(echo "$PROFILE_PLIST" | /usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin)
+          PROFILE_NAME=$(echo "$PROFILE_PLIST" | /usr/libexec/PlistBuddy -c "Print Name" /dev/stdin)
+
+          cp $PROVISIONING_PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/$PROFILE_UUID.mobileprovision
+
+          echo "PROVISIONING_PROFILE_UUID=$PROFILE_UUID" >> $GITHUB_OUTPUT
+          echo "PROVISIONING_PROFILE_NAME=$PROFILE_NAME" >> $GITHUB_OUTPUT
+
+          echo "Installed provisioning profile:"
+          echo "   UUID: $PROFILE_UUID"
+          echo "   Name: $PROFILE_NAME"
+          echo ""
+          echo "Installed profiles:"
+          ls -la ~/Library/MobileDevice/Provisioning\ Profiles/
+          echo ""
+          echo "Keychain certificates:"
+          security find-identity -v -p codesigning $KEYCHAIN_PATH
+
+      - name: Build Flutter iOS
+        run: |
+          cd app
+          flutter build ios --release --no-codesign --build-number=${{ github.run_number }}
+
+      - name: Build and Upload to App Store
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+          PROVISIONING_PROFILE_NAME: ${{ steps.install-cert.outputs.PROVISIONING_PROFILE_NAME }}
+        run: |
+          cd app/ios
+          bundle exec fastlane release
+
+      - name: Clean up keychain
+        if: always()
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true

--- a/app/ios/fastlane/Fastfile
+++ b/app/ios/fastlane/Fastfile
@@ -38,4 +38,45 @@ platform :ios do
       distribute_external: false
     )
   end
+
+  desc "Build and upload to App Store for review"
+  lane :release do
+    api_key = app_store_connect_api_key(
+      key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
+      issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],
+      key_content: ENV["APP_STORE_CONNECT_API_KEY_CONTENT"],
+      is_key_content_base64: true
+    )
+
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: "Runner.xcodeproj",
+      team_id: "7PFH55UQ86",
+      bundle_identifier: "com.bookgolas.app",
+      code_sign_identity: "Apple Distribution",
+      profile_name: ENV["PROVISIONING_PROFILE_NAME"] || "Bookgolas App Store"
+    )
+
+    build_app(
+      workspace: "Runner.xcworkspace",
+      scheme: "Runner",
+      export_method: "app-store",
+      export_options: {
+        provisioningProfiles: {
+          "com.bookgolas.app" => ENV["PROVISIONING_PROFILE_NAME"] || "Bookgolas App Store"
+        }
+      },
+      output_directory: "./build",
+      output_name: "Runner.ipa"
+    )
+
+    upload_to_app_store(
+      api_key: api_key,
+      skip_metadata: true,
+      skip_screenshots: true,
+      precheck_include_in_app_purchases: false,
+      submit_for_review: false,
+      automatic_release: false
+    )
+  end
 end


### PR DESCRIPTION
main 브랜치 push 시 iOS App Store에 빌드를 자동 업로드하는 CI/CD 파이프라인 추가

## 📋 Changes

- `Fastfile`에 `release` lane 추가 (App Store 업로드용)
- `ios-production.yml` GitHub Actions 워크플로우 생성
- main 브랜치 push 시 자동 트리거

## 🧠 Context & Background

현재 dev 브랜치는 TestFlight 배포가 자동화되어 있으나, main 브랜치(Production)는 수동 배포 필요했음.
이 PR로 main → App Store 배포도 자동화됨.

### 배포 플로우
```
dev push    → ios-testflight.yml → TestFlight 배포
main push   → ios-production.yml → App Store 업로드 (심사 대기)
```

### release lane 설정
- `skip_metadata: true` - 메타데이터는 App Store Connect 웹에서 관리
- `skip_screenshots: true` - 스크린샷도 웹에서 관리
- `submit_for_review: false` - 수동 심사 제출 (안전)
- `automatic_release: false` - 수동 릴리즈

## ✅ How to Test

1. main 브랜치에 push
2. GitHub Actions에서 `iOS App Store Deploy` 워크플로우 확인
3. App Store Connect에서 빌드 업로드 확인

## 🔗 Related Issues

- Closes: BYU-203

🤖 Generated with [Claude Code](https://claude.com/claude-code)