### PR TITLE
feat(text-input): 텍스트 입력 UX 개선 - undo/redo 및 공통 모달 (BYU-254)

### DIFF
--- a/app/lib/ui/book_detail/widgets/modals/add_memorable_page_modal.dart
+++ b/app/lib/ui/book_detail/widgets/modals/add_memorable_page_modal.dart
@@ -4,6 +4,9 @@ import 'package:flutter/services.dart';
 
 import 'package:book_golas/ui/core/widgets/custom_snackbar.dart';
 import 'package:book_golas/ui/core/widgets/keyboard_accessory_bar.dart';
+import 'package:book_golas/ui/core/widgets/extracted_text_modal.dart';
+import 'package:book_golas/ui/core/widgets/full_text_view_modal.dart';
+import 'package:book_golas/ui/core/utils/text_history_manager.dart';
 
 class AddMemorablePageModal extends StatefulWidget {
   final Uint8List? initialImageBytes;
@@ -57,23 +60,25 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
   bool _hasShownPageError = false;
   bool _hideKeyboardAccessory = false;
   bool _uploadSuccess = false;
-  int? _pageNumber;
-  final List<String> _textHistory = [];
-  String _lastSavedText = '';
+  late TextHistoryManager _historyManager;
 
   @override
   void initState() {
     super.initState();
     _fullImageBytes = widget.initialImageBytes;
     _textController = TextEditingController(text: widget.initialExtractedText);
-    _pageController = TextEditingController(
-      text:
-          widget.initialPageNumber != null
-              ? widget.initialPageNumber.toString()
-              : '',
+    _historyManager = TextHistoryManager(
+      controller: _textController,
+      initialText: widget.initialExtractedText,
+      onHistoryChanged: () {
+        if (mounted) setState(() {});
+      },
     );
-    _pageNumber = widget.initialPageNumber;
-    _lastSavedText = widget.initialExtractedText;
+    _pageController = TextEditingController(
+      text: widget.initialPageNumber != null
+          ? widget.initialPageNumber.toString()
+          : '',
+    );
 
     _pageFocusNode.addListener(_onFocusChange);
     _textFocusNode.addListener(_onFocusChange);
@@ -96,29 +101,23 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
   }
 
   void _saveTextToHistory() {
-    final currentText = _textController.text;
-    if (_textHistory.isEmpty || _textHistory.last != currentText) {
-      _textHistory.add(currentText);
-      if (_textHistory.length > 50) {
-        _textHistory.removeAt(0);
-      }
-    }
+    _historyManager.saveIfChanged();
   }
 
   void _undoText() {
-    if (_textHistory.isEmpty) return;
-
-    final previousText = _textHistory.removeLast();
-    setState(() {
-      _textController.text = previousText;
-      _textController.selection = TextSelection.fromPosition(
-        TextPosition(offset: previousText.length),
-      );
-    });
-    _notifyStateChanged();
+    if (_historyManager.undo()) {
+      _notifyStateChanged();
+    }
   }
 
-  bool get _canUndo => _textHistory.isNotEmpty;
+  void _redoText() {
+    if (_historyManager.redo()) {
+      _notifyStateChanged();
+    }
+  }
+
+  bool get _canUndo => _historyManager.canUndo;
+  bool get _canRedo => _historyManager.canRedo;
 
   void _handleClose() {
     Navigator.pop(context);
@@ -147,170 +146,24 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
     required String extractedText,
     required int? extractedPageNum,
   }) {
-    showModalBottomSheet<bool>(
+    showExtractedTextModal(
       context: context,
-      isScrollControlled: true,
-      isDismissible: false,
-      enableDrag: false,
-      backgroundColor: Colors.transparent,
-      builder:
-          (bottomSheetContext) => Container(
-            constraints: BoxConstraints(
-              maxHeight: MediaQuery.of(context).size.height * 0.7,
-            ),
-            padding: const EdgeInsets.all(20),
-            decoration: BoxDecoration(
-              color: isDark ? const Color(0xFF1E1E1E) : Colors.white,
-              borderRadius: const BorderRadius.vertical(
-                top: Radius.circular(20),
-              ),
-            ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Container(
-                  width: 40,
-                  height: 4,
-                  margin: const EdgeInsets.only(bottom: 20),
-                  decoration: BoxDecoration(
-                    color: Colors.grey[400],
-                    borderRadius: BorderRadius.circular(2),
-                  ),
-                ),
-                Text(
-                  '추출된 텍스트',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                    color: isDark ? Colors.white : Colors.black,
-                  ),
-                ),
-                const SizedBox(height: 16),
-                Flexible(
-                  child: Container(
-                    width: double.infinity,
-                    padding: const EdgeInsets.all(16),
-                    decoration: BoxDecoration(
-                      color: isDark ? Colors.grey[900] : Colors.grey[100],
-                      borderRadius: BorderRadius.circular(12),
-                      border: Border.all(
-                        color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
-                      ),
-                    ),
-                    child: SingleChildScrollView(
-                      child: Text(
-                        extractedText,
-                        style: TextStyle(
-                          fontSize: 14,
-                          height: 1.6,
-                          color: isDark ? Colors.white : Colors.black,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-                if (extractedPageNum != null) ...[
-                  const SizedBox(height: 12),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(
-                        CupertinoIcons.book,
-                        size: 14,
-                        color: isDark ? Colors.grey[400] : Colors.grey[600],
-                      ),
-                      const SizedBox(width: 6),
-                      Text(
-                        '페이지 $extractedPageNum',
-                        style: TextStyle(
-                          fontSize: 13,
-                          color: isDark ? Colors.grey[400] : Colors.grey[600],
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-                const SizedBox(height: 8),
-                Text(
-                  '소모된 크레딧은 복구되지 않습니다.',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: 12,
-                    color: isDark ? Colors.grey[500] : Colors.grey[500],
-                  ),
-                ),
-                const SizedBox(height: 20),
-                Row(
-                  children: [
-                    Expanded(
-                      child: GestureDetector(
-                        onTap: () => Navigator.pop(bottomSheetContext, false),
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(vertical: 14),
-                          decoration: BoxDecoration(
-                            color: isDark ? Colors.grey[800] : Colors.grey[200],
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          child: Center(
-                            child: Text(
-                              '다시 선택',
-                              style: TextStyle(
-                                fontSize: 15,
-                                fontWeight: FontWeight.w600,
-                                color:
-                                    isDark ? Colors.grey[300] : Colors.grey[700],
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: GestureDetector(
-                        onTap: () => Navigator.pop(bottomSheetContext, true),
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(vertical: 14),
-                          decoration: BoxDecoration(
-                            color: const Color(0xFF5B7FFF),
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          child: const Center(
-                            child: Text(
-                              '적용하기',
-                              style: TextStyle(
-                                fontSize: 15,
-                                fontWeight: FontWeight.w600,
-                                color: Colors.white,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-                SizedBox(
-                  height: MediaQuery.of(bottomSheetContext).padding.bottom + 8,
-                ),
-              ],
-            ),
-          ),
-    ).then((shouldApply) {
+      initialText: extractedText,
+      pageNumber: extractedPageNum,
+      creditWarning: '소모된 크레딧은 복구되지 않습니다.',
+    ).then((modifiedText) {
       if (!mounted) return;
 
-      if (shouldApply == true) {
+      if (modifiedText != null) {
         _saveTextToHistory();
         setState(() {
-          _textController.text = extractedText;
+          _textController.text = modifiedText;
           if (extractedPageNum != null) {
-            _pageNumber = extractedPageNum;
             _pageController.text = extractedPageNum.toString();
           }
         });
         _notifyStateChanged();
-      } else if (shouldApply == false) {
+      } else {
         _handleOcrExtraction(Theme.of(context).brightness == Brightness.dark);
       }
     });
@@ -319,7 +172,6 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
   void _handlePageNumberChange(String value) {
     if (value.isEmpty) {
       setState(() {
-        _pageNumber = null;
         _pageValidationError = null;
         _hasShownPageError = false;
       });
@@ -341,12 +193,10 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
           _hasShownPageError = true;
         }
         setState(() {
-          _pageNumber = parsed;
           _pageValidationError = '전체 페이지 수를 초과할 수 없습니다.';
         });
       } else {
         setState(() {
-          _pageNumber = parsed;
           _pageValidationError = null;
           _hasShownPageError = false;
         });
@@ -408,47 +258,48 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
         }
       },
       child: GestureDetector(
-      onTap: () {
-        _textFocusNode.unfocus();
-        _pageFocusNode.unfocus();
-      },
-      child: SafeArea(
-        bottom: false,
-        child: Padding(
-          padding: EdgeInsets.only(bottom: keyboardHeight),
-          child: Stack(
-            children: [
-              Container(
-                height:
-                    MediaQuery.of(context).size.height * 0.85 -
-                    MediaQuery.of(context).padding.top,
-                decoration: BoxDecoration(
-                  color: isDark ? const Color(0xFF1E1E1E) : Colors.white,
-                  borderRadius: const BorderRadius.vertical(
-                    top: Radius.circular(24),
+        onTap: () {
+          _textFocusNode.unfocus();
+          _pageFocusNode.unfocus();
+        },
+        child: SafeArea(
+          bottom: false,
+          child: Padding(
+            padding: EdgeInsets.only(bottom: keyboardHeight),
+            child: Stack(
+              children: [
+                Container(
+                  height: MediaQuery.of(context).size.height * 0.85 -
+                      MediaQuery.of(context).padding.top,
+                  decoration: BoxDecoration(
+                    color: isDark ? const Color(0xFF1E1E1E) : Colors.white,
+                    borderRadius: const BorderRadius.vertical(
+                      top: Radius.circular(24),
+                    ),
+                  ),
+                  child: Column(
+                    children: [
+                      SizedBox(height: 12 + MediaQuery.of(context).padding.top),
+                      _buildDragHandle(),
+                      _buildHeader(isDark),
+                      Expanded(child: _buildContent(isDark)),
+                    ],
                   ),
                 ),
-                child: Column(
-                  children: [
-                    SizedBox(height: 12 + MediaQuery.of(context).padding.top),
-                    _buildDragHandle(),
-                    _buildHeader(isDark),
-                    Expanded(child: _buildContent(isDark)),
-                  ],
-                ),
-              ),
-              if (!isKeyboardOpen && !_isUploading)
-                _buildUploadButton(isDark),
-              if (isKeyboardOpen &&
-                  (_textFocusNode.hasFocus || _pageFocusNode.hasFocus) &&
-                  !_hideKeyboardAccessory)
-                _buildKeyboardAccessory(isDark),
-              if (_isUploading) _buildLoadingOverlay(),
-            ],
+                if (!isKeyboardOpen &&
+                    !_isUploading &&
+                    !_textFocusNode.hasFocus)
+                  _buildUploadButton(isDark),
+                if (isKeyboardOpen &&
+                    (_textFocusNode.hasFocus || _pageFocusNode.hasFocus) &&
+                    !_hideKeyboardAccessory)
+                  _buildKeyboardAccessory(isDark),
+                if (_isUploading) _buildLoadingOverlay(),
+              ],
+            ),
           ),
         ),
       ),
-    ),
     );
   }
 
@@ -461,6 +312,116 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
         borderRadius: BorderRadius.circular(2),
       ),
     );
+  }
+
+  bool get _hasContent =>
+      _fullImageBytes != null ||
+      _textController.text.isNotEmpty ||
+      _pageController.text.isNotEmpty;
+
+  void _showResetConfirmation(bool isDark) {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (bottomSheetContext) => Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: isDark ? const Color(0xFF1E1E1E) : Colors.white,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 40,
+              height: 4,
+              margin: const EdgeInsets.only(bottom: 20),
+              decoration: BoxDecoration(
+                color: Colors.grey[400],
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Text(
+              '내용을 정말 초기화하시겠어요?',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
+                color: isDark ? Colors.white : Colors.black,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Row(
+              children: [
+                Expanded(
+                  child: GestureDetector(
+                    onTap: () => Navigator.pop(bottomSheetContext),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      decoration: BoxDecoration(
+                        color: isDark ? Colors.grey[800] : Colors.grey[200],
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Center(
+                        child: Text(
+                          '취소',
+                          style: TextStyle(
+                            fontSize: 15,
+                            fontWeight: FontWeight.w600,
+                            color: isDark ? Colors.grey[300] : Colors.grey[700],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: GestureDetector(
+                    onTap: () {
+                      Navigator.pop(bottomSheetContext);
+                      _resetAll();
+                    },
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      decoration: BoxDecoration(
+                        color: Colors.red[400],
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: const Center(
+                        child: Text(
+                          '초기화',
+                          style: TextStyle(
+                            fontSize: 15,
+                            fontWeight: FontWeight.w600,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            SizedBox(
+              height: MediaQuery.of(bottomSheetContext).padding.bottom + 8,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _resetAll() {
+    _saveTextToHistory();
+    setState(() {
+      _fullImageBytes = null;
+      _textController.clear();
+      _pageController.clear();
+      _pageValidationError = null;
+      _hasShownPageError = false;
+    });
+    _notifyStateChanged();
   }
 
   Widget _buildHeader(bool isDark) {
@@ -488,13 +449,47 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
               color: isDark ? Colors.white : Colors.black,
             ),
           ),
-          const SizedBox(width: 38),
+          _hasContent
+              ? GestureDetector(
+                  onTap: () => _showResetConfirmation(isDark),
+                  child: Container(
+                    padding: const EdgeInsets.all(8),
+                    child: Text(
+                      '초기화',
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                        color: isDark ? Colors.grey[400] : Colors.grey[600],
+                      ),
+                    ),
+                  ),
+                )
+              : const SizedBox(width: 38),
         ],
       ),
     );
   }
 
   Widget _buildContent(bool isDark) {
+    final isTextFocused = _textFocusNode.hasFocus;
+
+    if (isTextFocused) {
+      // 풀 모달 모드: 텍스트 필드만 표시
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildTextSectionHeader(isDark),
+            const SizedBox(height: 12),
+            Expanded(child: _buildExpandedTextField(isDark)),
+            const SizedBox(height: 20),
+          ],
+        ),
+      );
+    }
+
+    // 일반 모드: 전체 스크롤 가능
     return SingleChildScrollView(
       controller: _scrollController,
       padding: const EdgeInsets.symmetric(horizontal: 20),
@@ -524,10 +519,9 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
           width: 2,
         ),
       ),
-      child:
-          _fullImageBytes != null
-              ? _buildImagePreview(isDark)
-              : _buildImagePlaceholder(isDark),
+      child: _fullImageBytes != null
+          ? _buildImagePreview(isDark)
+          : _buildImagePlaceholder(isDark),
     );
   }
 
@@ -552,7 +546,8 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
               onTap: () => _handleOcrExtraction(isDark),
               behavior: HitTestBehavior.opaque,
               child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
                 decoration: BoxDecoration(
                   color: Colors.black54,
                   borderRadius: BorderRadius.circular(8),
@@ -601,7 +596,8 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
               },
               behavior: HitTestBehavior.opaque,
               child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
                 decoration: BoxDecoration(
                   color: Colors.black54,
                   borderRadius: BorderRadius.circular(8),
@@ -632,23 +628,22 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
   Widget _buildImagePlaceholder(bool isDark) {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onTap:
-          () => widget.onShowImageSourceSheet((
-            imageBytes,
-            ocrText,
-            ocrPageNumber,
-          ) {
-            setState(() {
-              _fullImageBytes = imageBytes;
-              if (ocrText.isNotEmpty) {
-                _textController.text = ocrText;
-              }
-              if (ocrPageNumber != null) {
-                _pageController.text = ocrPageNumber.toString();
-              }
-            });
-            _notifyStateChanged();
-          }),
+      onTap: () => widget.onShowImageSourceSheet((
+        imageBytes,
+        ocrText,
+        ocrPageNumber,
+      ) {
+        setState(() {
+          _fullImageBytes = imageBytes;
+          if (ocrText.isNotEmpty) {
+            _textController.text = ocrText;
+          }
+          if (ocrPageNumber != null) {
+            _pageController.text = ocrPageNumber.toString();
+          }
+        });
+        _notifyStateChanged();
+      }),
       child: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -689,10 +684,9 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
             Icon(
               CupertinoIcons.book,
               size: 16,
-              color:
-                  _pageValidationError != null
-                      ? Colors.red[400]
-                      : (isDark ? Colors.grey[400] : Colors.grey[600]),
+              color: _pageValidationError != null
+                  ? Colors.red[400]
+                  : (isDark ? Colors.grey[400] : Colors.grey[600]),
             ),
             const SizedBox(width: 8),
             Text(
@@ -700,10 +694,9 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
               style: TextStyle(
                 fontSize: 14,
                 fontWeight: FontWeight.w600,
-                color:
-                    _pageValidationError != null
-                        ? Colors.red[400]
-                        : (isDark ? Colors.white : Colors.black),
+                color: _pageValidationError != null
+                    ? Colors.red[400]
+                    : (isDark ? Colors.white : Colors.black),
               ),
             ),
             Text(
@@ -724,10 +717,9 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 16,
-                  color:
-                      _pageValidationError != null
-                          ? Colors.red[400]
-                          : (isDark ? Colors.white : Colors.black),
+                  color: _pageValidationError != null
+                      ? Colors.red[400]
+                      : (isDark ? Colors.white : Colors.black),
                 ),
                 onChanged: _handlePageNumberChange,
                 decoration: InputDecoration(
@@ -743,32 +735,25 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(8),
                     borderSide: BorderSide(
-                      color:
-                          _pageValidationError != null
-                              ? Colors.red[400]!
-                              : (isDark
-                                  ? Colors.grey[700]!
-                                  : Colors.grey[300]!),
+                      color: _pageValidationError != null
+                          ? Colors.red[400]!
+                          : (isDark ? Colors.grey[700]! : Colors.grey[300]!),
                     ),
                   ),
                   enabledBorder: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(8),
                     borderSide: BorderSide(
-                      color:
-                          _pageValidationError != null
-                              ? Colors.red[400]!
-                              : (isDark
-                                  ? Colors.grey[700]!
-                                  : Colors.grey[300]!),
+                      color: _pageValidationError != null
+                          ? Colors.red[400]!
+                          : (isDark ? Colors.grey[700]! : Colors.grey[300]!),
                     ),
                   ),
                   focusedBorder: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(8),
                     borderSide: BorderSide(
-                      color:
-                          _pageValidationError != null
-                              ? Colors.red[400]!
-                              : const Color(0xFF5B7FFF),
+                      color: _pageValidationError != null
+                          ? Colors.red[400]!
+                          : const Color(0xFF5B7FFF),
                     ),
                   ),
                 ),
@@ -780,137 +765,194 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
     );
   }
 
+  void _showFullTextModal(bool isDark) {
+    showFullTextViewModal(
+      context: context,
+      initialText: _textController.text,
+      hintText: '인상 깊은 대목을 기록해보세요.',
+      startInEditMode: true,
+    ).then((modifiedText) {
+      if (!mounted) return;
+      if (modifiedText != null) {
+        _saveTextToHistory();
+        _textController.text = modifiedText;
+        _notifyStateChanged();
+        setState(() {});
+      }
+    });
+  }
+
+  Widget _buildTextSectionHeader(bool isDark) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Row(
+          children: [
+            Icon(
+              CupertinoIcons.doc_text,
+              size: 16,
+              color: isDark ? Colors.grey[400] : Colors.grey[600],
+            ),
+            const SizedBox(width: 8),
+            Text(
+              '기록 문구',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+                color: isDark ? Colors.white : Colors.black,
+              ),
+            ),
+            Text(
+              ' *',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+                color: Colors.red[400],
+              ),
+            ),
+          ],
+        ),
+        Row(
+          children: [
+            if (_textController.text.isNotEmpty) ...[
+              GestureDetector(
+                onTap: () => _showFullTextModal(isDark),
+                child: Row(
+                  children: [
+                    Icon(
+                      CupertinoIcons.arrow_up_left_arrow_down_right,
+                      size: 14,
+                      color: isDark ? Colors.grey[400] : Colors.grey[600],
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      '전체보기',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                        color: isDark ? Colors.grey[400] : Colors.grey[600],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 16),
+            ],
+            GestureDetector(
+              onTap: () {
+                _saveTextToHistory();
+                setState(() {
+                  _textController.clear();
+                });
+                _notifyStateChanged();
+              },
+              child: Row(
+                children: [
+                  Icon(CupertinoIcons.trash, size: 14, color: Colors.red[400]),
+                  const SizedBox(width: 4),
+                  Text(
+                    '모두 지우기',
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                      color: Colors.red[400],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildExpandedTextField(bool isDark) {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: isDark ? Colors.grey[900] : Colors.grey[100],
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
+        ),
+      ),
+      child: TextField(
+        controller: _textController,
+        focusNode: _textFocusNode,
+        maxLines: null,
+        expands: true,
+        keyboardType: TextInputType.multiline,
+        textInputAction: TextInputAction.newline,
+        textAlignVertical: TextAlignVertical.top,
+        onChanged: (value) {
+          _saveTextToHistory();
+          _notifyStateChanged();
+        },
+        style: TextStyle(
+          fontSize: 15,
+          height: 1.6,
+          color: isDark ? Colors.white : Colors.black,
+        ),
+        decoration: InputDecoration(
+          hintText: '인상 깊은 대목을 기록해보세요.',
+          hintStyle: TextStyle(
+            color: isDark ? Colors.grey[600] : Colors.grey[400],
+          ),
+          border: InputBorder.none,
+          contentPadding: const EdgeInsets.all(16),
+        ),
+      ),
+    );
+  }
+
   Widget _buildTextSection(bool isDark) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Row(
-              children: [
-                Icon(
-                  CupertinoIcons.doc_text,
-                  size: 16,
-                  color: isDark ? Colors.grey[400] : Colors.grey[600],
-                ),
-                const SizedBox(width: 8),
-                Text(
-                  '기록 문구',
-                  style: TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w600,
-                    color: isDark ? Colors.white : Colors.black,
-                  ),
-                ),
-                Text(
-                  ' *',
-                  style: TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w600,
-                    color: Colors.red[400],
-                  ),
-                ),
-              ],
-            ),
-            Row(
-              children: [
-                if (_canUndo)
-                  GestureDetector(
-                    onTap: _undoText,
-                    child: Row(
-                      children: [
-                        Icon(
-                          CupertinoIcons.arrow_uturn_left,
-                          size: 14,
-                          color: isDark ? Colors.grey[400] : Colors.grey[600],
-                        ),
-                        const SizedBox(width: 4),
-                        Text(
-                          '되돌리기',
-                          style: TextStyle(
-                            fontSize: 13,
-                            fontWeight: FontWeight.w500,
-                            color: isDark ? Colors.grey[400] : Colors.grey[600],
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                if (_canUndo && _textController.text.isNotEmpty)
-                  const SizedBox(width: 16),
-                if (_textController.text.isNotEmpty)
-                  GestureDetector(
-                    onTap: () {
-                      _saveTextToHistory();
-                      setState(() {
-                        _textController.clear();
-                      });
-                      _notifyStateChanged();
-                    },
-                    child: Row(
-                      children: [
-                        Icon(CupertinoIcons.trash, size: 14, color: Colors.red[400]),
-                        const SizedBox(width: 4),
-                        Text(
-                          '모두 지우기',
-                          style: TextStyle(
-                            fontSize: 13,
-                            fontWeight: FontWeight.w500,
-                            color: Colors.red[400],
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-              ],
-            ),
-          ],
-        ),
+        _buildTextSectionHeader(isDark),
         const SizedBox(height: 12),
-        Container(
-          constraints: const BoxConstraints(minHeight: 150),
-          decoration: BoxDecoration(
-            color: isDark ? Colors.grey[900] : Colors.grey[100],
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
-            ),
-          ),
-          child: TextField(
-            controller: _textController,
-            focusNode: _textFocusNode,
-            maxLines: null,
-            minLines: 6,
-            keyboardType: TextInputType.multiline,
-            textInputAction: TextInputAction.newline,
-            onChanged: (value) {
-              setState(() {});
-              _notifyStateChanged();
-            },
-            onTap: () {
-              Future.delayed(const Duration(milliseconds: 300), () {
-                if (_scrollController.hasClients) {
-                  _scrollController.animateTo(
-                    _scrollController.position.maxScrollExtent,
-                    duration: const Duration(milliseconds: 200),
-                    curve: Curves.easeOut,
-                  );
-                }
-              });
-            },
-            style: TextStyle(
-              fontSize: 15,
-              height: 1.6,
-              color: isDark ? Colors.white : Colors.black,
-            ),
-            decoration: InputDecoration(
-              hintText: '인상 깊은 대목을 기록해보세요.',
-              hintStyle: TextStyle(
-                color: isDark ? Colors.grey[600] : Colors.grey[400],
+        GestureDetector(
+          onTap: () {
+            _textFocusNode.requestFocus();
+          },
+          child: Container(
+            constraints: const BoxConstraints(minHeight: 150, maxHeight: 180),
+            decoration: BoxDecoration(
+              color: isDark ? Colors.grey[900] : Colors.grey[100],
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
               ),
-              border: InputBorder.none,
-              contentPadding: const EdgeInsets.all(16),
+            ),
+            child: Scrollbar(
+              thumbVisibility: true,
+              child: TextField(
+                controller: _textController,
+                focusNode: _textFocusNode,
+                maxLines: null,
+                expands: true,
+                keyboardType: TextInputType.multiline,
+                textInputAction: TextInputAction.newline,
+                textAlignVertical: TextAlignVertical.top,
+                onChanged: (value) {
+                  _saveTextToHistory();
+                  _notifyStateChanged();
+                },
+                style: TextStyle(
+                  fontSize: 15,
+                  height: 1.6,
+                  color: isDark ? Colors.white : Colors.black,
+                ),
+                decoration: InputDecoration(
+                  hintText: '인상 깊은 대목을 기록해보세요.',
+                  hintStyle: TextStyle(
+                    color: isDark ? Colors.grey[600] : Colors.grey[400],
+                  ),
+                  border: InputBorder.none,
+                  contentPadding: const EdgeInsets.all(16),
+                ),
+              ),
             ),
           ),
         ),
@@ -928,17 +970,15 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
         child: Container(
           padding: const EdgeInsets.symmetric(vertical: 16),
           decoration: BoxDecoration(
-            color:
-                _canUpload
-                    ? const Color(0xFF5B7FFF)
-                    : (isDark ? Colors.grey[700] : Colors.grey[300]),
+            color: _canUpload
+                ? const Color(0xFF5B7FFF)
+                : (isDark ? Colors.grey[700] : Colors.grey[300]),
             borderRadius: BorderRadius.circular(16),
             boxShadow: [
               BoxShadow(
-                color:
-                    _canUpload
-                        ? const Color(0xFF5B7FFF).withValues(alpha: 0.3)
-                        : Colors.transparent,
+                color: _canUpload
+                    ? const Color(0xFF5B7FFF).withValues(alpha: 0.3)
+                    : Colors.transparent,
                 blurRadius: 12,
                 offset: const Offset(0, 4),
               ),
@@ -950,10 +990,9 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
               style: TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.w600,
-                color:
-                    _canUpload
-                        ? Colors.white
-                        : (isDark ? Colors.grey[500] : Colors.grey[500]),
+                color: _canUpload
+                    ? Colors.white
+                    : (isDark ? Colors.grey[500] : Colors.grey[500]),
               ),
             ),
           ),
@@ -975,8 +1014,13 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
         showNavigation: true,
         canGoUp: isTextFocused,
         canGoDown: isPageFocused,
+        onUndo: (isTextFocused && _canUndo) ? _undoText : null,
+        canUndo: isTextFocused && _canUndo,
+        onRedo: (isTextFocused && _canRedo) ? _redoText : null,
+        canRedo: isTextFocused && _canRedo,
         onUp: () {
           if (_textFocusNode.hasFocus) {
+            _saveTextToHistory();
             _textFocusNode.unfocus();
             _pageFocusNode.requestFocus();
           }
@@ -991,8 +1035,10 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
           setState(() {
             _hideKeyboardAccessory = true;
           });
-          _textFocusNode.unfocus();
-          _pageFocusNode.unfocus();
+          if (_textFocusNode.hasFocus) {
+            _saveTextToHistory();
+          }
+          SystemChannels.textInput.invokeMethod('TextInput.hide');
           Future.delayed(const Duration(milliseconds: 300), () {
             if (mounted) {
               setState(() {
@@ -1041,7 +1087,8 @@ Future<Map<String, dynamic>?> showAddMemorablePageModal({
   int? initialPageNumber,
   required int totalPages,
   required void Function(Uint8List imageBytes) onImageTap,
-  required void Function(void Function(Uint8List?, String, int?) onImageSelected)
+  required void Function(
+          void Function(Uint8List?, String, int?) onImageSelected)
       onShowImageSourceSheet,
   required void Function(VoidCallback onConfirm) onShowReplaceImageConfirmation,
   required void Function(
@@ -1060,20 +1107,19 @@ Future<Map<String, dynamic>?> showAddMemorablePageModal({
     context: context,
     isScrollControlled: true,
     isDismissible: true,
-    enableDrag: true,
+    enableDrag: false,
     backgroundColor: Colors.transparent,
-    builder:
-        (modalContext) => AddMemorablePageModal(
-          initialImageBytes: initialImageBytes,
-          initialExtractedText: initialExtractedText,
-          initialPageNumber: initialPageNumber,
-          totalPages: totalPages,
-          onImageTap: onImageTap,
-          onShowImageSourceSheet: onShowImageSourceSheet,
-          onShowReplaceImageConfirmation: onShowReplaceImageConfirmation,
-          onExtractText: onExtractText,
-          onUpload: onUpload,
-          onStateChanged: onStateChanged,
-        ),
+    builder: (modalContext) => AddMemorablePageModal(
+      initialImageBytes: initialImageBytes,
+      initialExtractedText: initialExtractedText,
+      initialPageNumber: initialPageNumber,
+      totalPages: totalPages,
+      onImageTap: onImageTap,
+      onShowImageSourceSheet: onShowImageSourceSheet,
+      onShowReplaceImageConfirmation: onShowReplaceImageConfirmation,
+      onExtractText: onExtractText,
+      onUpload: onUpload,
+      onStateChanged: onStateChanged,
+    ),
   );
 }

--- a/app/lib/ui/core/utils/text_history_manager.dart
+++ b/app/lib/ui/core/utils/text_history_manager.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+class TextHistoryManager {
+  final TextEditingController controller;
+  final List<String> _undoStack = [];
+  final List<String> _redoStack = [];
+  final int maxHistorySize;
+  final VoidCallback? onHistoryChanged;
+
+  bool _isUndoing = false;
+  String _lastSavedText = '';
+
+  TextHistoryManager({
+    required this.controller,
+    this.maxHistorySize = 50,
+    this.onHistoryChanged,
+    String? initialText,
+  }) {
+    final initial = initialText ?? controller.text;
+    _undoStack.add(initial);
+    _lastSavedText = initial;
+  }
+
+  bool get canUndo => _undoStack.length > 1;
+  bool get canRedo => _redoStack.isNotEmpty;
+  bool get isUndoing => _isUndoing;
+
+  void saveToHistory() {
+    if (_isUndoing) return;
+
+    final currentText = controller.text;
+    if (_undoStack.isEmpty || _undoStack.last != currentText) {
+      _undoStack.add(currentText);
+      _redoStack.clear();
+      if (_undoStack.length > maxHistorySize) {
+        _undoStack.removeAt(0);
+      }
+      _lastSavedText = currentText;
+      onHistoryChanged?.call();
+    }
+  }
+
+  void saveIfChanged() {
+    final currentText = controller.text;
+    if (currentText != _lastSavedText) {
+      saveToHistory();
+    }
+  }
+
+  bool undo() {
+    if (!canUndo) return false;
+
+    _isUndoing = true;
+    final currentText = controller.text;
+
+    if (_undoStack.last == currentText && _undoStack.length > 1) {
+      _redoStack.add(_undoStack.removeLast());
+    } else if (_undoStack.last != currentText) {
+      _redoStack.add(currentText);
+    }
+
+    if (_undoStack.isNotEmpty) {
+      final previousText = _undoStack.last;
+      controller.text = previousText;
+      controller.selection = TextSelection.fromPosition(
+        TextPosition(offset: previousText.length),
+      );
+      _lastSavedText = previousText;
+    }
+
+    _isUndoing = false;
+    onHistoryChanged?.call();
+    return true;
+  }
+
+  bool redo() {
+    if (!canRedo) return false;
+
+    _isUndoing = true;
+    final nextText = _redoStack.removeLast();
+    _undoStack.add(nextText);
+    controller.text = nextText;
+    controller.selection = TextSelection.fromPosition(
+      TextPosition(offset: nextText.length),
+    );
+    _lastSavedText = nextText;
+    _isUndoing = false;
+    onHistoryChanged?.call();
+    return true;
+  }
+
+  void clear() {
+    saveToHistory();
+    controller.clear();
+    _lastSavedText = '';
+    onHistoryChanged?.call();
+  }
+
+  void reset() {
+    _undoStack.clear();
+    _redoStack.clear();
+    _undoStack.add(controller.text);
+    _lastSavedText = controller.text;
+    onHistoryChanged?.call();
+  }
+}

--- a/app/lib/ui/core/widgets/extracted_text_modal.dart
+++ b/app/lib/ui/core/widgets/extracted_text_modal.dart
@@ -1,0 +1,326 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:book_golas/ui/core/widgets/keyboard_accessory_bar.dart';
+import 'package:book_golas/ui/core/utils/text_history_manager.dart';
+
+class ExtractedTextModal extends StatefulWidget {
+  final String initialText;
+  final int? pageNumber;
+  final bool isDark;
+  final String title;
+  final String subtitle;
+  final String applyButtonText;
+  final String cancelButtonText;
+  final String? creditWarning;
+
+  const ExtractedTextModal({
+    super.key,
+    required this.initialText,
+    this.pageNumber,
+    required this.isDark,
+    this.title = '추출된 텍스트',
+    this.subtitle = '추출된 내용을 확인해주세요. 직접 수정도 가능해요!',
+    this.applyButtonText = '적용하기',
+    this.cancelButtonText = '다시 선택',
+    this.creditWarning,
+  });
+
+  @override
+  State<ExtractedTextModal> createState() => _ExtractedTextModalState();
+}
+
+class _ExtractedTextModalState extends State<ExtractedTextModal> {
+  late TextEditingController _controller;
+  late FocusNode _focusNode;
+  late TextHistoryManager _historyManager;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialText);
+    _focusNode = FocusNode();
+    _historyManager = TextHistoryManager(
+      controller: _controller,
+      initialText: widget.initialText,
+      onHistoryChanged: () {
+        if (mounted) setState(() {});
+      },
+    );
+    _focusNode.addListener(_onFocusChange);
+  }
+
+  void _onFocusChange() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _focusNode.removeListener(_onFocusChange);
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _applyAndClose() {
+    Navigator.pop(context, _controller.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
+    final maxModalHeight = screenHeight * 0.85;
+    final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
+    final isKeyboardOpen = keyboardHeight > 0;
+    final isTextFocused = _focusNode.hasFocus;
+
+    return GestureDetector(
+      onTap: () {
+        if (_focusNode.hasFocus) {
+          _focusNode.unfocus();
+          _applyAndClose();
+        }
+      },
+      child: Padding(
+        padding: EdgeInsets.only(
+          top: MediaQuery.of(context).padding.top + 40,
+          bottom: keyboardHeight,
+        ),
+        child: Stack(
+          children: [
+            Container(
+              constraints: BoxConstraints(maxHeight: maxModalHeight),
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: widget.isDark ? const Color(0xFF1E1E1E) : Colors.white,
+                borderRadius:
+                    const BorderRadius.vertical(top: Radius.circular(24)),
+              ),
+              child: Column(
+                children: [
+                  Text(
+                    widget.title,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      color: widget.isDark ? Colors.white : Colors.black,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    widget.subtitle,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      fontSize: 13,
+                      color:
+                          widget.isDark ? Colors.grey[400] : Colors.grey[600],
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: () {},
+                      child: Container(
+                        width: double.infinity,
+                        decoration: BoxDecoration(
+                          color: widget.isDark
+                              ? Colors.grey[900]
+                              : Colors.grey[100],
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(
+                            color: widget.isDark
+                                ? Colors.grey[700]!
+                                : Colors.grey[300]!,
+                          ),
+                        ),
+                        child: Scrollbar(
+                          thumbVisibility: true,
+                          child: TextField(
+                            controller: _controller,
+                            focusNode: _focusNode,
+                            maxLines: null,
+                            expands: true,
+                            keyboardType: TextInputType.multiline,
+                            textAlignVertical: TextAlignVertical.top,
+                            onChanged: (_) => _historyManager.saveIfChanged(),
+                            style: TextStyle(
+                              fontSize: 14,
+                              height: 1.6,
+                              color:
+                                  widget.isDark ? Colors.white : Colors.black,
+                            ),
+                            decoration: InputDecoration(
+                              hintText: '텍스트를 입력하세요',
+                              hintStyle: TextStyle(
+                                color: widget.isDark
+                                    ? Colors.grey[600]
+                                    : Colors.grey[400],
+                              ),
+                              border: InputBorder.none,
+                              contentPadding: const EdgeInsets.all(16),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  if (widget.pageNumber != null) ...[
+                    const SizedBox(height: 12),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          CupertinoIcons.book,
+                          size: 14,
+                          color: widget.isDark
+                              ? Colors.grey[400]
+                              : Colors.grey[600],
+                        ),
+                        const SizedBox(width: 6),
+                        Text(
+                          '페이지 ${widget.pageNumber}',
+                          style: TextStyle(
+                            fontSize: 13,
+                            color: widget.isDark
+                                ? Colors.grey[400]
+                                : Colors.grey[600],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                  if (!isTextFocused) ...[
+                    if (widget.creditWarning != null) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        widget.creditWarning!,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: widget.isDark
+                              ? Colors.grey[500]
+                              : Colors.grey[500],
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: 20),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: GestureDetector(
+                            onTap: () => Navigator.pop(context, null),
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(vertical: 14),
+                              decoration: BoxDecoration(
+                                color: widget.isDark
+                                    ? Colors.grey[800]
+                                    : Colors.grey[200],
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              child: Center(
+                                child: Text(
+                                  widget.cancelButtonText,
+                                  style: TextStyle(
+                                    fontSize: 15,
+                                    fontWeight: FontWeight.w600,
+                                    color: widget.isDark
+                                        ? Colors.grey[300]
+                                        : Colors.grey[700],
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: GestureDetector(
+                            onTap: _applyAndClose,
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(vertical: 14),
+                              decoration: BoxDecoration(
+                                color: const Color(0xFF5B7FFF),
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              child: Center(
+                                child: Text(
+                                  widget.applyButtonText,
+                                  style: const TextStyle(
+                                    fontSize: 15,
+                                    fontWeight: FontWeight.w600,
+                                    color: Colors.white,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    SizedBox(
+                      height: MediaQuery.of(context).padding.bottom + 8,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            if (isKeyboardOpen && isTextFocused)
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                child: KeyboardAccessoryBar(
+                  isDark: widget.isDark,
+                  onUndo: _historyManager.canUndo
+                      ? () => _historyManager.undo()
+                      : null,
+                  canUndo: _historyManager.canUndo,
+                  onRedo: _historyManager.canRedo
+                      ? () => _historyManager.redo()
+                      : null,
+                  canRedo: _historyManager.canRedo,
+                  onDone: () {
+                    SystemChannels.textInput.invokeMethod('TextInput.hide');
+                    setState(() {});
+                  },
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+Future<String?> showExtractedTextModal({
+  required BuildContext context,
+  required String initialText,
+  int? pageNumber,
+  String title = '추출된 텍스트',
+  String subtitle = '추출된 내용을 확인해주세요. 직접 수정도 가능해요!',
+  String applyButtonText = '적용하기',
+  String cancelButtonText = '다시 선택',
+  String? creditWarning,
+}) {
+  final isDark = Theme.of(context).brightness == Brightness.dark;
+
+  return showModalBottomSheet<String?>(
+    context: context,
+    isScrollControlled: true,
+    isDismissible: false,
+    enableDrag: false,
+    backgroundColor: Colors.transparent,
+    builder: (modalContext) => ExtractedTextModal(
+      initialText: initialText,
+      pageNumber: pageNumber,
+      isDark: isDark,
+      title: title,
+      subtitle: subtitle,
+      applyButtonText: applyButtonText,
+      cancelButtonText: cancelButtonText,
+      creditWarning: creditWarning,
+    ),
+  );
+}

--- a/app/lib/ui/core/widgets/full_text_view_modal.dart
+++ b/app/lib/ui/core/widgets/full_text_view_modal.dart
@@ -1,0 +1,417 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:book_golas/ui/core/widgets/keyboard_accessory_bar.dart';
+import 'package:book_golas/ui/core/widgets/custom_snackbar.dart';
+import 'package:book_golas/ui/core/utils/text_history_manager.dart';
+
+class FullTextViewModal extends StatefulWidget {
+  final String initialText;
+  final bool isDark;
+  final String title;
+  final String hintText;
+  final bool isEditable;
+  final bool startInEditMode;
+
+  const FullTextViewModal({
+    super.key,
+    required this.initialText,
+    required this.isDark,
+    this.title = '기록 문구',
+    this.hintText = '텍스트를 입력하세요...',
+    this.isEditable = true,
+    this.startInEditMode = false,
+  });
+
+  @override
+  State<FullTextViewModal> createState() => _FullTextViewModalState();
+}
+
+class _FullTextViewModalState extends State<FullTextViewModal> {
+  late TextEditingController _controller;
+  late FocusNode _focusNode;
+  late TextHistoryManager _historyManager;
+  late bool _isEditing;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialText);
+    _focusNode = FocusNode();
+    _historyManager = TextHistoryManager(
+      controller: _controller,
+      initialText: widget.initialText,
+      onHistoryChanged: () {
+        if (mounted) setState(() {});
+      },
+    );
+    _isEditing = widget.startInEditMode;
+    _focusNode.addListener(_onFocusChange);
+
+    if (_isEditing) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _focusNode.requestFocus();
+      });
+    }
+  }
+
+  void _onFocusChange() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _focusNode.removeListener(_onFocusChange);
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _handleCopy() {
+    Clipboard.setData(ClipboardData(text: _controller.text));
+    CustomSnackbar.show(
+      context,
+      message: '텍스트가 복사되었습니다.',
+      rootOverlay: true,
+      bottomOffset: 40,
+    );
+  }
+
+  void _handleSave() {
+    Navigator.pop(context, _controller.text);
+  }
+
+  void _handleCancel() {
+    if (_isEditing && _controller.text != widget.initialText) {
+      _controller.text = widget.initialText;
+      setState(() {
+        _isEditing = false;
+      });
+      _focusNode.unfocus();
+    } else {
+      Navigator.pop(context);
+    }
+  }
+
+  void _startEditing() {
+    setState(() {
+      _isEditing = true;
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _focusNode.requestFocus();
+    });
+  }
+
+  void _clearText() {
+    _historyManager.saveIfChanged();
+    _controller.clear();
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
+    final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
+    final isKeyboardOpen = keyboardHeight > 0;
+    final isTextFocused = _focusNode.hasFocus;
+
+    return GestureDetector(
+      onTap: () {
+        if (_focusNode.hasFocus) {
+          _focusNode.unfocus();
+        }
+      },
+      child: Padding(
+        padding: EdgeInsets.only(
+          top: MediaQuery.of(context).padding.top,
+          bottom: keyboardHeight,
+        ),
+        child: Stack(
+          children: [
+            Container(
+              height: screenHeight * 0.85,
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: widget.isDark ? const Color(0xFF1E1E1E) : Colors.white,
+                borderRadius:
+                    const BorderRadius.vertical(top: Radius.circular(24)),
+              ),
+              child: Column(
+                children: [
+                  Container(
+                    width: 40,
+                    height: 4,
+                    margin: const EdgeInsets.only(bottom: 16),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[400],
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                  _buildHeader(),
+                  const SizedBox(height: 16),
+                  _buildActionButtons(),
+                  const SizedBox(height: 12),
+                  Expanded(child: _buildContent()),
+                  SizedBox(
+                    height: MediaQuery.of(context).padding.bottom + 8,
+                  ),
+                ],
+              ),
+            ),
+            if (isKeyboardOpen && isTextFocused && _isEditing)
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                child: KeyboardAccessoryBar(
+                  isDark: widget.isDark,
+                  onUndo: _historyManager.canUndo
+                      ? () => _historyManager.undo()
+                      : null,
+                  canUndo: _historyManager.canUndo,
+                  onRedo: _historyManager.canRedo
+                      ? () => _historyManager.redo()
+                      : null,
+                  canRedo: _historyManager.canRedo,
+                  onDone: () {
+                    SystemChannels.textInput.invokeMethod('TextInput.hide');
+                    setState(() {});
+                  },
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        if (_isEditing)
+          GestureDetector(
+            onTap: _handleCancel,
+            child: Text(
+              '취소',
+              style: TextStyle(
+                fontSize: 16,
+                color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
+              ),
+            ),
+          )
+        else
+          Text(
+            widget.title,
+            style: TextStyle(
+              fontSize: 17,
+              fontWeight: FontWeight.w600,
+              color: widget.isDark ? Colors.white : Colors.black,
+            ),
+          ),
+        if (_isEditing)
+          GestureDetector(
+            onTap: _handleSave,
+            child: const Text(
+              '저장',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: Color(0xFF5B7FFF),
+              ),
+            ),
+          )
+        else
+          GestureDetector(
+            onTap: () => Navigator.pop(context),
+            child: Icon(
+              CupertinoIcons.xmark,
+              size: 22,
+              color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildActionButtons() {
+    if (!_isEditing) {
+      return Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          GestureDetector(
+            onTap: () => Navigator.pop(context),
+            child: Row(
+              children: [
+                Icon(
+                  CupertinoIcons.arrow_down_right_arrow_up_left,
+                  size: 14,
+                  color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  '축소보기',
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                    color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 16),
+          GestureDetector(
+            onTap: _handleCopy,
+            child: Row(
+              children: [
+                Icon(
+                  CupertinoIcons.doc_on_clipboard,
+                  size: 14,
+                  color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  '복사하기',
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                    color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (widget.isEditable) ...[
+            const SizedBox(width: 16),
+            GestureDetector(
+              onTap: _startEditing,
+              child: const Row(
+                children: [
+                  Icon(
+                    CupertinoIcons.pencil,
+                    size: 14,
+                    color: Color(0xFF5B7FFF),
+                  ),
+                  SizedBox(width: 4),
+                  Text(
+                    '수정하기',
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                      color: Color(0xFF5B7FFF),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ],
+      );
+    }
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        GestureDetector(
+          onTap: _clearText,
+          child: Row(
+            children: [
+              Icon(CupertinoIcons.trash, size: 14, color: Colors.red[400]),
+              const SizedBox(width: 4),
+              Text(
+                '모두 지우기',
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                  color: Colors.red[400],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildContent() {
+    if (_isEditing) {
+      return GestureDetector(
+        onTap: () => _focusNode.requestFocus(),
+        child: Container(
+          decoration: BoxDecoration(
+            color: widget.isDark ? Colors.grey[900] : Colors.grey[100],
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: widget.isDark ? Colors.grey[700]! : Colors.grey[300]!,
+            ),
+          ),
+          child: TextField(
+            controller: _controller,
+            focusNode: _focusNode,
+            maxLines: null,
+            expands: true,
+            keyboardType: TextInputType.multiline,
+            textAlignVertical: TextAlignVertical.top,
+            onChanged: (_) => _historyManager.saveIfChanged(),
+            style: TextStyle(
+              fontSize: 16,
+              height: 1.8,
+              color: widget.isDark ? Colors.white : Colors.black,
+            ),
+            decoration: InputDecoration(
+              hintText: widget.hintText,
+              hintStyle: TextStyle(
+                color: widget.isDark ? Colors.grey[600] : Colors.grey[400],
+              ),
+              border: InputBorder.none,
+              contentPadding: const EdgeInsets.all(16),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Scrollbar(
+      thumbVisibility: true,
+      child: SingleChildScrollView(
+        child: SelectableText(
+          _controller.text,
+          style: TextStyle(
+            fontSize: 16,
+            height: 1.8,
+            color: widget.isDark ? Colors.white : Colors.black,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Future<String?> showFullTextViewModal({
+  required BuildContext context,
+  required String initialText,
+  String title = '기록 문구',
+  String hintText = '텍스트를 입력하세요...',
+  bool isEditable = true,
+  bool startInEditMode = false,
+}) {
+  final isDark = Theme.of(context).brightness == Brightness.dark;
+
+  return showModalBottomSheet<String?>(
+    context: context,
+    isScrollControlled: true,
+    isDismissible: false,
+    enableDrag: false,
+    backgroundColor: Colors.transparent,
+    builder: (modalContext) => FullTextViewModal(
+      initialText: initialText,
+      isDark: isDark,
+      title: title,
+      hintText: hintText,
+      isEditable: isEditable,
+      startInEditMode: startInEditMode,
+    ),
+  );
+}

--- a/app/lib/ui/core/widgets/keyboard_accessory_bar.dart
+++ b/app/lib/ui/core/widgets/keyboard_accessory_bar.dart
@@ -1,16 +1,23 @@
+import 'dart:async';
 import 'dart:ui';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
-class KeyboardAccessoryBar extends StatelessWidget {
+class KeyboardAccessoryBar extends StatefulWidget {
   final VoidCallback onDone;
   final bool isDark;
   final IconData? icon;
   final VoidCallback? onUp;
   final VoidCallback? onDown;
+  final VoidCallback? onUndo;
+  final VoidCallback? onRedo;
   final bool showNavigation;
   final bool canGoUp;
   final bool canGoDown;
+  final bool canUndo;
+  final bool canRedo;
 
   const KeyboardAccessoryBar({
     super.key,
@@ -19,27 +26,69 @@ class KeyboardAccessoryBar extends StatelessWidget {
     this.icon,
     this.onUp,
     this.onDown,
+    this.onUndo,
+    this.onRedo,
     this.showNavigation = false,
     this.canGoUp = true,
     this.canGoDown = true,
+    this.canUndo = false,
+    this.canRedo = false,
   });
+
+  @override
+  State<KeyboardAccessoryBar> createState() => _KeyboardAccessoryBarState();
+}
+
+class _KeyboardAccessoryBarState extends State<KeyboardAccessoryBar> {
+  Timer? _repeatTimer;
+  static const _initialDelay = Duration(milliseconds: 500);
+  static const _repeatInterval = Duration(milliseconds: 100);
+
+  @override
+  void dispose() {
+    _repeatTimer?.cancel();
+    super.dispose();
+  }
+
+  void _startRepeat(VoidCallback action) {
+    action();
+    HapticFeedback.lightImpact();
+
+    _repeatTimer = Timer(_initialDelay, () {
+      _repeatTimer = Timer.periodic(_repeatInterval, (_) {
+        action();
+        HapticFeedback.selectionClick();
+      });
+    });
+  }
+
+  void _stopRepeat() {
+    _repeatTimer?.cancel();
+    _repeatTimer = null;
+  }
 
   Widget _buildIconButton({
     required VoidCallback? onTap,
     required IconData iconData,
     bool enabled = true,
+    bool supportLongPress = false,
   }) {
     final effectiveAlpha = enabled ? 1.0 : 0.3;
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: enabled ? onTap : null,
+      onLongPressStart: supportLongPress && enabled && onTap != null
+          ? (_) => _startRepeat(onTap)
+          : null,
+      onLongPressEnd: supportLongPress && enabled ? (_) => _stopRepeat() : null,
+      onLongPressCancel: supportLongPress && enabled ? _stopRepeat : null,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
         child: Icon(
           iconData,
           size: 20,
-          color: isDark
+          color: widget.isDark
               ? Colors.white.withValues(alpha: 0.9 * effectiveAlpha)
               : Colors.black.withValues(alpha: 0.7 * effectiveAlpha),
         ),
@@ -51,7 +100,7 @@ class KeyboardAccessoryBar extends StatelessWidget {
     return Container(
       width: 1,
       height: 20,
-      color: isDark
+      color: widget.isDark
           ? Colors.white.withValues(alpha: 0.2)
           : Colors.black.withValues(alpha: 0.1),
     );
@@ -71,13 +120,14 @@ class KeyboardAccessoryBar extends StatelessWidget {
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
                 colors: [
-                  Colors.white.withValues(alpha: isDark ? 0.15 : 0.6),
-                  Colors.white.withValues(alpha: isDark ? 0.08 : 0.3),
+                  Colors.white.withValues(alpha: widget.isDark ? 0.15 : 0.6),
+                  Colors.white.withValues(alpha: widget.isDark ? 0.08 : 0.3),
                 ],
               ),
               borderRadius: BorderRadius.circular(100),
               border: Border.all(
-                color: Colors.white.withValues(alpha: isDark ? 0.2 : 0.4),
+                color:
+                    Colors.white.withValues(alpha: widget.isDark ? 0.2 : 0.4),
                 width: 1,
               ),
               boxShadow: [
@@ -90,23 +140,42 @@ class KeyboardAccessoryBar extends StatelessWidget {
             ),
             child: Row(
               children: [
-                if (showNavigation) ...[
+                if (widget.showNavigation) ...[
                   _buildIconButton(
-                    onTap: onUp,
+                    onTap: widget.onUp,
                     iconData: CupertinoIcons.chevron_up,
-                    enabled: canGoUp && onUp != null,
+                    enabled: widget.canGoUp && widget.onUp != null,
                   ),
                   _buildDivider(),
                   _buildIconButton(
-                    onTap: onDown,
+                    onTap: widget.onDown,
                     iconData: CupertinoIcons.chevron_down,
-                    enabled: canGoDown && onDown != null,
+                    enabled: widget.canGoDown && widget.onDown != null,
                   ),
                 ],
                 const Spacer(),
+                if (widget.onUndo != null) ...[
+                  _buildIconButton(
+                    onTap: widget.onUndo,
+                    iconData: CupertinoIcons.arrow_uturn_left,
+                    enabled: widget.canUndo,
+                    supportLongPress: true,
+                  ),
+                  _buildDivider(),
+                ],
+                if (widget.onRedo != null) ...[
+                  _buildIconButton(
+                    onTap: widget.onRedo,
+                    iconData: CupertinoIcons.arrow_uturn_right,
+                    enabled: widget.canRedo,
+                    supportLongPress: true,
+                  ),
+                  _buildDivider(),
+                ],
                 _buildIconButton(
-                  onTap: onDone,
-                  iconData: icon ?? CupertinoIcons.keyboard_chevron_compact_down,
+                  onTap: widget.onDone,
+                  iconData: widget.icon ??
+                      CupertinoIcons.keyboard_chevron_compact_down,
                 ),
               ],
             ),


### PR DESCRIPTION
텍스트 입력 경험을 전반적으로 개선하여 OCR 편집, undo/redo 기능, 공통 모달 위젯을 추가했습니다.

## 📋 Changes

### Core Features
- **TextHistoryManager**: undo/redo 스택을 관리하는 공통 클래스
- **KeyboardAccessoryBar**: redo 버튼 추가, 길게 누르면 반복 실행
- **ExtractedTextModal**: OCR 결과 확인/편집 공통 위젯
- **FullTextViewModal**: 전체보기 읽기/수정 모드 공통 위젯

### OCR Improvements
- `sanitizeOcrText()`: 불가시 문자, 특수 공백 제거
- 한글 단일 글자 공백 오류 제거 로직
- OCR 확인 모달에서 직접 텍스트 편집 가능
- 풀 모달로 변경하여 전체 영역 활용

### Modal UX Enhancements
- 키보드 접기: 포커스 유지하며 키보드만 숨김
- 스와이프 다운 모달 해제 방지 (enableDrag: false)
- 텍스트 필드 포커스 시 확장 표시
- 전체보기 기능: 축소보기/복사하기/수정하기

### Refactoring
- 중복 모달 코드를 공통 위젯으로 통합
- add_memorable_page_modal, existing_image_modal, ocr_utils 리팩터링
- scanDocumentAndExtractText도 공통 위젯 사용하도록 개선

## 🧠 Context & Background

이 PR은 여러 세션에 걸쳐 진행된 작업을 origin/dev 위에 squash한 결과입니다.

### 원본 커밋 히스토리 (13개 → 1개로 squash)
1. `feat(ocr): OCR 확인 다이얼로그에서 텍스트 편집 가능하게 개선`
2. `feat(modal): 기록 모달의 텍스트 에어리어 스크롤 동작 개선`
3. `feat(ocr): OCR 확인 다이얼로그 UX 개선`
4. `feat(ocr): OCR 확인 다이얼로그 UX 추가 개선`
5. `feat(ocr): OCR 텍스트 정제 강화 및 키보드 악세서리 undo 기능 확장`
6. `fix(modal): 키보드 악세서리 undo 활성화 문제 수정`
7. `fix(modal): undo 기능 로직 수정 - 텍스트 입력 시에만 활성화`
8. `refactor(modal): OCR 모달과 동일한 undo 로직 적용`
9. `feat(modal): 기록 모달 텍스트필드 스크롤 로직 개선`
10. `feat(modal): 텍스트 필드 포커스 시 풀 모달 전환 기능 구현`
11. `feat(core): add TextHistoryManager and enhance KeyboardAccessoryBar`
12. `feat(modal): apply undo/redo and enhance text editing UX across modals`
13. `refactor(modal): extract common widgets for text modals`

## ✅ How to Test

1. 기록 추가 모달에서 텍스트 입력 후 undo/redo 테스트
2. OCR 추출 후 텍스트 편집 및 적용 테스트
3. 전체보기 모달에서 읽기/수정 모드 전환 테스트
4. 키보드 접기 버튼으로 포커스 유지 확인

## 🔗 Related Issues

- Closes: BYU-254