### PR TITLE
feat: Supabase 환경 분리 (prod/dev)

### DIFF
--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -45,8 +45,8 @@ jobs:
         run: |
           cd app
           echo "ALADIN_TTB_KEY=${{ secrets.ALADIN_TTB_KEY }}" >> .env
-          echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" >> .env
-          echo "SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}" >> .env
+          echo "SUPABASE_URL_PROD=${{ secrets.SUPABASE_URL_PROD }}" >> .env
+          echo "SUPABASE_ANON_KEY_PROD=${{ secrets.SUPABASE_ANON_KEY_PROD }}" >> .env
           echo "ENVIRONMENT=production" >> .env
 
       - name: Install Certificate and Provisioning Profile

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -45,9 +45,9 @@ jobs:
         run: |
           cd app
           echo "ALADIN_TTB_KEY=${{ secrets.ALADIN_TTB_KEY }}" >> .env
-          echo "SUPABASE_URL=${{ secrets.SUPABASE_URL }}" >> .env
-          echo "SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}" >> .env
-          echo "ENVIRONMENT=production" >> .env
+          echo "SUPABASE_URL_DEV=${{ secrets.SUPABASE_URL_DEV }}" >> .env
+          echo "SUPABASE_ANON_KEY_DEV=${{ secrets.SUPABASE_ANON_KEY_DEV }}" >> .env
+          echo "ENVIRONMENT=development" >> .env
 
       - name: Install Certificate and Provisioning Profile
         id: install-cert

--- a/app/lib/config/app_config.dart
+++ b/app/lib/config/app_config.dart
@@ -8,11 +8,28 @@ class AppConfig {
   static String get aladinBaseUrl =>
       'http://www.aladin.co.kr/ttb/api/ItemSearch.aspx';
 
-  // Supabase 설정
-  static String get supabaseUrl =>
-      dotenv.env['SUPABASE_URL'] ?? 'https://enyxrgxixrnoazzgqyyd.supabase.co';
-  static String get supabaseAnonKey =>
-      dotenv.env['SUPABASE_ANON_KEY'] ?? 'your_supabase_anon_key_here';
+  // Supabase 설정 (환경별 분기)
+  static String get supabaseUrl {
+    if (isProduction) {
+      return dotenv.env['SUPABASE_URL_PROD'] ??
+          dotenv.env['SUPABASE_URL'] ??
+          'https://enyxrgxixrnoazzgqyyd.supabase.co';
+    }
+    return dotenv.env['SUPABASE_URL_DEV'] ??
+        dotenv.env['SUPABASE_URL'] ??
+        'https://reoiqefoymdsqzpbouxi.supabase.co';
+  }
+
+  static String get supabaseAnonKey {
+    if (isProduction) {
+      return dotenv.env['SUPABASE_ANON_KEY_PROD'] ??
+          dotenv.env['SUPABASE_ANON_KEY'] ??
+          '';
+    }
+    return dotenv.env['SUPABASE_ANON_KEY_DEV'] ??
+        dotenv.env['SUPABASE_ANON_KEY'] ??
+        '';
+  }
 
   // Google Cloud Vision API 설정
   static String get googleCloudVisionApiKey =>
@@ -29,7 +46,7 @@ class AppConfig {
       throw Exception(
           'ALADIN_TTB_KEY is required but not found in environment variables');
     }
-    if (supabaseAnonKey == 'your_supabase_anon_key_here') {
+    if (supabaseAnonKey.isEmpty) {
       throw Exception(
           'SUPABASE_ANON_KEY is required but not properly configured');
     }


### PR DESCRIPTION
## Summary
main 브랜치와 dev 브랜치에서 서로 다른 Supabase 프로젝트에 연결되도록 환경 분리 구현

## 📋 Changes

- `app_config.dart`에 환경별 Supabase URL/Key 분기 로직 추가
- `ios-testflight.yml`에서 dev 환경변수 사용 (`ENVIRONMENT=development`)
- `ios-production.yml`에서 prod 환경변수 사용 (`ENVIRONMENT=production`)
- GitHub Secrets에 4개 시크릿 추가 완료
  - `SUPABASE_URL_PROD`, `SUPABASE_ANON_KEY_PROD`
  - `SUPABASE_URL_DEV`, `SUPABASE_ANON_KEY_DEV`

## 🧠 Context & Background

- Supabase Free 플랜 제한으로 인해 notion-rag 프로젝트 일시정지
- book-golas-dev 프로젝트 신규 생성 및 스키마 동기화 완료
- 운영 데이터와 개발 데이터 분리로 안전한 테스트 환경 확보

## ✅ How to Test

1. dev 브랜치 push → TestFlight 배포 → dev DB 연결 확인
2. main 브랜치 push → App Store 배포 → prod DB 연결 확인

## 🔗 Related Issues

- Related: BYU-203

🤖 Generated with [Claude Code](https://claude.com/claude-code)