### PR TITLE
daily/2026-01-02 → dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,18 @@ PR 생성 시 아래 템플릿을 사용해. (인용문은 지우고 해당 내�
 
 나에게 리뷰할 때만 주석을 포함해서 알려주고, 커밋 및 푸시 시점에는 주석은 삭제해야해.
 
+### Import Rules
+
+- **패키지 별칭 사용 필수**: 상대 경로(`../../../`) 대신 패키지 별칭(`package:book_golas/...`) 사용
+- 예시:
+  ```dart
+  // ✅ Good
+  import 'package:book_golas/ui/core/widgets/glass_text_field.dart';
+
+  // ❌ Bad
+  import '../../../core/widgets/glass_text_field.dart';
+  ```
+
 ## Tech Stack
 
 - **Frontend**: Flutter 3.5.3 with Dart

--- a/app/lib/ui/auth/widgets/login_screen.dart
+++ b/app/lib/ui/auth/widgets/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:book_golas/ui/core/widgets/custom_snackbar.dart';
+import 'package:book_golas/ui/core/widgets/glass_text_field.dart';
 import 'package:book_golas/ui/core/widgets/keyboard_accessory_bar.dart';
 
 enum AuthMode { signIn, signUp, forgotPassword }
@@ -29,7 +30,6 @@ class _LoginScreenState extends State<LoginScreen> {
   AuthMode _authMode = AuthMode.signIn;
   bool _isLoading = false;
   bool _saveEmail = false;
-  bool _obscurePassword = true;
   bool _isKeyboardVisible = false;
 
   @override
@@ -384,9 +384,9 @@ class _LoginScreenState extends State<LoginScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  _buildGlassTextField(
+                  GlassTextField(
+                    key: _emailFieldKey,
                     controller: _emailController,
-                    fieldKey: _emailFieldKey,
                     focusNode: _emailFocusNode,
                     label: '이메일',
                     hint: 'example@email.com',
@@ -410,13 +410,14 @@ class _LoginScreenState extends State<LoginScreen> {
                   ),
                   if (_authMode != AuthMode.forgotPassword) ...[
                     const SizedBox(height: 16),
-                    _buildGlassTextField(
+                    GlassTextField(
+                      key: _passwordFieldKey,
                       controller: _passwordController,
-                      fieldKey: _passwordFieldKey,
                       focusNode: _passwordFocusNode,
                       label: '비밀번호',
                       hint: '6자 이상 입력해주세요',
-                      obscureText: _obscurePassword,
+                      obscureText: true,
+                      showPasswordToggle: true,
                       prefixIcon: Icons.lock_outline,
                       isDark: isDark,
                       textInputAction: _authMode == AuthMode.signUp
@@ -428,18 +429,6 @@ class _LoginScreenState extends State<LoginScreen> {
                           : const [AutofillHints.newPassword],
                       autocorrect: false,
                       enableSuggestions: false,
-                      suffixIcon: IconButton(
-                        icon: Icon(
-                          _obscurePassword
-                              ? Icons.visibility_off_outlined
-                              : Icons.visibility_outlined,
-                          color: isDark ? Colors.grey[400] : Colors.grey[600],
-                          size: 20,
-                        ),
-                        onPressed: () {
-                          setState(() => _obscurePassword = !_obscurePassword);
-                        },
-                      ),
                       validator: (value) {
                         if (value == null || value.isEmpty) {
                           return '비밀번호를 입력해주세요';
@@ -453,9 +442,9 @@ class _LoginScreenState extends State<LoginScreen> {
                   ],
                   if (_authMode == AuthMode.signUp) ...[
                     const SizedBox(height: 16),
-                    _buildGlassTextField(
+                    GlassTextField(
+                      key: _nicknameFieldKey,
                       controller: _nicknameController,
-                      fieldKey: _nicknameFieldKey,
                       focusNode: _nicknameFocusNode,
                       label: '닉네임',
                       hint: '앱에서 사용할 이름',
@@ -534,86 +523,6 @@ class _LoginScreenState extends State<LoginScreen> {
           ),
         ),
       ),
-    );
-  }
-
-  Widget _buildGlassTextField({
-    required TextEditingController controller,
-    required String label,
-    required String hint,
-    required IconData prefixIcon,
-    required bool isDark,
-    GlobalKey? fieldKey,
-    FocusNode? focusNode,
-    TextInputType keyboardType = TextInputType.text,
-    TextInputAction? textInputAction,
-    void Function(String)? onFieldSubmitted,
-    bool obscureText = false,
-    Widget? suffixIcon,
-    String? Function(String?)? validator,
-    List<String>? autofillHints,
-    bool autocorrect = true,
-    bool enableSuggestions = true,
-  }) {
-    return Column(
-      key: fieldKey,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          label,
-          style: TextStyle(
-            fontSize: 13,
-            fontWeight: FontWeight.w600,
-            color: isDark ? Colors.grey[300] : Colors.grey[700],
-          ),
-        ),
-        const SizedBox(height: 8),
-        _GlassTextFieldContainer(
-          isDark: isDark,
-          child: TextFormField(
-            controller: controller,
-            focusNode: focusNode,
-            keyboardType: keyboardType,
-            textInputAction: textInputAction,
-            onFieldSubmitted: onFieldSubmitted,
-            obscureText: obscureText,
-            autocorrect: autocorrect,
-            enableSuggestions: enableSuggestions,
-            autofillHints: autofillHints,
-            style: TextStyle(
-              fontSize: 15,
-              color: isDark ? Colors.white : Colors.black87,
-            ),
-            decoration: InputDecoration(
-              hintText: hint,
-              hintStyle: TextStyle(
-                color: isDark ? Colors.grey[500] : Colors.grey[400],
-                fontSize: 14,
-              ),
-              prefixIcon: Icon(
-                prefixIcon,
-                color: isDark ? Colors.grey[400] : Colors.grey[600],
-                size: 20,
-              ),
-              suffixIcon: suffixIcon,
-              border: InputBorder.none,
-              focusedBorder: InputBorder.none,
-              enabledBorder: InputBorder.none,
-              errorBorder: InputBorder.none,
-              focusedErrorBorder: InputBorder.none,
-              contentPadding: const EdgeInsets.symmetric(
-                horizontal: 16,
-                vertical: 16,
-              ),
-              errorStyle: const TextStyle(
-                fontSize: 12,
-                height: 1,
-              ),
-            ),
-            validator: validator,
-          ),
-        ),
-      ],
     );
   }
 
@@ -760,69 +669,5 @@ class _LoginScreenState extends State<LoginScreen> {
       case AuthMode.forgotPassword:
         return '비밀번호 재설정 이메일 보내기';
     }
-  }
-}
-
-class _GlassTextFieldContainer extends StatefulWidget {
-  final bool isDark;
-  final Widget child;
-
-  const _GlassTextFieldContainer({
-    required this.isDark,
-    required this.child,
-  });
-
-  @override
-  State<_GlassTextFieldContainer> createState() =>
-      _GlassTextFieldContainerState();
-}
-
-class _GlassTextFieldContainerState extends State<_GlassTextFieldContainer> {
-  bool _isFocused = false;
-
-  @override
-  Widget build(BuildContext context) {
-    return Focus(
-      onFocusChange: (hasFocus) {
-        setState(() => _isFocused = hasFocus);
-      },
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        curve: Curves.easeOut,
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(14),
-          child: BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-            child: Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
-                  colors: widget.isDark
-                      ? [
-                          Colors.white.withValues(alpha: _isFocused ? 0.20 : 0.08),
-                          Colors.white.withValues(alpha: _isFocused ? 0.12 : 0.04),
-                        ]
-                      : [
-                          Colors.white.withValues(alpha: _isFocused ? 1.0 : 0.85),
-                          Colors.white.withValues(alpha: _isFocused ? 0.95 : 0.65),
-                        ],
-                ),
-                borderRadius: BorderRadius.circular(14),
-                border: Border.all(
-                  color: widget.isDark
-                      ? Colors.white.withValues(alpha: _isFocused ? 0.30 : 0.1)
-                      : (_isFocused
-                          ? const Color(0xFF5B7FFF).withValues(alpha: 0.5)
-                          : Colors.grey.withValues(alpha: 0.15)),
-                  width: _isFocused ? 1.5 : 1,
-                ),
-              ),
-              child: widget.child,
-            ),
-          ),
-        ),
-      ),
-    );
   }
 }

