### PR TITLE
Daily/2026-01-14-02

### DIFF
--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -101,6 +101,9 @@ PODS:
     - TOCropViewController (~> 2.7.4)
   - image_picker_ios (0.0.1):
     - Flutter
+  - mobile_scanner (7.0.0):
+    - Flutter
+    - FlutterMacOS
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -135,6 +138,7 @@ DEPENDENCIES:
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+  - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
@@ -181,6 +185,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_cropper/ios"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
+  mobile_scanner:
+    :path: ".symlinks/plugins/mobile_scanner/darwin"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   permission_handler_apple:
@@ -217,6 +223,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   image_cropper: 5f162dcf988100dc1513f9c6b7eb42cd6fbf9156
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
+  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d

--- a/app/lib/data/services/aladin_api_service.dart
+++ b/app/lib/data/services/aladin_api_service.dart
@@ -1,9 +1,11 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 import 'package:book_golas/config/app_config.dart';
 import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/ui/core/utils/isbn_validator.dart';
 
 class AladinApiService {
   static Future<List<BookSearchResult>> searchBooks(String query) async {
@@ -12,6 +14,12 @@ class AladinApiService {
     AppConfig.validateApiKeys();
 
     try {
+      final cleanedQuery = IsbnValidator.cleanISBN(query);
+      if (IsbnValidator.isValidISBN13(cleanedQuery)) {
+        final result = await lookupByISBN(cleanedQuery);
+        return result != null ? [result] : [];
+      }
+
       final searchUri =
           Uri.parse(AppConfig.aladinBaseUrl).replace(queryParameters: {
         'ttbkey': AppConfig.aladinApiKey,
@@ -22,7 +30,7 @@ class AladinApiService {
         'SearchTarget': 'Book',
         'output': 'js',
         'Version': AppConfig.apiVersion,
-        'Cover': 'Big', // 200px 고화질 이미지
+        'Cover': 'Big',
       });
 
       final searchResponse = await http.get(searchUri);
@@ -36,7 +44,7 @@ class AladinApiService {
         for (var item in searchItems.take(5)) {
           final isbn13 = item['isbn13'];
           if (isbn13 != null && isbn13.toString().isNotEmpty) {
-            final detailedBook = await _fetchBookDetails(isbn13.toString());
+            final detailedBook = await lookupByISBN(isbn13.toString());
             if (detailedBook != null) {
               detailedBooks.add(detailedBook);
             } else {
@@ -52,12 +60,12 @@ class AladinApiService {
         throw Exception('Failed to load books: ${searchResponse.statusCode}');
       }
     } catch (e) {
-      print('Error searching books: $e');
+      debugPrint('Error searching books: $e');
       return [];
     }
   }
 
-  static Future<BookSearchResult?> _fetchBookDetails(String isbn) async {
+  static Future<BookSearchResult?> lookupByISBN(String isbn) async {
     try {
       final lookupUri =
           Uri.parse('http://www.aladin.co.kr/ttb/api/ItemLookUp.aspx')
@@ -68,25 +76,25 @@ class AladinApiService {
         'output': 'js',
         'Version': AppConfig.apiVersion,
         'OptResult': 'ebookList,usedList,reviewList',
-        'Cover': 'Big', // 200px 고화질 이미지
+        'Cover': 'Big',
       });
 
-      print('📡 상품 조회 API 요청: $lookupUri');
+      debugPrint('Aladin API lookup request: $lookupUri');
       final response = await http.get(lookupUri);
 
       if (response.statusCode == 200) {
         final jsonData = json.decode(response.body);
-        print('📩 상세 정보 응답: ${jsonData.toString()}');
+        debugPrint('Aladin API lookup response received');
 
         final List<dynamic> items = jsonData['item'] ?? [];
         if (items.isNotEmpty) {
           return BookSearchResult.fromJson(items[0]);
         }
       } else {
-        print('⚠️ 상세 정보 API 응답 실패 (HTTP ${response.statusCode})');
+        debugPrint('Aladin API lookup failed: HTTP ${response.statusCode}');
       }
     } catch (e) {
-      print('❌ 상세 정보 조회 실패: $e');
+      debugPrint('Aladin API lookup error: $e');
     }
     return null;
   }

--- a/app/lib/ui/barcode_scanner/barcode_scanner_screen.dart
+++ b/app/lib/ui/barcode_scanner/barcode_scanner_screen.dart
@@ -1,0 +1,173 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+import 'package:book_golas/ui/barcode_scanner/widgets/scanner_error_widget.dart';
+import 'package:book_golas/ui/barcode_scanner/widgets/scanner_overlay.dart';
+import 'package:book_golas/ui/core/utils/isbn_validator.dart';
+
+class BarcodeScannerScreen extends StatefulWidget {
+  const BarcodeScannerScreen({super.key});
+
+  @override
+  State<BarcodeScannerScreen> createState() => _BarcodeScannerScreenState();
+}
+
+class _BarcodeScannerScreenState extends State<BarcodeScannerScreen>
+    with WidgetsBindingObserver {
+  late final MobileScannerController _controller;
+  StreamSubscription<BarcodeCapture>? _subscription;
+  bool _hasScanned = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+
+    _controller = MobileScannerController(
+      autoStart: false,
+      formats: [BarcodeFormat.ean13, BarcodeFormat.ean8],
+      detectionSpeed: DetectionSpeed.noDuplicates,
+      facing: CameraFacing.back,
+    );
+
+    _subscription = _controller.barcodes.listen(_handleBarcode);
+    unawaited(_controller.start());
+  }
+
+  void _handleBarcode(BarcodeCapture capture) {
+    if (_hasScanned) return;
+
+    final barcode = capture.barcodes.firstOrNull;
+    if (barcode?.rawValue == null) return;
+
+    final scannedValue = barcode!.rawValue!;
+    final cleanedIsbn = IsbnValidator.cleanISBN(scannedValue);
+
+    if (IsbnValidator.isValidISBN13(cleanedIsbn)) {
+      _hasScanned = true;
+      HapticFeedback.mediumImpact();
+      Navigator.of(context).pop(cleanedIsbn);
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (!_controller.value.hasCameraPermission) return;
+
+    switch (state) {
+      case AppLifecycleState.resumed:
+        _subscription = _controller.barcodes.listen(_handleBarcode);
+        unawaited(_controller.start());
+        break;
+      case AppLifecycleState.inactive:
+        unawaited(_subscription?.cancel());
+        _subscription = null;
+        unawaited(_controller.stop());
+        break;
+      case AppLifecycleState.detached:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.paused:
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Stack(
+        children: [
+          MobileScanner(
+            controller: _controller,
+            onDetect: _handleBarcode,
+            errorBuilder: (context, error) {
+              return ScannerErrorWidget(error: error);
+            },
+          ),
+          const ScannerOverlay(),
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  GestureDetector(
+                    onTap: () => Navigator.of(context).pop(),
+                    child: Container(
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        color: Colors.black.withValues(alpha: 0.5),
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        CupertinoIcons.xmark,
+                        color: Colors.white,
+                        size: 20,
+                      ),
+                    ),
+                  ),
+                  const Text(
+                    'ISBN 바코드 스캔',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(width: 40),
+                ],
+              ),
+            ),
+          ),
+          Positioned(
+            bottom: 60,
+            left: 0,
+            right: 0,
+            child: Center(
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                decoration: BoxDecoration(
+                  color: Colors.black.withValues(alpha: 0.6),
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      CupertinoIcons.barcode,
+                      color: Colors.white.withValues(alpha: 0.8),
+                      size: 18,
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      '책 뒷면의 ISBN 바코드를 스캔해주세요',
+                      style: TextStyle(
+                        color: Colors.white.withValues(alpha: 0.9),
+                        fontSize: 13,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Future<void> dispose() async {
+    WidgetsBinding.instance.removeObserver(this);
+    unawaited(_subscription?.cancel());
+    _subscription = null;
+    super.dispose();
+    await _controller.dispose();
+  }
+}

--- a/app/lib/ui/barcode_scanner/widgets/scanner_error_widget.dart
+++ b/app/lib/ui/barcode_scanner/widgets/scanner_error_widget.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+class ScannerErrorWidget extends StatelessWidget {
+  final MobileScannerException error;
+
+  const ScannerErrorWidget({required this.error, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    String message;
+    IconData icon;
+
+    switch (error.errorCode) {
+      case MobileScannerErrorCode.permissionDenied:
+        message = '카메라 권한이 필요합니다\n설정에서 권한을 허용해주세요';
+        icon = Icons.no_photography_outlined;
+        break;
+      case MobileScannerErrorCode.controllerUninitialized:
+        message = '카메라를 초기화하는 중입니다';
+        icon = Icons.hourglass_empty;
+        break;
+      default:
+        message = '카메라 오류가 발생했습니다\n다시 시도해주세요';
+        icon = Icons.error_outline;
+    }
+
+    return Container(
+      color: Colors.black,
+      child: Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                icon,
+                size: 64,
+                color: Colors.white.withValues(alpha: 0.7),
+              ),
+              const SizedBox(height: 24),
+              Text(
+                message,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: Colors.white.withValues(alpha: 0.9),
+                  fontSize: 16,
+                  height: 1.5,
+                ),
+              ),
+              const SizedBox(height: 32),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text(
+                  '닫기',
+                  style: TextStyle(
+                    color: Color(0xFF5B7FFF),
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ui/barcode_scanner/widgets/scanner_overlay.dart
+++ b/app/lib/ui/barcode_scanner/widgets/scanner_overlay.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+
+class ScannerOverlay extends StatelessWidget {
+  const ScannerOverlay({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final scanAreaWidth = constraints.maxWidth * 0.85;
+        const scanAreaHeight = 160.0;
+
+        return Stack(
+          children: [
+            ColorFiltered(
+              colorFilter: ColorFilter.mode(
+                Colors.black.withValues(alpha: 0.6),
+                BlendMode.srcOut,
+              ),
+              child: Stack(
+                children: [
+                  Container(
+                    decoration: const BoxDecoration(
+                      color: Colors.black,
+                      backgroundBlendMode: BlendMode.dstOut,
+                    ),
+                  ),
+                  Align(
+                    alignment: Alignment.center,
+                    child: Container(
+                      width: scanAreaWidth,
+                      height: scanAreaHeight,
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Center(
+              child: Container(
+                width: scanAreaWidth,
+                height: scanAreaHeight,
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.white, width: 2),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Stack(
+                  children: [
+                    Positioned(
+                      top: 0,
+                      left: 0,
+                      child: _buildCorner(isTop: true, isLeft: true),
+                    ),
+                    Positioned(
+                      top: 0,
+                      right: 0,
+                      child: _buildCorner(isTop: true, isLeft: false),
+                    ),
+                    Positioned(
+                      bottom: 0,
+                      left: 0,
+                      child: _buildCorner(isTop: false, isLeft: true),
+                    ),
+                    Positioned(
+                      bottom: 0,
+                      right: 0,
+                      child: _buildCorner(isTop: false, isLeft: false),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            Positioned(
+              bottom: 120,
+              left: 0,
+              right: 0,
+              child: const Text(
+                '바코드를 프레임 안에 맞춰주세요',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildCorner({required bool isTop, required bool isLeft}) {
+    return Container(
+      width: 24,
+      height: 24,
+      decoration: BoxDecoration(
+        border: Border(
+          top: isTop
+              ? const BorderSide(color: Color(0xFF5B7FFF), width: 4)
+              : BorderSide.none,
+          bottom: !isTop
+              ? const BorderSide(color: Color(0xFF5B7FFF), width: 4)
+              : BorderSide.none,
+          left: isLeft
+              ? const BorderSide(color: Color(0xFF5B7FFF), width: 4)
+              : BorderSide.none,
+          right: !isLeft
+              ? const BorderSide(color: Color(0xFF5B7FFF), width: 4)
+              : BorderSide.none,
+        ),
+        borderRadius: BorderRadius.only(
+          topLeft: isTop && isLeft ? const Radius.circular(12) : Radius.zero,
+          topRight: isTop && !isLeft ? const Radius.circular(12) : Radius.zero,
+          bottomLeft:
+              !isTop && isLeft ? const Radius.circular(12) : Radius.zero,
+          bottomRight:
+              !isTop && !isLeft ? const Radius.circular(12) : Radius.zero,
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ui/core/utils/isbn_validator.dart
+++ b/app/lib/ui/core/utils/isbn_validator.dart
@@ -1,0 +1,31 @@
+class IsbnValidator {
+  static bool isValidISBN13(String isbn) {
+    final cleaned = cleanISBN(isbn);
+
+    if (cleaned.length != 13) return false;
+    if (!RegExp(r'^\d{13}$').hasMatch(cleaned)) return false;
+    if (!cleaned.startsWith('978') && !cleaned.startsWith('979')) return false;
+
+    return validateChecksum(cleaned);
+  }
+
+  static String cleanISBN(String isbn) {
+    return isbn.replaceAll(RegExp(r'[\s-]'), '');
+  }
+
+  static bool validateChecksum(String isbn13) {
+    if (isbn13.length != 13) return false;
+
+    int sum = 0;
+    for (int i = 0; i < 12; i++) {
+      final digit = int.tryParse(isbn13[i]);
+      if (digit == null) return false;
+      sum += digit * (i % 2 == 0 ? 1 : 3);
+    }
+
+    final checkDigit = (10 - (sum % 10)) % 10;
+    final lastDigit = int.tryParse(isbn13[12]);
+
+    return lastDigit == checkDigit;
+  }
+}

--- a/app/lib/ui/reading_start/widgets/reading_start_screen.dart
+++ b/app/lib/ui/reading_start/widgets/reading_start_screen.dart
@@ -8,7 +8,9 @@ import 'package:provider/provider.dart';
 import 'package:book_golas/data/services/book_service.dart';
 import 'package:book_golas/domain/models/book.dart';
 import 'package:book_golas/ui/book_detail/book_detail_screen.dart';
+import 'package:book_golas/ui/barcode_scanner/barcode_scanner_screen.dart';
 import 'package:book_golas/ui/core/widgets/book_image_widget.dart';
+import 'package:book_golas/ui/core/widgets/custom_snackbar.dart';
 import 'package:book_golas/ui/reading_start/view_model/reading_start_view_model.dart';
 import 'package:book_golas/ui/reading_start/widgets/priority_selector_widget.dart';
 import 'package:book_golas/ui/reading_start/widgets/schedule_change_modal.dart';
@@ -124,6 +126,34 @@ class _ReadingStartContentState extends State<_ReadingStartContent>
   void _clearSearchText() {
     _titleController.clear();
     _searchFocusNode.requestFocus();
+  }
+
+  Future<void> _openBarcodeScanner() async {
+    final vm = context.read<ReadingStartViewModel>();
+
+    final String? isbn = await Navigator.of(context).push<String>(
+      MaterialPageRoute(
+        builder: (context) => const BarcodeScannerScreen(),
+        fullscreenDialog: true,
+      ),
+    );
+
+    if (isbn != null && mounted) {
+      await vm.searchByISBN(isbn);
+
+      if (vm.scanError != null) {
+        if (mounted) {
+          CustomSnackbar.show(
+            context,
+            message: vm.scanError!,
+            rootOverlay: true,
+          );
+        }
+        vm.clearScanError();
+      } else if (vm.selectedBook != null) {
+        _nextPage(vm);
+      }
+    }
   }
 
   @override
@@ -606,7 +636,7 @@ class _ReadingStartContentState extends State<_ReadingStartContent>
                           GestureDetector(
                             onTap: _clearSearchText,
                             child: Padding(
-                              padding: const EdgeInsets.only(right: 14),
+                              padding: const EdgeInsets.only(right: 8),
                               child: Container(
                                 width: 20,
                                 height: 20,
@@ -626,6 +656,19 @@ class _ReadingStartContentState extends State<_ReadingStartContent>
                               ),
                             ),
                           ),
+                        GestureDetector(
+                          onTap: _openBarcodeScanner,
+                          child: Padding(
+                            padding: const EdgeInsets.only(right: 14),
+                            child: Icon(
+                              CupertinoIcons.barcode_viewfinder,
+                              color: isDark
+                                  ? Colors.white.withValues(alpha: 0.7)
+                                  : Colors.black.withValues(alpha: 0.5),
+                              size: 22,
+                            ),
+                          ),
+                        ),
                       ],
                     ),
                   ),

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -760,6 +760,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mobile_scanner:
+    dependency: "direct main"
+    description:
+      name: mobile_scanner
+      sha256: c6184bf2913dd66be244108c9c27ca04b01caf726321c44b0e7a7a1e32d41044
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.4"
   nested:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   permission_handler: ^12.0.1
   image: ^4.0.17
   path: ^1.8.3
+  mobile_scanner: ^7.1.4
 
   # Firebase & FCM
   firebase_core: ^3.6.0


### PR DESCRIPTION
바코드 스캐너 기능을 추가하여 책 검색 시 ISBN 스캔이 가능하도록 개선했습니다.

## 📋 Changes

- `mobile_scanner` 패키지 추가
- ISBN-13 검증 유틸리티 추가 (`isbn_validator.dart`)
- Aladin API에 ISBN 조회 기능 추가
- 전체화면 바코드 스캐너 화면 구현 (`barcode_scanner_screen.dart`)
- 독서 시작 화면에 바코드 스캐너 통합

## 🧠 Context & Background

바코드 스캔을 통해 책을 빠르게 검색할 수 있는 기능입니다.

## ✅ How to Test

1. 독서 시작 화면으로 이동
2. 검색창 우측의 바코드 아이콘 클릭
3. 책 뒷면의 ISBN 바코드 스캔
4. 검색 결과 확인

## 🔗 Related Issues

- Closes: BYU-39
