### PR TITLE
feat(book-detail): add document scanning with perspective correction (BYU-255)

### DIFF
--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -40,5 +40,12 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+        '$(inherited)',
+        'PERMISSION_CAMERA=1',
+        'PERMISSION_PHOTOS=1',
+      ]
+    end
   end
 end

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -11,6 +11,8 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
+  - cunning_document_scanner (1.0.0):
+    - Flutter
   - Firebase/CoreOnly (11.15.0):
     - FirebaseCore (~> 11.15.0)
   - Firebase/Messaging (11.15.0):
@@ -107,6 +109,8 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - permission_handler_apple (9.3.0):
+    - Flutter
   - PromisesObjC (2.4.0)
   - shared_preferences_foundation (0.0.1):
     - Flutter
@@ -122,6 +126,7 @@ PODS:
 
 DEPENDENCIES:
   - app_links (from `.symlinks/plugins/app_links/ios`)
+  - cunning_document_scanner (from `.symlinks/plugins/cunning_document_scanner/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - Flutter (from `Flutter`)
@@ -131,6 +136,7 @@ DEPENDENCIES:
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sign_in_with_apple (from `.symlinks/plugins/sign_in_with_apple/ios`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
@@ -157,6 +163,8 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   app_links:
     :path: ".symlinks/plugins/app_links/ios"
+  cunning_document_scanner:
+    :path: ".symlinks/plugins/cunning_document_scanner/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
   firebase_messaging:
@@ -175,6 +183,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  permission_handler_apple:
+    :path: ".symlinks/plugins/permission_handler_apple/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sign_in_with_apple:
@@ -188,6 +198,7 @@ SPEC CHECKSUMS:
   app_links: 3dbc685f76b1693c66a6d9dd1e9ab6f73d97dc0a
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
+  cunning_document_scanner: 43a2bda11ef6a33fd68766b287ed056b4caf6a06
   Firebase: d99ac19b909cd2c548339c2241ecd0d1599ab02e
   firebase_core: 995454a784ff288be5689b796deb9e9fa3601818
   firebase_messaging: f4a41dd102ac18b840eba3f39d67e77922d3f707
@@ -208,6 +219,7 @@ SPEC CHECKSUMS:
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
@@ -215,6 +227,6 @@ SPEC CHECKSUMS:
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 
-PODFILE CHECKSUM: a57f30d18f102dd3ce366b1d62a55ecbef2158e5
+PODFILE CHECKSUM: 538a5ef41cb5012eadb15da1632e7ee3ecb05f01
 
 COCOAPODS: 1.16.2

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -53,9 +53,11 @@
 			<false/>
 		</dict>
 		<key>NSCameraUsageDescription</key>
-		<string>프로필 사진을 촬영하기 위해 카메라에 접근합니다.</string>
+		<string>책 페이지를 스캔하기 위해 카메라 권한이 필요합니다.</string>
 		<key>NSPhotoLibraryUsageDescription</key>
-		<string>프로필 사진을 변경하기 위해 사진 라이브러리에 접근합니다.</string>
+		<string>갤러리에서 이미지를 선택하기 위해 권한이 필요합니다.</string>
+		<key>NSPhotoLibraryAddUsageDescription</key>
+		<string>스캔한 이미지를 저장하기 위해 권한이 필요합니다.</string>
 		<key>UIApplicationSupportsIndirectInputEvents</key>
 		<true/>
 		<key>UILaunchStoryboardName</key>

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -616,9 +616,21 @@ class _BookDetailContentState extends State<_BookDetailContent>
   Future<void> _showImageSourceActionSheet(
       {required Function(Uint8List imageBytes, String ocrText, int? pageNumber)
           onImageSelected}) async {
-    final source = await showImageSourceSheet(context: context);
-    if (source != null && mounted) {
-      await pickImageAndExtractText(context, source, onImageSelected);
+    final sourceType = await showImageSourceSheet(context: context);
+    if (sourceType == null || !mounted) return;
+
+    switch (sourceType) {
+      case ImageSourceType.documentScan:
+        await scanDocumentAndExtractText(context, onImageSelected);
+        break;
+      case ImageSourceType.camera:
+        await pickImageAndExtractText(
+            context, ImageSource.camera, onImageSelected);
+        break;
+      case ImageSourceType.gallery:
+        await pickImageAndExtractText(
+            context, ImageSource.gallery, onImageSelected);
+        break;
     }
   }
 

--- a/app/lib/ui/book_detail/utils/document_scan_utils.dart
+++ b/app/lib/ui/book_detail/utils/document_scan_utils.dart
@@ -1,0 +1,146 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:cunning_document_scanner/cunning_document_scanner.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:image/image.dart' as img;
+
+import 'package:book_golas/ui/core/widgets/custom_snackbar.dart';
+
+Future<Uint8List?> scanDocumentWithCamera(BuildContext context) async {
+  try {
+    final cameraStatus = await Permission.camera.request();
+    if (!cameraStatus.isGranted) {
+      if (context.mounted) {
+        CustomSnackbar.show(
+          context,
+          message: '카메라 권한이 필요합니다.',
+          rootOverlay: true,
+        );
+      }
+      return null;
+    }
+
+    debugPrint('문서 스캔 시작');
+
+    final imagesPath = await CunningDocumentScanner.getPictures(
+      isGalleryImportAllowed: false,
+    );
+
+    if (imagesPath == null || imagesPath.isEmpty) {
+      debugPrint('문서 스캔 취소 또는 실패');
+      return null;
+    }
+
+    final scannedFile = File(imagesPath.first);
+    if (!await scannedFile.exists()) {
+      debugPrint('스캔된 파일이 존재하지 않음: ${imagesPath.first}');
+      return null;
+    }
+
+    final imageBytes = await scannedFile.readAsBytes();
+    final compressedBytes = await _compressImage(imageBytes);
+
+    try {
+      await scannedFile.delete();
+    } catch (e) {
+      debugPrint('임시 파일 삭제 실패 (무시): $e');
+    }
+
+    debugPrint(
+        '문서 스캔 완료 (압축 전: ${imageBytes.length} bytes, 압축 후: ${compressedBytes.length} bytes)');
+    return compressedBytes;
+  } catch (e, stackTrace) {
+    debugPrint('문서 스캔 실패: $e');
+    debugPrint('Stack trace: $stackTrace');
+
+    if (context.mounted) {
+      CustomSnackbar.show(
+        context,
+        message: '문서 스캔에 실패했습니다.',
+        rootOverlay: true,
+      );
+    }
+    return null;
+  }
+}
+
+Future<Uint8List?> scanDocumentFromGallery(BuildContext context) async {
+  try {
+    final photosStatus = await Permission.photos.request();
+    if (!photosStatus.isGranted) {
+      if (context.mounted) {
+        CustomSnackbar.show(
+          context,
+          message: '사진 권한이 필요합니다.',
+          rootOverlay: true,
+        );
+      }
+      return null;
+    }
+
+    debugPrint('갤러리 문서 스캔 시작');
+
+    final imagesPath = await CunningDocumentScanner.getPictures(
+      isGalleryImportAllowed: true,
+    );
+
+    if (imagesPath == null || imagesPath.isEmpty) {
+      debugPrint('갤러리 문서 스캔 취소 또는 실패');
+      return null;
+    }
+
+    final scannedFile = File(imagesPath.first);
+    if (!await scannedFile.exists()) {
+      debugPrint('스캔된 파일이 존재하지 않음: ${imagesPath.first}');
+      return null;
+    }
+
+    final imageBytes = await scannedFile.readAsBytes();
+    final compressedBytes = await _compressImage(imageBytes);
+
+    try {
+      await scannedFile.delete();
+    } catch (e) {
+      debugPrint('임시 파일 삭제 실패 (무시): $e');
+    }
+
+    debugPrint(
+        '갤러리 문서 스캔 완료 (압축 전: ${imageBytes.length} bytes, 압축 후: ${compressedBytes.length} bytes)');
+    return compressedBytes;
+  } catch (e, stackTrace) {
+    debugPrint('갤러리 문서 스캔 실패: $e');
+    debugPrint('Stack trace: $stackTrace');
+
+    if (context.mounted) {
+      CustomSnackbar.show(
+        context,
+        message: '이미지 처리에 실패했습니다.',
+        rootOverlay: true,
+      );
+    }
+    return null;
+  }
+}
+
+Future<Uint8List> _compressImage(Uint8List imageBytes) async {
+  try {
+    final image = img.decodeImage(imageBytes);
+    if (image == null) {
+      debugPrint('이미지 디코딩 실패, 원본 반환');
+      return imageBytes;
+    }
+
+    final compressedBytes = img.encodeJpg(image, quality: 85);
+
+    final compressionRatio =
+        (imageBytes.length - compressedBytes.length) / imageBytes.length * 100;
+    debugPrint('이미지 압축 완료 (압축률: ${compressionRatio.toStringAsFixed(1)}%)');
+
+    return Uint8List.fromList(compressedBytes);
+  } catch (e) {
+    debugPrint('이미지 압축 실패, 원본 반환: $e');
+    return imageBytes;
+  }
+}

--- a/app/lib/ui/book_detail/utils/ocr_utils.dart
+++ b/app/lib/ui/book_detail/utils/ocr_utils.dart
@@ -7,6 +7,7 @@ import 'package:image_picker/image_picker.dart';
 
 import 'package:book_golas/ui/core/widgets/custom_snackbar.dart';
 import 'package:book_golas/data/services/google_vision_ocr_service.dart';
+import 'package:book_golas/ui/book_detail/utils/document_scan_utils.dart';
 
 int? extractPageNumber(String text) {
   final patterns = [
@@ -57,7 +58,8 @@ Future<void> extractTextFromLocalImage(
 
   try {
     final tempDir = Directory.systemTemp;
-    final tempFile = File('${tempDir.path}/temp_ocr_${DateTime.now().millisecondsSinceEpoch}.jpg');
+    final tempFile = File(
+        '${tempDir.path}/temp_ocr_${DateTime.now().millisecondsSinceEpoch}.jpg');
     await tempFile.writeAsBytes(imageBytes);
 
     debugPrint('🟡 OCR: 크롭 화면 표시 중...');
@@ -144,7 +146,8 @@ Future<void> extractTextFromLocalImage(
 
     if (ocrText == null || ocrText.isEmpty) {
       debugPrint('🟠 OCR: 텍스트 추출 결과가 비어있습니다.');
-      CustomSnackbar.show(parentContext, message: '텍스트를 추출하지 못했습니다. 다른 영역을 선택해보세요.', rootOverlay: true);
+      CustomSnackbar.show(parentContext,
+          message: '텍스트를 추출하지 못했습니다. 다른 영역을 선택해보세요.', rootOverlay: true);
       return;
     }
 
@@ -159,7 +162,8 @@ Future<void> extractTextFromLocalImage(
       } catch (_) {}
     }
 
-    CustomSnackbar.show(parentContext, message: '텍스트 추출에 실패했습니다. 다시 시도해주세요.', rootOverlay: true);
+    CustomSnackbar.show(parentContext,
+        message: '텍스트 추출에 실패했습니다. 다시 시도해주세요.', rootOverlay: true);
   }
 }
 
@@ -262,7 +266,8 @@ Future<void> pickImageAndExtractText(
                 ),
               ],
             ),
-            SizedBox(height: MediaQuery.of(bottomSheetContext).padding.bottom + 8),
+            SizedBox(
+                height: MediaQuery.of(bottomSheetContext).padding.bottom + 8),
           ],
         ),
       ),
@@ -279,7 +284,8 @@ Future<void> pickImageAndExtractText(
 
     while (shouldRetry) {
       final tempDir = Directory.systemTemp;
-      final tempFile = File('${tempDir.path}/temp_ocr_${DateTime.now().millisecondsSinceEpoch}.jpg');
+      final tempFile = File(
+          '${tempDir.path}/temp_ocr_${DateTime.now().millisecondsSinceEpoch}.jpg');
       await tempFile.writeAsBytes(fullImageBytes);
 
       debugPrint('🟡 OCR: 크롭 화면 표시 중...');
@@ -461,7 +467,8 @@ Future<void> pickImageAndExtractText(
                             style: TextStyle(
                               fontSize: 15,
                               fontWeight: FontWeight.w600,
-                              color: isDark ? Colors.grey[300] : Colors.grey[700],
+                              color:
+                                  isDark ? Colors.grey[300] : Colors.grey[700],
                             ),
                           ),
                         ),
@@ -493,7 +500,8 @@ Future<void> pickImageAndExtractText(
                   ),
                 ],
               ),
-              SizedBox(height: MediaQuery.of(bottomSheetContext).padding.bottom + 8),
+              SizedBox(
+                  height: MediaQuery.of(bottomSheetContext).padding.bottom + 8),
             ],
           ),
         ),
@@ -507,7 +515,8 @@ Future<void> pickImageAndExtractText(
     onComplete(fullImageBytes, extractedText ?? '', extractedPageNumber);
   } catch (e) {
     debugPrint('🔴 이미지 선택 예외 발생 - $e');
-    CustomSnackbar.show(parentContext, message: '이미지를 불러오지 못했습니다.', rootOverlay: true);
+    CustomSnackbar.show(parentContext,
+        message: '이미지를 불러오지 못했습니다.', rootOverlay: true);
   }
 }
 
@@ -609,7 +618,8 @@ Future<void> reExtractTextFromImage(
               ),
             ],
           ),
-          SizedBox(height: MediaQuery.of(bottomSheetContext).padding.bottom + 8),
+          SizedBox(
+              height: MediaQuery.of(bottomSheetContext).padding.bottom + 8),
         ],
       ),
     ),
@@ -659,7 +669,8 @@ Future<void> reExtractTextFromImage(
     final bytes = await consolidateHttpClientResponseBytes(response);
 
     final tempDir = Directory.systemTemp;
-    final tempFile = File('${tempDir.path}/temp_image_${DateTime.now().millisecondsSinceEpoch}.jpg');
+    final tempFile = File(
+        '${tempDir.path}/temp_image_${DateTime.now().millisecondsSinceEpoch}.jpg');
     await tempFile.writeAsBytes(bytes);
 
     Navigator.of(context, rootNavigator: true).pop();
@@ -735,6 +746,311 @@ Future<void> reExtractTextFromImage(
     onConfirm(ocrText);
   } catch (e) {
     Navigator.of(context, rootNavigator: true).pop();
-    CustomSnackbar.show(context, message: '텍스트 다시 추출에 실패했습니다.', rootOverlay: true);
+    CustomSnackbar.show(context,
+        message: '텍스트 다시 추출에 실패했습니다.', rootOverlay: true);
+  }
+}
+
+Future<void> scanDocumentAndExtractText(
+  BuildContext context,
+  Function(Uint8List imageBytes, String ocrText, int? pageNumber) onComplete,
+) async {
+  final parentContext = context;
+
+  try {
+    final scannedBytes = await scanDocumentWithCamera(parentContext);
+    if (scannedBytes == null) {
+      debugPrint('문서 스캔 취소');
+      return;
+    }
+
+    debugPrint('문서 스캔 완료 (${scannedBytes.length} bytes)');
+
+    final isDark = Theme.of(parentContext).brightness == Brightness.dark;
+    final shouldExtract = await showModalBottomSheet<bool>(
+      context: parentContext,
+      backgroundColor: Colors.transparent,
+      isDismissible: false,
+      enableDrag: false,
+      builder: (bottomSheetContext) => Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: isDark ? const Color(0xFF1E1E1E) : Colors.white,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '텍스트를 추출하시겠어요?',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: isDark ? Colors.white : Colors.black,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '크레딧을 소모합니다.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 14,
+                color: isDark ? Colors.grey[400] : Colors.grey[600],
+              ),
+            ),
+            const SizedBox(height: 24),
+            Row(
+              children: [
+                Expanded(
+                  child: GestureDetector(
+                    onTap: () => Navigator.pop(bottomSheetContext, false),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      decoration: BoxDecoration(
+                        color: isDark ? Colors.grey[800] : Colors.grey[200],
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Center(
+                        child: Text(
+                          '괜찮아요',
+                          style: TextStyle(
+                            fontSize: 15,
+                            fontWeight: FontWeight.w600,
+                            color: isDark ? Colors.grey[300] : Colors.grey[700],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: GestureDetector(
+                    onTap: () => Navigator.pop(bottomSheetContext, true),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF5B7FFF),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: const Center(
+                        child: Text(
+                          '추출할게요',
+                          style: TextStyle(
+                            fontSize: 15,
+                            fontWeight: FontWeight.w600,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(
+                height: MediaQuery.of(bottomSheetContext).padding.bottom + 8),
+          ],
+        ),
+      ),
+    );
+
+    if (shouldExtract != true) {
+      onComplete(scannedBytes, '', null);
+      return;
+    }
+
+    showDialog(
+      context: parentContext,
+      barrierDismissible: false,
+      builder: (dialogContext) => PopScope(
+        canPop: false,
+        child: Center(
+          child: Container(
+            padding: const EdgeInsets.all(24),
+            decoration: BoxDecoration(
+              color: isDark ? const Color(0xFF2A2A2A) : Colors.white,
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const CircularProgressIndicator(color: Color(0xFF5B7FFF)),
+                const SizedBox(height: 16),
+                Text(
+                  '텍스트 추출 중...',
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: isDark ? Colors.white : Colors.black,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final ocrService = GoogleVisionOcrService();
+    final ocrText = await ocrService.extractTextFromBytes(scannedBytes);
+    final pageNumber = extractPageNumber(ocrText ?? '');
+
+    Navigator.of(parentContext, rootNavigator: true).pop();
+
+    if (ocrText == null || ocrText.isEmpty) {
+      debugPrint('OCR: 텍스트 추출 결과가 비어있습니다.');
+      CustomSnackbar.show(
+        parentContext,
+        message: '텍스트를 추출하지 못했습니다.',
+        rootOverlay: true,
+      );
+      onComplete(scannedBytes, '', null);
+      return;
+    }
+
+    debugPrint('OCR: 텍스트 추출 성공 (길이: ${ocrText.length})');
+
+    final shouldApply = await showModalBottomSheet<bool>(
+      context: parentContext,
+      isScrollControlled: true,
+      isDismissible: false,
+      enableDrag: false,
+      backgroundColor: Colors.transparent,
+      builder: (bottomSheetContext) => Container(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(parentContext).size.height * 0.7,
+        ),
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: isDark ? const Color(0xFF1E1E1E) : Colors.white,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '추출된 텍스트',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: isDark ? Colors.white : Colors.black,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Flexible(
+              child: Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: isDark ? Colors.grey[900] : Colors.grey[100],
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(
+                    color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
+                  ),
+                ),
+                child: SingleChildScrollView(
+                  child: Text(
+                    ocrText,
+                    style: TextStyle(
+                      fontSize: 14,
+                      height: 1.6,
+                      color: isDark ? Colors.white : Colors.black,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            if (pageNumber != null) ...[
+              const SizedBox(height: 12),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.menu_book_outlined,
+                    size: 14,
+                    color: isDark ? Colors.grey[400] : Colors.grey[600],
+                  ),
+                  const SizedBox(width: 6),
+                  Text(
+                    '페이지 $pageNumber',
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: isDark ? Colors.grey[400] : Colors.grey[600],
+                    ),
+                  ),
+                ],
+              ),
+            ],
+            const SizedBox(height: 24),
+            Row(
+              children: [
+                Expanded(
+                  child: GestureDetector(
+                    onTap: () => Navigator.pop(bottomSheetContext, false),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      decoration: BoxDecoration(
+                        color: isDark ? Colors.grey[800] : Colors.grey[200],
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Center(
+                        child: Text(
+                          '다시 스캔',
+                          style: TextStyle(
+                            fontSize: 15,
+                            fontWeight: FontWeight.w600,
+                            color: isDark ? Colors.grey[300] : Colors.grey[700],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: GestureDetector(
+                    onTap: () => Navigator.pop(bottomSheetContext, true),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF5B7FFF),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: const Center(
+                        child: Text(
+                          '적용하기',
+                          style: TextStyle(
+                            fontSize: 15,
+                            fontWeight: FontWeight.w600,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(
+                height: MediaQuery.of(bottomSheetContext).padding.bottom + 8),
+          ],
+        ),
+      ),
+    );
+
+    if (shouldApply == true) {
+      onComplete(scannedBytes, ocrText, pageNumber);
+    } else {
+      await scanDocumentAndExtractText(parentContext, onComplete);
+    }
+  } catch (e) {
+    debugPrint('문서 스캔 및 OCR 실패: $e');
+    CustomSnackbar.show(
+      parentContext,
+      message: '문서 스캔에 실패했습니다.',
+      rootOverlay: true,
+    );
   }
 }

--- a/app/lib/ui/book_detail/widgets/sheets/image_source_sheet.dart
+++ b/app/lib/ui/book_detail/widgets/sheets/image_source_sheet.dart
@@ -7,7 +7,13 @@ import 'package:image_picker/image_picker.dart';
 
 import 'package:book_golas/ui/core/widgets/custom_snackbar.dart';
 
-Future<ImageSource?> showImageSourceSheet({
+enum ImageSourceType {
+  camera,
+  gallery,
+  documentScan,
+}
+
+Future<ImageSourceType?> showImageSourceSheet({
   required BuildContext context,
 }) async {
   final isDark = Theme.of(context).brightness == Brightness.dark;
@@ -15,7 +21,7 @@ Future<ImageSource?> showImageSourceSheet({
       (Platform.isAndroid || Platform.isIOS) &&
       (Platform.isAndroid || (Platform.isIOS && !Platform.isMacOS));
 
-  return showModalBottomSheet<ImageSource>(
+  return showModalBottomSheet<ImageSourceType>(
     context: context,
     backgroundColor: Colors.transparent,
     builder: (sheetContext) {
@@ -42,6 +48,44 @@ Future<ImageSource?> showImageSourceSheet({
                 leading: Container(
                   padding: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
+                    color: const Color(0xFF10B981).withAlpha(25),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: const Icon(
+                    CupertinoIcons.doc_text_viewfinder,
+                    color: Color(0xFF10B981),
+                  ),
+                ),
+                title: Text(
+                  '문서 스캔',
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: isDark ? Colors.white : Colors.black,
+                  ),
+                ),
+                subtitle: Text(
+                  '평탄화 및 자동 보정',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: isDark ? Colors.grey[400] : Colors.grey[600],
+                  ),
+                ),
+                onTap: isCameraAvailable && Platform.isIOS
+                    ? () => Navigator.pop(
+                        sheetContext, ImageSourceType.documentScan)
+                    : () {
+                        Navigator.pop(sheetContext);
+                        CustomSnackbar.show(
+                          context,
+                          message: '시뮬레이터에서는 카메라를 사용할 수 없습니다',
+                          type: SnackbarType.warning,
+                        );
+                      },
+              ),
+              ListTile(
+                leading: Container(
+                  padding: const EdgeInsets.all(8),
+                  decoration: BoxDecoration(
                     color: const Color(0xFF5B7FFF).withAlpha(25),
                     borderRadius: BorderRadius.circular(10),
                   ),
@@ -57,8 +101,15 @@ Future<ImageSource?> showImageSourceSheet({
                     color: isDark ? Colors.white : Colors.black,
                   ),
                 ),
+                subtitle: Text(
+                  '일반 촬영',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: isDark ? Colors.grey[400] : Colors.grey[600],
+                  ),
+                ),
                 onTap: isCameraAvailable && Platform.isIOS
-                    ? () => Navigator.pop(sheetContext, ImageSource.camera)
+                    ? () => Navigator.pop(sheetContext, ImageSourceType.camera)
                     : () {
                         Navigator.pop(sheetContext);
                         CustomSnackbar.show(
@@ -87,7 +138,15 @@ Future<ImageSource?> showImageSourceSheet({
                     color: isDark ? Colors.white : Colors.black,
                   ),
                 ),
-                onTap: () => Navigator.pop(sheetContext, ImageSource.gallery),
+                subtitle: Text(
+                  '저장된 이미지 선택',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: isDark ? Colors.grey[400] : Colors.grey[600],
+                  ),
+                ),
+                onTap: () =>
+                    Navigator.pop(sheetContext, ImageSourceType.gallery),
               ),
               const SizedBox(height: 20),
             ],

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -193,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  cunning_document_scanner:
+    dependency: "direct main"
+    description:
+      name: cunning_document_scanner
+      sha256: de0c0705799f7d5cc9b82b67bfb8b3e965a1fbff4afbd70ea10cd1dad4f3a98c
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -561,7 +569,7 @@ packages:
     source: hosted
     version: "4.1.2"
   image:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image
       sha256: "51555e36056541237b15b57afc31a0f53d4f9aefd9bd00873a6dc0090e54e332"
@@ -769,7 +777,7 @@ packages:
     source: hosted
     version: "2.1.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
@@ -832,6 +840,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.1"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.1"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.7"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -32,6 +32,10 @@ dependencies:
   url_launcher: ^6.2.5
   path_provider: ^2.1.2
   confetti: ^0.7.0
+  cunning_document_scanner: ^1.4.0
+  permission_handler: ^12.0.1
+  image: ^4.0.17
+  path: ^1.8.3
 
   # Firebase & FCM
   firebase_core: ^3.6.0


### PR DESCRIPTION
이미지 등록 시 문서 스캔 기능을 추가하여 평탄화된 이미지로 등록할 수 있습니다.

## 📋 Changes

- `cunning_document_scanner` 패키지 추가 (Apple VisionKit 기반)
- `document_scan_utils.dart` 생성 (문서 스캔 + JPEG 85% 압축)
- 이미지 소스 선택에 '문서 스캔' 옵션 추가
- iOS Podfile에 카메라/사진 권한 설정 추가
- Info.plist 권한 설명 업데이트

## 🧠 Context & Background

- BYU-255: [독서 상세] OCR 평탄화 구현 (DeepSeek OCR도 살펴보기)
- Apple VisionKit 사용으로 무료 문서 스캔 (edge detection + perspective correction)
- OCR 텍스트 추출은 기존 Google Vision API 유지

## ✅ How to Test

1. 책 상세 화면에서 '이미지 추가' 버튼 클릭
2. '문서 스캔' 옵션 선택
3. 책 페이지를 촬영하여 자동 평탄화 확인
4. OCR 텍스트 추출 여부 선택 후 저장

## 🔗 Related Issues

- Closes: BYU-255