--- a/app/lib/ui/book_detail/widgets/dialogs/today_goal_sheet.dart
+++ b/app/lib/ui/book_detail/widgets/dialogs/today_goal_sheet.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 
-/// 오늘의 분량 설정 시트
-///
-/// 시작 페이지와 목표 페이지를 입력받아 오늘의 분량을 설정합니다.
+import 'package:book_golas/ui/core/widgets/glass_text_field.dart';
+
 class TodayGoalSheet {
   /// 오늘의 분량 설정 시트 표시
   ///
@@ -20,6 +19,7 @@ class TodayGoalSheet {
         TextEditingController(text: initialStartPage?.toString() ?? '');
     final endController =
         TextEditingController(text: initialTargetPage?.toString() ?? '');
+    final isDark = Theme.of(context).brightness == Brightness.dark;
 
     showModalBottomSheet(
       context: context,
@@ -27,9 +27,9 @@ class TodayGoalSheet {
       backgroundColor: Colors.transparent,
       builder: (context) {
         return Container(
-          decoration: const BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+          decoration: BoxDecoration(
+            color: isDark ? const Color(0xFF1E1E1E) : Colors.white,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
           ),
           padding: EdgeInsets.only(
             left: 24,
@@ -41,34 +41,31 @@ class TodayGoalSheet {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const Text(
+              Text(
                 '오늘의 분량 설정',
                 style: TextStyle(
                   fontWeight: FontWeight.bold,
                   fontSize: 20,
+                  color: isDark ? Colors.white : Colors.black,
                 ),
               ),
               const SizedBox(height: 20),
-              TextField(
+              GlassTextField(
                 controller: startController,
                 keyboardType: TextInputType.number,
-                decoration: InputDecoration(
-                  labelText: '시작 페이지',
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                ),
+                label: '시작 페이지',
+                hint: '시작 페이지 입력',
+                prefixIcon: Icons.first_page_rounded,
+                isDark: isDark,
               ),
               const SizedBox(height: 12),
-              TextField(
+              GlassTextField(
                 controller: endController,
                 keyboardType: TextInputType.number,
-                decoration: InputDecoration(
-                  labelText: '목표 페이지',
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                ),
+                label: '목표 페이지',
+                hint: '목표 페이지 입력',
+                prefixIcon: Icons.last_page_rounded,
+                isDark: isDark,
               ),
               const SizedBox(height: 24),
               SizedBox(

--- a/app/lib/ui/book_detail/widgets/dialogs/update_page_dialog.dart
+++ b/app/lib/ui/book_detail/widgets/dialogs/update_page_dialog.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 
-/// 현재 페이지 업데이트 다이얼로그
-///
-/// 사용자가 현재 읽은 페이지를 업데이트할 수 있는 바텀시트
+import 'package:book_golas/ui/core/widgets/glass_text_field.dart';
+
 class UpdatePageDialog {
   /// 페이지 업데이트 다이얼로그 표시
   ///
@@ -18,7 +17,6 @@ class UpdatePageDialog {
   }) async {
     final TextEditingController controller = TextEditingController(text: '');
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    String? errorText;
     bool isValid = false;
 
     String? validatePage(String value) {
@@ -93,47 +91,20 @@ class UpdatePageDialog {
                     ],
                   ),
                   const SizedBox(height: 20),
-                  TextField(
+                  GlassTextField(
                     controller: controller,
                     keyboardType: TextInputType.number,
-                    autofocus: true,
-                    onChanged: (value) {
+                    hint: '${currentPage + 1} ~ $totalPages',
+                    prefixIcon: Icons.menu_book_rounded,
+                    isDark: isDark,
+                    validateOnChange: true,
+                    validationDebounceMs: 100,
+                    validator: (value) => validatePage(value ?? ''),
+                    onValidityChanged: (valid) {
                       setModalState(() {
-                        errorText = validatePage(value);
-                        isValid = errorText == null && value.isNotEmpty;
+                        isValid = valid && controller.text.isNotEmpty;
                       });
                     },
-                    decoration: InputDecoration(
-                      labelText: '새 페이지 번호',
-                      hintText: '${currentPage + 1} ~ $totalPages',
-                      errorText: errorText,
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide: BorderSide(
-                          color: errorText != null
-                              ? Colors.red
-                              : const Color(0xFF5B7FFF),
-                          width: 2,
-                        ),
-                      ),
-                      errorBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide: const BorderSide(
-                          color: Colors.red,
-                          width: 2,
-                        ),
-                      ),
-                      focusedErrorBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide: const BorderSide(
-                          color: Colors.red,
-                          width: 2,
-                        ),
-                      ),
-                    ),
                   ),
                   const SizedBox(height: 24),
                   Row(

--- a/app/lib/ui/book_detail/widgets/modals/add_memorable_page_modal.dart
+++ b/app/lib/ui/book_detail/widgets/modals/add_memorable_page_modal.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:book_golas/ui/core/widgets/custom_snackbar.dart';
+import 'package:book_golas/ui/core/widgets/glass_text_field.dart';
 import 'package:book_golas/ui/core/widgets/keyboard_accessory_bar.dart';
 
 class AddMemorablePageModal extends StatefulWidget {
@@ -817,50 +818,18 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
           ],
         ),
         const SizedBox(height: 12),
-        Container(
-          constraints: const BoxConstraints(minHeight: 150),
-          decoration: BoxDecoration(
-            color: isDark ? Colors.grey[900] : Colors.grey[100],
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
-            ),
-          ),
-          child: TextField(
-            controller: _textController,
-            focusNode: _textFocusNode,
-            maxLines: null,
-            minLines: 6,
-            keyboardType: TextInputType.multiline,
-            textInputAction: TextInputAction.newline,
-            onChanged: (value) {
-              setState(() {});
-            },
-            onTap: () {
-              Future.delayed(const Duration(milliseconds: 300), () {
-                if (_scrollController.hasClients) {
-                  _scrollController.animateTo(
-                    _scrollController.position.maxScrollExtent,
-                    duration: const Duration(milliseconds: 200),
-                    curve: Curves.easeOut,
-                  );
-                }
-              });
-            },
-            style: TextStyle(
-              fontSize: 15,
-              height: 1.6,
-              color: isDark ? Colors.white : Colors.black,
-            ),
-            decoration: InputDecoration(
-              hintText: '인상적인 대목을 기록해보세요.',
-              hintStyle: TextStyle(
-                color: isDark ? Colors.grey[600] : Colors.grey[400],
-              ),
-              border: InputBorder.none,
-              contentPadding: const EdgeInsets.all(16),
-            ),
-          ),
+        GlassTextField(
+          controller: _textController,
+          focusNode: _textFocusNode,
+          maxLines: null,
+          minLines: 6,
+          keyboardType: TextInputType.multiline,
+          textInputAction: TextInputAction.newline,
+          hint: '인상적인 대목을 기록해보세요.',
+          isDark: isDark,
+          onChanged: (value) {
+            setState(() {});
+          },
         ),
       ],
     );

--- a/app/lib/ui/core/widgets/glass_text_field.dart
+++ b/app/lib/ui/core/widgets/glass_text_field.dart
@@ -1,0 +1,541 @@
+import 'dart:async';
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+enum GlassTextFieldState {
+  normal,
+  focused,
+  error,
+  disabled,
+  loading,
+}
+
+enum ErrorMessagePosition {
+  below,
+  inline,
+  none,
+}
+
+class GlassTextField extends StatefulWidget {
+  final TextEditingController? controller;
+  final FocusNode? focusNode;
+  final String? label;
+  final String? hint;
+  final IconData? prefixIcon;
+  final Widget? suffixIcon;
+  final TextInputType keyboardType;
+  final TextInputAction? textInputAction;
+  final bool obscureText;
+  final bool showPasswordToggle;
+  final bool autocorrect;
+  final bool enableSuggestions;
+  final List<String>? autofillHints;
+  final String? Function(String?)? validator;
+  final void Function(String)? onFieldSubmitted;
+  final void Function(String)? onChanged;
+  final bool? isDark;
+  final bool enabled;
+  final int? maxLines;
+  final int? minLines;
+  final double borderRadius;
+
+  final bool validateOnChange;
+  final bool validateOnBlur;
+  final String? externalError;
+  final int validationDebounceMs;
+
+  final ErrorMessagePosition errorMessagePosition;
+  final bool showErrorIcon;
+  final bool hapticFeedbackOnError;
+  final bool shakeOnError;
+
+  final bool isLoading;
+
+  final void Function(String? error)? onErrorChanged;
+  final void Function(bool isValid)? onValidityChanged;
+
+  const GlassTextField({
+    super.key,
+    this.controller,
+    this.focusNode,
+    this.label,
+    this.hint,
+    this.prefixIcon,
+    this.suffixIcon,
+    this.keyboardType = TextInputType.text,
+    this.textInputAction,
+    this.obscureText = false,
+    this.showPasswordToggle = false,
+    this.autocorrect = true,
+    this.enableSuggestions = true,
+    this.autofillHints,
+    this.validator,
+    this.onFieldSubmitted,
+    this.onChanged,
+    this.isDark,
+    this.enabled = true,
+    this.maxLines = 1,
+    this.minLines,
+    this.borderRadius = 14,
+    this.validateOnChange = false,
+    this.validateOnBlur = false,
+    this.externalError,
+    this.validationDebounceMs = 300,
+    this.errorMessagePosition = ErrorMessagePosition.below,
+    this.showErrorIcon = true,
+    this.hapticFeedbackOnError = true,
+    this.shakeOnError = false,
+    this.isLoading = false,
+    this.onErrorChanged,
+    this.onValidityChanged,
+  });
+
+  @override
+  State<GlassTextField> createState() => _GlassTextFieldState();
+}
+
+class _GlassTextFieldState extends State<GlassTextField>
+    with SingleTickerProviderStateMixin {
+  late TextEditingController _controller;
+  late FocusNode _focusNode;
+  bool _isFocused = false;
+  bool _obscureText = false;
+  bool _ownsController = false;
+  bool _ownsFocusNode = false;
+
+  String? _errorMessage;
+  bool _isDirty = false;
+  bool _hasBlurred = false;
+  Timer? _debounceTimer;
+
+  late AnimationController _shakeController;
+  late Animation<double> _shakeAnimation;
+
+  GlassTextFieldState get _currentState {
+    if (!widget.enabled) return GlassTextFieldState.disabled;
+    if (widget.isLoading) return GlassTextFieldState.loading;
+    if (_shouldShowError) return GlassTextFieldState.error;
+    if (_isFocused) return GlassTextFieldState.focused;
+    return GlassTextFieldState.normal;
+  }
+
+  String? get _displayError => widget.externalError ?? _errorMessage;
+
+  bool get _shouldShowError {
+    if (_displayError == null) return false;
+    if (widget.externalError != null) return true;
+    if (widget.validateOnChange && _isDirty) return true;
+    if (widget.validateOnBlur && _hasBlurred) return true;
+    return false;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _obscureText = widget.obscureText;
+
+    if (widget.controller != null) {
+      _controller = widget.controller!;
+    } else {
+      _controller = TextEditingController();
+      _ownsController = true;
+    }
+
+    if (widget.focusNode != null) {
+      _focusNode = widget.focusNode!;
+    } else {
+      _focusNode = FocusNode();
+      _ownsFocusNode = true;
+    }
+
+    _focusNode.addListener(_handleFocusChange);
+
+    _shakeController = AnimationController(
+      duration: const Duration(milliseconds: 400),
+      vsync: this,
+    );
+
+    _shakeAnimation = TweenSequence<double>([
+      TweenSequenceItem(tween: Tween(begin: 0, end: 10), weight: 1),
+      TweenSequenceItem(tween: Tween(begin: 10, end: -8), weight: 1),
+      TweenSequenceItem(tween: Tween(begin: -8, end: 6), weight: 1),
+      TweenSequenceItem(tween: Tween(begin: 6, end: -4), weight: 1),
+      TweenSequenceItem(tween: Tween(begin: -4, end: 0), weight: 1),
+    ]).animate(CurvedAnimation(
+      parent: _shakeController,
+      curve: Curves.easeOut,
+    ));
+  }
+
+  @override
+  void didUpdateWidget(GlassTextField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.externalError != oldWidget.externalError) {
+      if (widget.externalError != null) {
+        _triggerErrorFeedback();
+      }
+      widget.onErrorChanged?.call(widget.externalError);
+      widget.onValidityChanged?.call(widget.externalError == null);
+    }
+
+    if (widget.controller != oldWidget.controller) {
+      if (_ownsController) {
+        _controller.dispose();
+        _ownsController = false;
+      }
+      if (widget.controller != null) {
+        _controller = widget.controller!;
+      } else {
+        _controller = TextEditingController();
+        _ownsController = true;
+      }
+    }
+
+    if (widget.focusNode != oldWidget.focusNode) {
+      _focusNode.removeListener(_handleFocusChange);
+      if (_ownsFocusNode) {
+        _focusNode.dispose();
+        _ownsFocusNode = false;
+      }
+      if (widget.focusNode != null) {
+        _focusNode = widget.focusNode!;
+      } else {
+        _focusNode = FocusNode();
+        _ownsFocusNode = true;
+      }
+      _focusNode.addListener(_handleFocusChange);
+    }
+  }
+
+  @override
+  void dispose() {
+    _debounceTimer?.cancel();
+    _shakeController.dispose();
+    _focusNode.removeListener(_handleFocusChange);
+    if (_ownsController) {
+      _controller.dispose();
+    }
+    if (_ownsFocusNode) {
+      _focusNode.dispose();
+    }
+    super.dispose();
+  }
+
+  void _handleFocusChange() {
+    final hasFocus = _focusNode.hasFocus;
+
+    if (_isFocused != hasFocus) {
+      setState(() => _isFocused = hasFocus);
+    }
+
+    if (!hasFocus && _isFocused == false && _isDirty) {
+      _hasBlurred = true;
+      if (widget.validateOnBlur) {
+        _runValidation(_controller.text);
+      }
+    }
+  }
+
+  void _handleOnChanged(String value) {
+    _isDirty = true;
+    widget.onChanged?.call(value);
+
+    if (widget.validateOnChange) {
+      _debounceTimer?.cancel();
+      _debounceTimer = Timer(
+        Duration(milliseconds: widget.validationDebounceMs),
+        () => _runValidation(value),
+      );
+    }
+  }
+
+  void _runValidation(String value) {
+    if (widget.validator == null) return;
+
+    final error = widget.validator!(value);
+    final previousError = _errorMessage;
+
+    setState(() {
+      _errorMessage = error;
+    });
+
+    if (error != previousError) {
+      if (error != null && previousError == null) {
+        _triggerErrorFeedback();
+      }
+      widget.onErrorChanged?.call(error);
+      widget.onValidityChanged?.call(error == null);
+    }
+  }
+
+  void _triggerErrorFeedback() {
+    if (widget.hapticFeedbackOnError) {
+      HapticFeedback.mediumImpact();
+    }
+    if (widget.shakeOnError) {
+      _shakeController.forward(from: 0);
+    }
+  }
+
+  void _togglePasswordVisibility() {
+    setState(() => _obscureText = !_obscureText);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark =
+        widget.isDark ?? Theme.of(context).brightness == Brightness.dark;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (widget.label != null) ...[
+          Text(
+            widget.label!,
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: isDark ? Colors.grey[300] : Colors.grey[700],
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+        AnimatedBuilder(
+          animation: _shakeAnimation,
+          builder: (context, child) => Transform.translate(
+            offset: Offset(_shakeAnimation.value, 0),
+            child: child,
+          ),
+          child: _GlassContainer(
+            isDark: isDark,
+            state: _currentState,
+            borderRadius: widget.borderRadius,
+            child: TextFormField(
+              controller: _controller,
+              focusNode: _focusNode,
+              keyboardType: widget.keyboardType,
+              textInputAction: widget.textInputAction,
+              obscureText: _obscureText,
+              autocorrect: widget.autocorrect,
+              enableSuggestions: widget.enableSuggestions,
+              autofillHints: widget.autofillHints,
+              enabled: widget.enabled && !widget.isLoading,
+              maxLines: widget.obscureText ? 1 : widget.maxLines,
+              minLines: widget.minLines,
+              onFieldSubmitted: widget.onFieldSubmitted,
+              onChanged: _handleOnChanged,
+              style: TextStyle(
+                fontSize: 15,
+                color: widget.enabled
+                    ? (isDark ? Colors.white : Colors.black87)
+                    : (isDark ? Colors.grey[600] : Colors.grey[400]),
+              ),
+              decoration: InputDecoration(
+                hintText: widget.hint,
+                hintStyle: TextStyle(
+                  color: isDark ? Colors.grey[500] : Colors.grey[400],
+                  fontSize: 14,
+                ),
+                prefixIcon: widget.prefixIcon != null
+                    ? Icon(
+                        widget.prefixIcon,
+                        color: _currentState == GlassTextFieldState.error
+                            ? const Color(0xFFEF4444)
+                            : (isDark ? Colors.grey[400] : Colors.grey[600]),
+                        size: 20,
+                      )
+                    : null,
+                suffixIcon: _buildSuffixIcon(isDark),
+                border: InputBorder.none,
+                focusedBorder: InputBorder.none,
+                enabledBorder: InputBorder.none,
+                errorBorder: InputBorder.none,
+                focusedErrorBorder: InputBorder.none,
+                disabledBorder: InputBorder.none,
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 16,
+                ),
+              ),
+              validator: widget.validator,
+            ),
+          ),
+        ),
+        _buildErrorMessage(isDark),
+      ],
+    );
+  }
+
+  Widget _buildErrorMessage(bool isDark) {
+    if (!_shouldShowError ||
+        widget.errorMessagePosition != ErrorMessagePosition.below) {
+      return const SizedBox.shrink();
+    }
+
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOut,
+      alignment: Alignment.topLeft,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.only(top: 6, left: 4),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (widget.showErrorIcon)
+              const Padding(
+                padding: EdgeInsets.only(right: 4, top: 1),
+                child: Icon(
+                  Icons.error_outline_rounded,
+                  size: 14,
+                  color: Color(0xFFEF4444),
+                ),
+              ),
+            Expanded(
+              child: Text(
+                _displayError!,
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                  color: Color(0xFFEF4444),
+                  height: 1.3,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget? _buildSuffixIcon(bool isDark) {
+    if (widget.isLoading) {
+      return Padding(
+        padding: const EdgeInsets.all(12),
+        child: SizedBox(
+          width: 20,
+          height: 20,
+          child: CircularProgressIndicator(
+            strokeWidth: 2,
+            valueColor: AlwaysStoppedAnimation<Color>(
+              isDark ? Colors.grey[400]! : Colors.grey[600]!,
+            ),
+          ),
+        ),
+      );
+    }
+
+    if (_shouldShowError &&
+        widget.errorMessagePosition == ErrorMessagePosition.inline) {
+      return const Icon(
+        Icons.error_outline_rounded,
+        color: Color(0xFFEF4444),
+        size: 20,
+      );
+    }
+
+    if (widget.showPasswordToggle && widget.obscureText) {
+      return IconButton(
+        icon: Icon(
+          _obscureText
+              ? Icons.visibility_off_outlined
+              : Icons.visibility_outlined,
+          color: isDark ? Colors.grey[400] : Colors.grey[600],
+          size: 20,
+        ),
+        onPressed: _togglePasswordVisibility,
+      );
+    }
+
+    return widget.suffixIcon;
+  }
+}
+
+class _GlassContainer extends StatelessWidget {
+  final bool isDark;
+  final GlassTextFieldState state;
+  final double borderRadius;
+  final Widget child;
+
+  const _GlassContainer({
+    required this.isDark,
+    required this.state,
+    required this.borderRadius,
+    required this.child,
+  });
+
+  Color _getBorderColor() {
+    switch (state) {
+      case GlassTextFieldState.error:
+        return const Color(0xFFEF4444).withValues(alpha: 0.8);
+      case GlassTextFieldState.focused:
+        return isDark
+            ? Colors.white.withValues(alpha: 0.30)
+            : const Color(0xFF5B7FFF).withValues(alpha: 0.5);
+      case GlassTextFieldState.disabled:
+        return Colors.grey.withValues(alpha: 0.1);
+      case GlassTextFieldState.loading:
+      case GlassTextFieldState.normal:
+        return isDark
+            ? Colors.white.withValues(alpha: 0.1)
+            : Colors.grey.withValues(alpha: 0.15);
+    }
+  }
+
+  double _getBorderWidth() {
+    return (state == GlassTextFieldState.focused ||
+            state == GlassTextFieldState.error)
+        ? 1.5
+        : 1.0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isFocusedOrError = state == GlassTextFieldState.focused ||
+        state == GlassTextFieldState.error;
+    final borderWidth = _getBorderWidth();
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOut,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(borderRadius),
+        border: Border.all(
+          color: _getBorderColor(),
+          width: borderWidth,
+        ),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(borderRadius - borderWidth),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+          child: Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: isDark
+                    ? [
+                        Colors.white
+                            .withValues(alpha: isFocusedOrError ? 0.20 : 0.08),
+                        Colors.white
+                            .withValues(alpha: isFocusedOrError ? 0.12 : 0.04),
+                      ]
+                    : [
+                        Colors.white
+                            .withValues(alpha: isFocusedOrError ? 1.0 : 0.85),
+                        Colors.white
+                            .withValues(alpha: isFocusedOrError ? 0.95 : 0.65),
+                      ],
+              ),
+            ),
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ui/reading_start/widgets/reading_start_screen.dart
+++ b/app/lib/ui/reading_start/widgets/reading_start_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import 'package:book_golas/data/services/book_service.dart';
 import 'package:book_golas/ui/core/widgets/book_image_widget.dart';
+import 'package:book_golas/ui/core/widgets/glass_text_field.dart';
 import 'package:book_golas/ui/reading_start/view_model/reading_start_view_model.dart';
 
 class ReadingStartScreen extends StatelessWidget {
@@ -149,36 +150,11 @@ class _ReadingStartContentState extends State<_ReadingStartContent> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               const SizedBox(height: 40),
-              TextField(
+              GlassTextField(
                 controller: _titleController,
-                decoration: InputDecoration(
-                  hintText: '책 이름을 입력해주세요.',
-                  hintStyle: TextStyle(
-                    color: isDark ? Colors.grey[600] : Colors.grey,
-                    fontSize: 16,
-                  ),
-                  border: OutlineInputBorder(
-                    borderSide: BorderSide(
-                      color: isDark ? Colors.grey[700]! : Colors.grey,
-                    ),
-                  ),
-                  enabledBorder: OutlineInputBorder(
-                    borderSide: BorderSide(
-                      color: isDark ? Colors.grey[700]! : Colors.grey,
-                    ),
-                  ),
-                  focusedBorder: const OutlineInputBorder(
-                    borderSide: BorderSide(color: Colors.blue),
-                  ),
-                  contentPadding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 12,
-                  ),
-                ),
-                style: TextStyle(
-                  fontSize: 16,
-                  color: isDark ? Colors.white : Colors.black,
-                ),
+                hint: '책 이름을 입력해주세요.',
+                prefixIcon: Icons.search_rounded,
+                isDark: isDark,
               ),
               const SizedBox(height: 16),
               if (vm.isSearching)


### PR DESCRIPTION
2026-01-02 일일 작업을 dev 브랜치로 머지합니다.

## 📋 Changes

### BYU-215: 재사용 가능한 GlassTextField 위젯 구현
- `glass_text_field.dart`: 5가지 상태(Normal/Focused/Error/Disabled/Loading) 지원
- 실시간 검증, blur 검증, 외부 에러 주입 지원
- Haptic 피드백, Shake 애니메이션, 에러 메시지 표시
- book_detail, reading_start 화면에 적용
- CLAUDE.md에 import 규칙 추가

## 🔗 Related Issues

- BYU-215: [Core] 재사용 가능한 Glass Input Widget 설계

🤖 Generated with [Claude Code](https://claude.com/claude-code)