### PR TITLE
daily/2026-01-23

### DIFF
--- a/app/lib/data/services/highlight_settings_service.dart
+++ b/app/lib/data/services/highlight_settings_service.dart
@@ -1,0 +1,71 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class HighlightSettingsService {
+  static const String _keyColorIndex = 'highlight_color_index';
+  static const String _keyStrokeWidth = 'highlight_stroke_width';
+  static const String _keyOpacity = 'highlight_opacity';
+
+  static const int defaultColorIndex = 0;
+  static const double defaultStrokeWidth = 8.0;
+  static const double defaultOpacity = 0.5;
+
+  static Future<int> getColorIndex() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_keyColorIndex) ?? defaultColorIndex;
+  }
+
+  static Future<void> setColorIndex(int index) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_keyColorIndex, index);
+  }
+
+  static Future<double> getStrokeWidth() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getDouble(_keyStrokeWidth) ?? defaultStrokeWidth;
+  }
+
+  static Future<void> setStrokeWidth(double width) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_keyStrokeWidth, width);
+  }
+
+  static Future<double> getOpacity() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getDouble(_keyOpacity) ?? defaultOpacity;
+  }
+
+  static Future<void> setOpacity(double opacity) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_keyOpacity, opacity);
+  }
+
+  static Future<HighlightSettings> loadAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    return HighlightSettings(
+      colorIndex: prefs.getInt(_keyColorIndex) ?? defaultColorIndex,
+      strokeWidth: prefs.getDouble(_keyStrokeWidth) ?? defaultStrokeWidth,
+      opacity: prefs.getDouble(_keyOpacity) ?? defaultOpacity,
+    );
+  }
+
+  static Future<void> saveAll(HighlightSettings settings) async {
+    final prefs = await SharedPreferences.getInstance();
+    await Future.wait([
+      prefs.setInt(_keyColorIndex, settings.colorIndex),
+      prefs.setDouble(_keyStrokeWidth, settings.strokeWidth),
+      prefs.setDouble(_keyOpacity, settings.opacity),
+    ]);
+  }
+}
+
+class HighlightSettings {
+  final int colorIndex;
+  final double strokeWidth;
+  final double opacity;
+
+  const HighlightSettings({
+    required this.colorIndex,
+    required this.strokeWidth,
+    required this.opacity,
+  });
+}

--- a/app/lib/domain/models/highlight_data.dart
+++ b/app/lib/domain/models/highlight_data.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+
+class HighlightPoint {
+  final double x;
+  final double y;
+
+  const HighlightPoint({required this.x, required this.y});
+
+  factory HighlightPoint.fromJson(Map<String, dynamic> json) {
+    return HighlightPoint(
+      x: (json['x'] as num).toDouble(),
+      y: (json['y'] as num).toDouble(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {'x': x, 'y': y};
+
+  Offset toOffset(Size imageSize) {
+    return Offset(x * imageSize.width, y * imageSize.height);
+  }
+
+  factory HighlightPoint.fromOffset(Offset offset, Size imageSize) {
+    return HighlightPoint(
+      x: offset.dx / imageSize.width,
+      y: offset.dy / imageSize.height,
+    );
+  }
+}
+
+class HighlightData {
+  final String id;
+  final List<HighlightPoint> points;
+  final String color;
+  final double opacity;
+  final double strokeWidth;
+
+  HighlightData({
+    String? id,
+    required this.points,
+    required this.color,
+    this.opacity = 0.5,
+    this.strokeWidth = 0.05,
+  }) : id = id ?? const Uuid().v4();
+
+  factory HighlightData.fromJson(Map<String, dynamic> json) {
+    return HighlightData(
+      id: json['id'] as String,
+      points: (json['points'] as List)
+          .map((p) => HighlightPoint.fromJson(p as Map<String, dynamic>))
+          .toList(),
+      color: json['color'] as String,
+      opacity: (json['opacity'] as num?)?.toDouble() ?? 0.5,
+      strokeWidth: (json['strokeWidth'] as num?)?.toDouble() ?? 0.05,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'points': points.map((p) => p.toJson()).toList(),
+      'color': color,
+      'opacity': opacity,
+      'strokeWidth': strokeWidth,
+    };
+  }
+
+  Color get colorValue {
+    final hexColor = color.replaceFirst('#', '');
+    return Color(int.parse('FF$hexColor', radix: 16))
+        .withValues(alpha: opacity);
+  }
+
+  double getScaledStrokeWidth(Size imageSize) {
+    if (strokeWidth > 1.0) {
+      return strokeWidth / 400.0 * imageSize.width;
+    }
+    return strokeWidth * imageSize.width;
+  }
+
+  static double normalizeStrokeWidth(double pixelWidth, Size imageSize) {
+    return pixelWidth / imageSize.width;
+  }
+
+  Path toPath(Size imageSize) {
+    if (points.isEmpty) return Path();
+
+    final path = Path();
+    final firstPoint = points.first.toOffset(imageSize);
+    path.moveTo(firstPoint.dx, firstPoint.dy);
+
+    for (int i = 1; i < points.length; i++) {
+      final point = points[i].toOffset(imageSize);
+      path.lineTo(point.dx, point.dy);
+    }
+
+    return path;
+  }
+
+  HighlightData copyWith({
+    String? id,
+    List<HighlightPoint>? points,
+    String? color,
+    double? opacity,
+    double? strokeWidth,
+  }) {
+    return HighlightData(
+      id: id ?? this.id,
+      points: points ?? this.points,
+      color: color ?? this.color,
+      opacity: opacity ?? this.opacity,
+      strokeWidth: strokeWidth ?? this.strokeWidth,
+    );
+  }
+
+  static List<HighlightData> fromJsonList(dynamic json) {
+    if (json == null) return [];
+    if (json is! List) return [];
+    return json
+        .map((item) => HighlightData.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+
+  static List<Map<String, dynamic>> toJsonList(List<HighlightData> highlights) {
+    return highlights.map((h) => h.toJson()).toList();
+  }
+}
+
+class HighlightColor {
+  static const String yellow = '#FFEB3B';
+  static const String orange = '#FF9800';
+  static const String pink = '#E91E63';
+  static const String blue = '#2196F3';
+  static const String green = '#4CAF50';
+  static const String purple = '#9C27B0';
+
+  static const List<String> colors = [
+    yellow,
+    orange,
+    pink,
+    blue,
+    green,
+    purple,
+  ];
+
+  static Color toColor(String hex) {
+    final hexColor = hex.replaceFirst('#', '');
+    return Color(int.parse('FF$hexColor', radix: 16));
+  }
+}

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -8,6 +8,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:book_golas/data/services/book_service.dart';
 import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/domain/models/highlight_data.dart';
 import 'package:book_golas/ui/core/widgets/custom_snackbar.dart';
 import 'package:book_golas/ui/book_detail/view_model/book_detail_view_model.dart';
 import 'package:book_golas/ui/book_detail/view_model/memorable_page_view_model.dart';
@@ -527,14 +528,19 @@ class _BookDetailContentState extends State<_BookDetailContent>
     );
   }
 
-  void _showFullScreenImage(String imageId, String imageUrl) {
+  void _showFullScreenImage(String imageId, String imageUrl,
+      {List<HighlightData>? highlights}) {
     Navigator.of(context).push(
       PageRouteBuilder(
         opaque: false,
         barrierColor: Colors.transparent,
         pageBuilder: (context, animation, secondaryAnimation) {
           return DraggableDismissNetworkImage(
-              animation: animation, imageUrl: imageUrl, imageId: imageId);
+            animation: animation,
+            imageUrl: imageUrl,
+            imageId: imageId,
+            highlights: highlights,
+          );
         },
         transitionDuration: const Duration(milliseconds: 200),
       ),
@@ -579,11 +585,13 @@ class _BookDetailContentState extends State<_BookDetailContent>
       onUpload: (
           {Uint8List? imageBytes,
           required String extractedText,
-          int? pageNumber}) async {
+          int? pageNumber,
+          List<HighlightData>? highlights}) async {
         return await _uploadAndSaveMemorablePage(
             imageBytes: imageBytes,
             extractedText: extractedText,
-            pageNumber: pageNumber);
+            pageNumber: pageNumber,
+            highlights: highlights);
       },
       onStateChanged: (imageBytes, text, pageNumber) {
         if (imageBytes != null || text.isNotEmpty || pageNumber != null) {
@@ -606,7 +614,8 @@ class _BookDetailContentState extends State<_BookDetailContent>
   Future<bool> _uploadAndSaveMemorablePage(
       {Uint8List? imageBytes,
       required String extractedText,
-      int? pageNumber}) async {
+      int? pageNumber,
+      List<HighlightData>? highlights}) async {
     final memorableVm = context.read<MemorablePageViewModel>();
     final bookVm = context.read<BookDetailViewModel>();
 
@@ -622,17 +631,21 @@ class _BookDetailContentState extends State<_BookDetailContent>
       }
 
       final userId = Supabase.instance.client.auth.currentUser?.id;
+      final insertData = {
+        'book_id': bookVm.currentBook.id,
+        'user_id': userId,
+        'image_url': publicUrl,
+        'caption': '',
+        'extracted_text': extractedText.isEmpty ? null : extractedText,
+        'page_number': pageNumber,
+        'created_at': DateTime.now().toIso8601String(),
+      };
+      if (highlights != null && highlights.isNotEmpty) {
+        insertData['highlights'] = HighlightData.toJsonList(highlights);
+      }
       final insertResult = await Supabase.instance.client
           .from('book_images')
-          .insert({
-            'book_id': bookVm.currentBook.id,
-            'user_id': userId,
-            'image_url': publicUrl,
-            'caption': '',
-            'extracted_text': extractedText.isEmpty ? null : extractedText,
-            'page_number': pageNumber,
-            'created_at': DateTime.now().toIso8601String(),
-          })
+          .insert(insertData)
           .select('id')
           .single();
 
@@ -726,6 +739,18 @@ class _BookDetailContentState extends State<_BookDetailContent>
     final memorableVm = context.read<MemorablePageViewModel>();
     final bookVm = context.read<BookDetailViewModel>();
 
+    // cachedImages에서 해당 이미지의 highlights 데이터 가져오기
+    List<HighlightData>? initialHighlights;
+    if (memorableVm.cachedImages != null) {
+      final imageData = memorableVm.cachedImages!.firstWhere(
+        (img) => img['id'] == imageId,
+        orElse: () => <String, dynamic>{},
+      );
+      if (imageData.isNotEmpty && imageData['highlights'] != null) {
+        initialHighlights = HighlightData.fromJsonList(imageData['highlights']);
+      }
+    }
+
     showExistingImageModal(
       context: context,
       imageId: imageId,
@@ -734,8 +759,11 @@ class _BookDetailContentState extends State<_BookDetailContent>
       pageNumber: pageNumber,
       totalPages: bookVm.currentBook.totalPages,
       cachedEditedText: memorableVm.editedTexts[imageId],
+      initialHighlights: initialHighlights,
       onFullScreenImage: (id, url) {
-        if (url != null) _showFullScreenImage(id, url);
+        if (url != null) {
+          _showFullScreenImage(id, url, highlights: initialHighlights);
+        }
       },
       onDeleteImage: (id, url, {bool dismissParentOnDelete = false}) async {
         final confirmed = await showDeleteConfirmationSheet(
@@ -779,11 +807,13 @@ class _BookDetailContentState extends State<_BookDetailContent>
       onSave: (
           {required String imageId,
           required String extractedText,
-          required int? pageNumber}) async {
+          required int? pageNumber,
+          required List<HighlightData>? highlights}) async {
         final success = await memorableVm.updateImageRecord(
             imageId: imageId,
             extractedText: extractedText,
-            pageNumber: pageNumber);
+            pageNumber: pageNumber,
+            highlights: highlights);
         return success;
       },
       onTextEdited: (id, text) => memorableVm.setEditedText(id, text),

--- a/app/lib/ui/book_detail/view_model/memorable_page_view_model.dart
+++ b/app/lib/ui/book_detail/view_model/memorable_page_view_model.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:book_golas/domain/models/highlight_data.dart';
 import 'package:book_golas/ui/core/view_model/base_view_model.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -56,22 +57,28 @@ class MemorablePageViewModel extends BaseViewModel {
     final sorted = List<Map<String, dynamic>>.from(_cachedImages!);
     switch (_sortMode) {
       case 'page_asc':
-        sorted.sort((a, b) => (a['page_number'] ?? 0).compareTo(b['page_number'] ?? 0));
+        sorted.sort(
+            (a, b) => (a['page_number'] ?? 0).compareTo(b['page_number'] ?? 0));
         break;
       case 'page_desc':
-        sorted.sort((a, b) => (b['page_number'] ?? 0).compareTo(a['page_number'] ?? 0));
+        sorted.sort(
+            (a, b) => (b['page_number'] ?? 0).compareTo(a['page_number'] ?? 0));
         break;
       case 'date_desc':
         sorted.sort((a, b) {
-          final aDate = DateTime.tryParse(a['created_at'] ?? '') ?? DateTime(1900);
-          final bDate = DateTime.tryParse(b['created_at'] ?? '') ?? DateTime(1900);
+          final aDate =
+              DateTime.tryParse(a['created_at'] ?? '') ?? DateTime(1900);
+          final bDate =
+              DateTime.tryParse(b['created_at'] ?? '') ?? DateTime(1900);
           return bDate.compareTo(aDate);
         });
         break;
       case 'date_asc':
         sorted.sort((a, b) {
-          final aDate = DateTime.tryParse(a['created_at'] ?? '') ?? DateTime(1900);
-          final bDate = DateTime.tryParse(b['created_at'] ?? '') ?? DateTime(1900);
+          final aDate =
+              DateTime.tryParse(a['created_at'] ?? '') ?? DateTime(1900);
+          final bDate =
+              DateTime.tryParse(b['created_at'] ?? '') ?? DateTime(1900);
           return aDate.compareTo(bDate);
         });
         break;
@@ -251,8 +258,7 @@ class MemorablePageViewModel extends BaseViewModel {
     try {
       await Supabase.instance.client
           .from('book_images')
-          .update({'extracted_text': newText})
-          .eq('id', imageId);
+          .update({'extracted_text': newText}).eq('id', imageId);
 
       _editedTexts.remove(imageId);
       await fetchBookImages();
@@ -267,12 +273,22 @@ class MemorablePageViewModel extends BaseViewModel {
     required String imageId,
     required String extractedText,
     int? pageNumber,
+    List<HighlightData>? highlights,
   }) async {
     try {
-      await Supabase.instance.client.from('book_images').update({
+      final updateData = <String, dynamic>{
         'extracted_text': extractedText,
         'page_number': pageNumber,
-      }).eq('id', imageId);
+      };
+
+      if (highlights != null) {
+        updateData['highlights'] = HighlightData.toJsonList(highlights);
+      }
+
+      await Supabase.instance.client
+          .from('book_images')
+          .update(updateData)
+          .eq('id', imageId);
 
       _editedTexts.remove(imageId);
       _cachedImages = null;

--- a/app/lib/ui/book_detail/widgets/draggable_dismiss_image.dart
+++ b/app/lib/ui/book_detail/widgets/draggable_dismiss_image.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
 
 import 'package:book_golas/data/services/image_cache_manager.dart';
+import 'package:book_golas/domain/models/highlight_data.dart';
 
 class DraggableDismissImage extends StatefulWidget {
   final Animation<double> animation;
@@ -107,12 +108,14 @@ class DraggableDismissNetworkImage extends StatefulWidget {
   final Animation<double> animation;
   final String imageUrl;
   final String imageId;
+  final List<HighlightData>? highlights;
 
   const DraggableDismissNetworkImage({
     super.key,
     required this.animation,
     required this.imageUrl,
     required this.imageId,
+    this.highlights,
   });
 
   @override
@@ -124,6 +127,7 @@ class _DraggableDismissNetworkImageState
     extends State<DraggableDismissNetworkImage> {
   double _dragOffset = 0;
   bool _isDragging = false;
+  bool _isImageLoaded = false;
 
   @override
   Widget build(BuildContext context) {
@@ -175,26 +179,62 @@ class _DraggableDismissNetworkImageState
                     maxScale: 4.0,
                     child: Hero(
                       tag: 'book_image_${widget.imageId}',
-                      child: CachedNetworkImage(
-                        imageUrl: widget.imageUrl,
-                        cacheManager: BookImageCacheManager.instance,
-                        fit: BoxFit.contain,
-                        placeholder: (context, url) => Shimmer.fromColors(
-                          baseColor: Colors.grey[800]!,
-                          highlightColor: Colors.grey[700]!,
-                          child: Container(
-                            width: 200,
-                            height: 200,
-                            color: Colors.grey[800],
-                          ),
-                        ),
-                        errorWidget: (context, url, error) => const Center(
-                          child: Icon(
-                            CupertinoIcons.photo,
-                            color: Colors.white,
-                            size: 48,
-                          ),
-                        ),
+                      child: LayoutBuilder(
+                        builder: (context, constraints) {
+                          return Stack(
+                            children: [
+                              CachedNetworkImage(
+                                imageUrl: widget.imageUrl,
+                                cacheManager: BookImageCacheManager.instance,
+                                fit: BoxFit.contain,
+                                imageBuilder: (context, imageProvider) {
+                                  if (!_isImageLoaded) {
+                                    WidgetsBinding.instance
+                                        .addPostFrameCallback((_) {
+                                      if (mounted) {
+                                        setState(() => _isImageLoaded = true);
+                                      }
+                                    });
+                                  }
+                                  return Image(
+                                    image: imageProvider,
+                                    fit: BoxFit.contain,
+                                  );
+                                },
+                                placeholder: (context, url) =>
+                                    Shimmer.fromColors(
+                                  baseColor: Colors.grey[800]!,
+                                  highlightColor: Colors.grey[700]!,
+                                  child: Container(
+                                    width: 200,
+                                    height: 200,
+                                    color: Colors.grey[800],
+                                  ),
+                                ),
+                                errorWidget: (context, url, error) =>
+                                    const Center(
+                                  child: Icon(
+                                    CupertinoIcons.photo,
+                                    color: Colors.white,
+                                    size: 48,
+                                  ),
+                                ),
+                              ),
+                              if (_isImageLoaded &&
+                                  widget.highlights != null &&
+                                  widget.highlights!.isNotEmpty)
+                                Positioned.fill(
+                                  child: IgnorePointer(
+                                    child: CustomPaint(
+                                      painter: _HighlightOverlayPainter(
+                                        highlights: widget.highlights!,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                            ],
+                          );
+                        },
                       ),
                     ),
                   ),
@@ -220,5 +260,33 @@ class _DraggableDismissNetworkImageState
         ),
       ),
     );
+  }
+}
+
+class _HighlightOverlayPainter extends CustomPainter {
+  final List<HighlightData> highlights;
+
+  _HighlightOverlayPainter({required this.highlights});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    for (final highlight in highlights) {
+      if (highlight.points.isEmpty) continue;
+
+      final paint = Paint()
+        ..color = highlight.colorValue
+        ..strokeWidth = highlight.getScaledStrokeWidth(size)
+        ..strokeCap = StrokeCap.round
+        ..strokeJoin = StrokeJoin.round
+        ..style = PaintingStyle.stroke;
+
+      final path = highlight.toPath(size);
+      canvas.drawPath(path, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _HighlightOverlayPainter oldDelegate) {
+    return oldDelegate.highlights != highlights;
   }
 }

--- a/app/lib/ui/book_detail/widgets/highlight/highlight_overlay.dart
+++ b/app/lib/ui/book_detail/widgets/highlight/highlight_overlay.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:book_golas/domain/models/highlight_data.dart';
+import 'highlight_painter.dart';
+
+class HighlightOverlay extends StatefulWidget {
+  final Size imageSize;
+  final List<HighlightData> highlights;
+  final String selectedColor;
+  final double selectedOpacity;
+  final double strokeWidth;
+  final bool isEraserMode;
+  final void Function(HighlightData highlight) onHighlightAdded;
+  final void Function(String highlightId) onHighlightRemoved;
+
+  const HighlightOverlay({
+    super.key,
+    required this.imageSize,
+    required this.highlights,
+    required this.selectedColor,
+    this.selectedOpacity = 0.5,
+    this.strokeWidth = 20.0,
+    required this.isEraserMode,
+    required this.onHighlightAdded,
+    required this.onHighlightRemoved,
+  });
+
+  @override
+  State<HighlightOverlay> createState() => _HighlightOverlayState();
+}
+
+class _HighlightOverlayState extends State<HighlightOverlay> {
+  List<Offset> _currentPoints = [];
+  int? _activePointerId;
+  int _pointerCount = 0;
+
+  Color get _currentColor {
+    return HighlightColor.toColor(widget.selectedColor)
+        .withValues(alpha: widget.selectedOpacity);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerDown: _onPointerDown,
+      onPointerMove: _onPointerMove,
+      onPointerUp: _onPointerUp,
+      onPointerCancel: _onPointerCancel,
+      child: GestureDetector(
+        onTapUp: widget.isEraserMode ? _onTapForEraser : null,
+        child: CustomPaint(
+          painter: HighlightPainter(
+            highlights: widget.highlights,
+            imageSize: widget.imageSize,
+            currentDrawingPoints: widget.isEraserMode ? null : _currentPoints,
+            currentColor: _currentColor,
+            currentStrokeWidth: widget.strokeWidth,
+          ),
+          size: widget.imageSize,
+        ),
+      ),
+    );
+  }
+
+  void _onPointerDown(PointerDownEvent event) {
+    _pointerCount++;
+
+    if (_pointerCount > 1) {
+      _cancelDrawing();
+      return;
+    }
+
+    if (widget.isEraserMode) return;
+
+    _activePointerId = event.pointer;
+    setState(() {
+      _currentPoints = [event.localPosition];
+    });
+  }
+
+  void _onPointerMove(PointerMoveEvent event) {
+    if (_pointerCount > 1) return;
+    if (widget.isEraserMode) return;
+    if (_activePointerId != event.pointer) return;
+
+    setState(() {
+      _currentPoints.add(event.localPosition);
+    });
+  }
+
+  void _onPointerUp(PointerUpEvent event) {
+    _pointerCount--;
+
+    if (event.pointer != _activePointerId) return;
+
+    if (!widget.isEraserMode && _currentPoints.length >= 2) {
+      HapticFeedback.lightImpact();
+
+      final points = _currentPoints
+          .map((offset) => HighlightPoint.fromOffset(offset, widget.imageSize))
+          .toList();
+
+      final normalizedStrokeWidth = HighlightData.normalizeStrokeWidth(
+        widget.strokeWidth,
+        widget.imageSize,
+      );
+
+      final highlight = HighlightData(
+        points: points,
+        color: widget.selectedColor,
+        opacity: widget.selectedOpacity,
+        strokeWidth: normalizedStrokeWidth,
+      );
+
+      widget.onHighlightAdded(highlight);
+    }
+
+    _resetDrawing();
+  }
+
+  void _onPointerCancel(PointerCancelEvent event) {
+    _pointerCount--;
+    if (event.pointer == _activePointerId) {
+      _resetDrawing();
+    }
+  }
+
+  void _cancelDrawing() {
+    setState(() {
+      _currentPoints = [];
+    });
+  }
+
+  void _resetDrawing() {
+    setState(() {
+      _currentPoints = [];
+      _activePointerId = null;
+    });
+  }
+
+  void _onTapForEraser(TapUpDetails details) {
+    final tapPoint = details.localPosition;
+
+    for (final highlight in widget.highlights.reversed) {
+      final path = highlight.toPath(widget.imageSize);
+      final scaledStrokeWidth =
+          highlight.getScaledStrokeWidth(widget.imageSize);
+
+      if (_isPointNearPath(tapPoint, path, scaledStrokeWidth + 20)) {
+        HapticFeedback.mediumImpact();
+        widget.onHighlightRemoved(highlight.id);
+        return;
+      }
+    }
+  }
+
+  bool _isPointNearPath(Offset point, Path path, double tolerance) {
+    final metrics = path.computeMetrics();
+    for (final metric in metrics) {
+      for (double t = 0; t <= metric.length; t += 5) {
+        final tangent = metric.getTangentForOffset(t);
+        if (tangent != null) {
+          final distance = (tangent.position - point).distance;
+          if (distance <= tolerance) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/app/lib/ui/book_detail/widgets/highlight/highlight_painter.dart
+++ b/app/lib/ui/book_detail/widgets/highlight/highlight_painter.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import 'package:book_golas/domain/models/highlight_data.dart';
+
+class HighlightPainter extends CustomPainter {
+  final List<HighlightData> highlights;
+  final List<Offset>? currentDrawingPoints;
+  final Color? currentColor;
+  final double? currentStrokeWidth;
+
+  HighlightPainter({
+    required this.highlights,
+    required Size imageSize,
+    this.currentDrawingPoints,
+    this.currentColor,
+    this.currentStrokeWidth,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    for (final highlight in highlights) {
+      if (highlight.points.isEmpty) continue;
+
+      final paint = Paint()
+        ..color = highlight.colorValue
+        ..strokeWidth = highlight.getScaledStrokeWidth(size)
+        ..strokeCap = StrokeCap.round
+        ..strokeJoin = StrokeJoin.round
+        ..style = PaintingStyle.stroke;
+
+      final path = highlight.toPath(size);
+      canvas.drawPath(path, paint);
+    }
+
+    if (currentDrawingPoints != null &&
+        currentDrawingPoints!.isNotEmpty &&
+        currentColor != null) {
+      final paint = Paint()
+        ..color = currentColor!
+        ..strokeWidth = currentStrokeWidth ?? 20.0
+        ..strokeCap = StrokeCap.round
+        ..strokeJoin = StrokeJoin.round
+        ..style = PaintingStyle.stroke;
+
+      final path = Path();
+      path.moveTo(
+          currentDrawingPoints!.first.dx, currentDrawingPoints!.first.dy);
+
+      for (int i = 1; i < currentDrawingPoints!.length; i++) {
+        path.lineTo(currentDrawingPoints![i].dx, currentDrawingPoints![i].dy);
+      }
+
+      canvas.drawPath(path, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant HighlightPainter oldDelegate) {
+    return highlights != oldDelegate.highlights ||
+        currentDrawingPoints != oldDelegate.currentDrawingPoints ||
+        currentColor != oldDelegate.currentColor;
+  }
+}

--- a/app/lib/ui/book_detail/widgets/highlight/highlight_toolbar.dart
+++ b/app/lib/ui/book_detail/widgets/highlight/highlight_toolbar.dart
@@ -1,0 +1,339 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:book_golas/domain/models/highlight_data.dart';
+
+class HighlightToolbar extends StatefulWidget {
+  final String selectedColor;
+  final double selectedOpacity;
+  final double selectedStrokeWidth;
+  final bool isEraserMode;
+  final VoidCallback onUndoTap;
+  final bool canUndo;
+  final void Function(String color) onColorSelected;
+  final void Function(double opacity) onOpacityChanged;
+  final void Function(double strokeWidth) onStrokeWidthChanged;
+  final void Function(bool isEraser) onEraserModeChanged;
+
+  const HighlightToolbar({
+    super.key,
+    required this.selectedColor,
+    this.selectedOpacity = 0.5,
+    this.selectedStrokeWidth = 20.0,
+    required this.isEraserMode,
+    required this.onUndoTap,
+    required this.canUndo,
+    required this.onColorSelected,
+    required this.onOpacityChanged,
+    required this.onStrokeWidthChanged,
+    required this.onEraserModeChanged,
+  });
+
+  @override
+  State<HighlightToolbar> createState() => _HighlightToolbarState();
+}
+
+class _HighlightToolbarState extends State<HighlightToolbar> {
+  bool _showSettings = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (_showSettings) ...[
+          _buildSettingsPanel(isDark),
+          const SizedBox(height: 8),
+        ],
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          decoration: BoxDecoration(
+            color: isDark ? const Color(0xFF2A2A2A) : Colors.white,
+            borderRadius: BorderRadius.circular(16),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: isDark ? 0.3 : 0.1),
+                blurRadius: 12,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          child: Row(
+            children: [
+              _buildUndoButton(isDark),
+              const SizedBox(width: 8),
+              _buildDivider(isDark),
+              const SizedBox(width: 8),
+              Expanded(
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: HighlightColor.colors
+                        .map((color) => _buildColorButton(color, isDark))
+                        .toList(),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              _buildDivider(isDark),
+              const SizedBox(width: 8),
+              _buildSettingsButton(isDark),
+              const SizedBox(width: 8),
+              _buildEraserButton(isDark),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSettingsPanel(bool isDark) {
+    final color = HighlightColor.toColor(widget.selectedColor);
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: isDark ? const Color(0xFF2A2A2A) : Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: isDark ? 0.4 : 0.15),
+            blurRadius: 12,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Icon(
+                CupertinoIcons.sun_min,
+                size: 14,
+                color: isDark ? Colors.grey[500] : Colors.grey[400],
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '투명도',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: isDark ? Colors.grey[400] : Colors.grey[600],
+                ),
+              ),
+              const Spacer(),
+              Text(
+                '${(widget.selectedOpacity * 100).toInt()}%',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: isDark ? Colors.white : Colors.black,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          SliderTheme(
+            data: SliderThemeData(
+              activeTrackColor: color.withValues(alpha: widget.selectedOpacity),
+              inactiveTrackColor: isDark ? Colors.grey[700] : Colors.grey[300],
+              thumbColor: color,
+              overlayColor: color.withValues(alpha: 0.2),
+              trackHeight: 4,
+              thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 8),
+            ),
+            child: Slider(
+              value: widget.selectedOpacity,
+              min: 0.1,
+              max: 0.8,
+              onChanged: (value) {
+                HapticFeedback.selectionClick();
+                widget.onOpacityChanged(value);
+              },
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Container(
+                width: 6,
+                height: 6,
+                decoration: BoxDecoration(
+                  color: color,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '굵기',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: isDark ? Colors.grey[400] : Colors.grey[600],
+                ),
+              ),
+              const Spacer(),
+              Text(
+                '${widget.selectedStrokeWidth.toInt()}px',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: isDark ? Colors.white : Colors.black,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          SliderTheme(
+            data: SliderThemeData(
+              activeTrackColor: color.withValues(alpha: widget.selectedOpacity),
+              inactiveTrackColor: isDark ? Colors.grey[700] : Colors.grey[300],
+              thumbColor: color,
+              overlayColor: color.withValues(alpha: 0.2),
+              trackHeight: 4,
+              thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 8),
+            ),
+            child: Slider(
+              value: widget.selectedStrokeWidth,
+              min: 4.0,
+              max: 40.0,
+              onChanged: (value) {
+                HapticFeedback.selectionClick();
+                widget.onStrokeWidthChanged(value);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSettingsButton(bool isDark) {
+    return GestureDetector(
+      onTap: () {
+        HapticFeedback.selectionClick();
+        setState(() {
+          _showSettings = !_showSettings;
+        });
+      },
+      child: Container(
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          color: _showSettings
+              ? const Color(0xFF5B7FFF)
+              : (isDark ? Colors.grey[800] : Colors.grey[100]),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Icon(
+          CupertinoIcons.slider_horizontal_3,
+          size: 18,
+          color: _showSettings
+              ? Colors.white
+              : (isDark ? Colors.white : Colors.black),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildUndoButton(bool isDark) {
+    return GestureDetector(
+      onTap: widget.canUndo
+          ? () {
+              HapticFeedback.lightImpact();
+              widget.onUndoTap();
+            }
+          : null,
+      child: Container(
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          color: isDark ? Colors.grey[800] : Colors.grey[100],
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Icon(
+          CupertinoIcons.arrow_uturn_left,
+          size: 18,
+          color: widget.canUndo
+              ? (isDark ? Colors.white : Colors.black)
+              : (isDark ? Colors.grey[600] : Colors.grey[400]),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDivider(bool isDark) {
+    return Container(
+      width: 1,
+      height: 24,
+      color: isDark ? Colors.grey[700] : Colors.grey[300],
+    );
+  }
+
+  Widget _buildColorButton(String colorHex, bool isDark) {
+    final isSelected = widget.selectedColor == colorHex && !widget.isEraserMode;
+    final color = HighlightColor.toColor(colorHex);
+
+    return GestureDetector(
+      onTap: () {
+        HapticFeedback.selectionClick();
+        widget.onEraserModeChanged(false);
+        widget.onColorSelected(colorHex);
+      },
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 3),
+        width: 28,
+        height: 28,
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.7),
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: isSelected ? color : Colors.transparent,
+            width: 3,
+          ),
+          boxShadow: isSelected
+              ? [
+                  BoxShadow(
+                    color: color.withValues(alpha: 0.4),
+                    blurRadius: 6,
+                    spreadRadius: 1,
+                  ),
+                ]
+              : null,
+        ),
+        child: isSelected
+            ? const Icon(Icons.check, size: 16, color: Colors.white)
+            : null,
+      ),
+    );
+  }
+
+  Widget _buildEraserButton(bool isDark) {
+    return GestureDetector(
+      onTap: () {
+        HapticFeedback.selectionClick();
+        widget.onEraserModeChanged(!widget.isEraserMode);
+      },
+      child: Container(
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          color: widget.isEraserMode
+              ? const Color(0xFF5B7FFF)
+              : (isDark ? Colors.grey[800] : Colors.grey[100]),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Icon(
+          CupertinoIcons.clear_circled,
+          size: 20,
+          color: widget.isEraserMode
+              ? Colors.white
+              : (isDark ? Colors.white : Colors.black),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ui/book_detail/widgets/modals/add_memorable_page_modal.dart
+++ b/app/lib/ui/book_detail/widgets/modals/add_memorable_page_modal.dart
@@ -2,11 +2,15 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'package:book_golas/data/services/highlight_settings_service.dart';
+import 'package:book_golas/domain/models/highlight_data.dart';
 import 'package:book_golas/ui/core/widgets/custom_snackbar.dart';
 import 'package:book_golas/ui/core/widgets/keyboard_accessory_bar.dart';
 import 'package:book_golas/ui/core/widgets/extracted_text_modal.dart';
 import 'package:book_golas/ui/core/widgets/full_text_view_modal.dart';
 import 'package:book_golas/ui/core/utils/text_history_manager.dart';
+import 'package:book_golas/ui/book_detail/widgets/highlight/highlight_painter.dart';
+import 'package:book_golas/ui/core/widgets/highlight_edit_view.dart';
 
 class AddMemorablePageModal extends StatefulWidget {
   final Uint8List? initialImageBytes;
@@ -25,6 +29,7 @@ class AddMemorablePageModal extends StatefulWidget {
     Uint8List? imageBytes,
     required String extractedText,
     int? pageNumber,
+    List<HighlightData>? highlights,
   }) onUpload;
   final void Function(Uint8List? imageBytes, String text, int? pageNumber)?
       onStateChanged;
@@ -62,6 +67,15 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
   bool _uploadSuccess = false;
   late TextHistoryManager _historyManager;
 
+  bool _isHighlightMode = false;
+  List<HighlightData> _highlights = [];
+  String _selectedHighlightColor = HighlightColor.yellow;
+  double _selectedHighlightOpacity = HighlightSettingsService.defaultOpacity;
+  double _selectedHighlightStrokeWidth =
+      HighlightSettingsService.defaultStrokeWidth;
+  bool _isEraserMode = false;
+  final List<List<HighlightData>> _highlightHistory = [];
+
   @override
   void initState() {
     super.initState();
@@ -82,6 +96,20 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
 
     _pageFocusNode.addListener(_onFocusChange);
     _textFocusNode.addListener(_onFocusChange);
+    _loadHighlightSettings();
+  }
+
+  Future<void> _loadHighlightSettings() async {
+    final settings = await HighlightSettingsService.loadAll();
+    if (mounted) {
+      setState(() {
+        _selectedHighlightColor =
+            HighlightColor.colors.elementAtOrNull(settings.colorIndex) ??
+                HighlightColor.yellow;
+        _selectedHighlightOpacity = settings.opacity;
+        _selectedHighlightStrokeWidth = settings.strokeWidth;
+      });
+    }
   }
 
   void _onFocusChange() {
@@ -118,6 +146,41 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
 
   bool get _canUndo => _historyManager.canUndo;
   bool get _canRedo => _historyManager.canRedo;
+
+  void _enterHighlightMode() {
+    _highlightHistory.clear();
+    _highlightHistory.add(List.from(_highlights));
+    setState(() {
+      _isHighlightMode = true;
+      _isEraserMode = false;
+    });
+  }
+
+  void _exitHighlightMode() {
+    setState(() {
+      _isHighlightMode = false;
+      _isEraserMode = false;
+    });
+    _highlightHistory.clear();
+  }
+
+  void _saveHighlightState() {
+    _highlightHistory.add(List.from(_highlights));
+    if (_highlightHistory.length > 50) {
+      _highlightHistory.removeAt(0);
+    }
+  }
+
+  void _undoHighlight() {
+    if (_highlightHistory.length > 1) {
+      _highlightHistory.removeLast();
+      setState(() {
+        _highlights = List.from(_highlightHistory.last);
+      });
+    }
+  }
+
+  bool get _canUndoHighlight => _highlightHistory.length > 1;
 
   void _handleClose() {
     Navigator.pop(context);
@@ -211,6 +274,7 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
       imageBytes: _fullImageBytes,
       extractedText: _textController.text,
       pageNumber: int.tryParse(_pageController.text),
+      highlights: _highlights.isNotEmpty ? _highlights : null,
     );
     if (success && mounted) {
       _uploadSuccess = true;
@@ -288,7 +352,8 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
                 ),
                 if (!isKeyboardOpen &&
                     !_isUploading &&
-                    !_textFocusNode.hasFocus)
+                    !_textFocusNode.hasFocus &&
+                    !_isHighlightMode)
                   _buildUploadButton(isDark),
                 if (isKeyboardOpen &&
                     (_textFocusNode.hasFocus || _pageFocusNode.hasFocus) &&
@@ -420,6 +485,8 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
       _pageController.clear();
       _pageValidationError = null;
       _hasShownPageError = false;
+      _highlights.clear();
+      _highlightHistory.clear();
     });
     _notifyStateChanged();
   }
@@ -473,8 +540,11 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
   Widget _buildContent(bool isDark) {
     final isTextFocused = _textFocusNode.hasFocus;
 
+    if (_isHighlightMode && _fullImageBytes != null) {
+      return _buildHighlightModeView(isDark);
+    }
+
     if (isTextFocused) {
-      // 풀 모달 모드: 텍스트 필드만 표시
       return Padding(
         padding: const EdgeInsets.symmetric(horizontal: 20),
         child: Column(
@@ -489,7 +559,6 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
       );
     }
 
-    // 일반 모드: 전체 스크롤 가능
     return SingleChildScrollView(
       controller: _scrollController,
       padding: const EdgeInsets.symmetric(horizontal: 20),
@@ -504,6 +573,62 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
           const SizedBox(height: 100),
         ],
       ),
+    );
+  }
+
+  Widget _buildHighlightModeView(bool isDark) {
+    return HighlightEditView(
+      imageWidget: Image.memory(
+        _fullImageBytes!,
+        fit: BoxFit.contain,
+      ),
+      highlights: _highlights,
+      selectedColor: _selectedHighlightColor,
+      selectedOpacity: _selectedHighlightOpacity,
+      selectedStrokeWidth: _selectedHighlightStrokeWidth,
+      isEraserMode: _isEraserMode,
+      canUndo: _canUndoHighlight,
+      onComplete: _exitHighlightMode,
+      onUndoTap: _undoHighlight,
+      onHighlightAdded: (highlight) {
+        _saveHighlightState();
+        setState(() {
+          _highlights.add(highlight);
+        });
+      },
+      onHighlightRemoved: (highlightId) {
+        _saveHighlightState();
+        setState(() {
+          _highlights.removeWhere((h) => h.id == highlightId);
+        });
+      },
+      onColorSelected: (color) {
+        final colorIndex = HighlightColor.colors.indexOf(color);
+        if (colorIndex >= 0) {
+          HighlightSettingsService.setColorIndex(colorIndex);
+        }
+        setState(() {
+          _selectedHighlightColor = color;
+          _isEraserMode = false;
+        });
+      },
+      onOpacityChanged: (opacity) {
+        HighlightSettingsService.setOpacity(opacity);
+        setState(() {
+          _selectedHighlightOpacity = opacity;
+        });
+      },
+      onStrokeWidthChanged: (strokeWidth) {
+        HighlightSettingsService.setStrokeWidth(strokeWidth);
+        setState(() {
+          _selectedHighlightStrokeWidth = strokeWidth;
+        });
+      },
+      onEraserModeChanged: (isEraser) {
+        setState(() {
+          _isEraserMode = isEraser;
+        });
+      },
     );
   }
 
@@ -532,11 +657,66 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
         children: [
           ClipRRect(
             borderRadius: BorderRadius.circular(14),
-            child: Image.memory(
-              _fullImageBytes!,
-              width: double.infinity,
-              height: double.infinity,
-              fit: BoxFit.cover,
+            child: Stack(
+              children: [
+                Image.memory(
+                  _fullImageBytes!,
+                  width: double.infinity,
+                  height: double.infinity,
+                  fit: BoxFit.cover,
+                ),
+                if (_highlights.isNotEmpty)
+                  Positioned.fill(
+                    child: LayoutBuilder(
+                      builder: (context, constraints) {
+                        return CustomPaint(
+                          painter: HighlightPainter(
+                            highlights: _highlights,
+                            imageSize: Size(
+                              constraints.maxWidth,
+                              constraints.maxHeight,
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Positioned(
+            top: 8,
+            right: 8,
+            child: GestureDetector(
+              onTap: _enterHighlightMode,
+              behavior: HitTestBehavior.opaque,
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                decoration: BoxDecoration(
+                  color: _highlights.isNotEmpty
+                      ? const Color(0xFF5B7FFF).withValues(alpha: 0.9)
+                      : Colors.black54,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(
+                      CupertinoIcons.pencil_outline,
+                      size: 14,
+                      color: Colors.white,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      _highlights.isNotEmpty
+                          ? '하이라이트 (${_highlights.length})'
+                          : '하이라이트',
+                      style: const TextStyle(fontSize: 12, color: Colors.white),
+                    ),
+                  ],
+                ),
+              ),
             ),
           ),
           Positioned(
@@ -584,6 +764,7 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
                     if (!mounted) return;
                     setState(() {
                       _fullImageBytes = imageBytes;
+                      _highlights.clear();
                       if (ocrText.isNotEmpty) {
                         _textController.text = ocrText;
                       }
@@ -919,6 +1100,7 @@ class _AddMemorablePageModalState extends State<AddMemorablePageModal> {
             _textFocusNode.requestFocus();
           },
           child: Container(
+            width: double.infinity,
             constraints: const BoxConstraints(minHeight: 150, maxHeight: 180),
             decoration: BoxDecoration(
               color: isDark ? Colors.grey[900] : Colors.grey[100],
@@ -1098,6 +1280,7 @@ Future<Map<String, dynamic>?> showAddMemorablePageModal({
     Uint8List? imageBytes,
     required String extractedText,
     int? pageNumber,
+    List<HighlightData>? highlights,
   }) onUpload,
   void Function(Uint8List? imageBytes, String text, int? pageNumber)?
       onStateChanged,

--- a/app/lib/ui/core/widgets/full_text_view_modal.dart
+++ b/app/lib/ui/core/widgets/full_text_view_modal.dart
@@ -112,9 +112,11 @@ class _FullTextViewModalState extends State<FullTextViewModal> {
   @override
   Widget build(BuildContext context) {
     final screenHeight = MediaQuery.of(context).size.height;
+    final topPadding = MediaQuery.of(context).padding.top;
     final keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
     final isKeyboardOpen = keyboardHeight > 0;
     final isTextFocused = _focusNode.hasFocus;
+    final availableHeight = screenHeight - topPadding;
 
     return GestureDetector(
       onTap: () {
@@ -124,14 +126,15 @@ class _FullTextViewModalState extends State<FullTextViewModal> {
       },
       child: Padding(
         padding: EdgeInsets.only(
-          top: MediaQuery.of(context).padding.top,
+          top: topPadding,
           bottom: keyboardHeight,
         ),
         child: Stack(
           children: [
             Container(
-              height: screenHeight * 0.85,
-              padding: const EdgeInsets.all(20),
+              width: double.infinity,
+              height: availableHeight,
+              padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
               decoration: BoxDecoration(
                 color: widget.isDark ? const Color(0xFF1E1E1E) : Colors.white,
                 borderRadius:

--- a/app/lib/ui/core/widgets/highlight_edit_view.dart
+++ b/app/lib/ui/core/widgets/highlight_edit_view.dart
@@ -1,0 +1,470 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:book_golas/domain/models/highlight_data.dart';
+import 'package:book_golas/ui/book_detail/widgets/highlight/highlight_overlay.dart';
+
+class HighlightEditView extends StatefulWidget {
+  final Widget imageWidget;
+  final List<HighlightData> highlights;
+  final String selectedColor;
+  final double selectedOpacity;
+  final double selectedStrokeWidth;
+  final bool isEraserMode;
+  final bool canUndo;
+  final VoidCallback onComplete;
+  final VoidCallback onUndoTap;
+  final void Function(HighlightData highlight) onHighlightAdded;
+  final void Function(String highlightId) onHighlightRemoved;
+  final void Function(String color) onColorSelected;
+  final void Function(double opacity) onOpacityChanged;
+  final void Function(double strokeWidth) onStrokeWidthChanged;
+  final void Function(bool isEraser) onEraserModeChanged;
+
+  const HighlightEditView({
+    super.key,
+    required this.imageWidget,
+    required this.highlights,
+    required this.selectedColor,
+    required this.selectedOpacity,
+    required this.selectedStrokeWidth,
+    required this.isEraserMode,
+    required this.canUndo,
+    required this.onComplete,
+    required this.onUndoTap,
+    required this.onHighlightAdded,
+    required this.onHighlightRemoved,
+    required this.onColorSelected,
+    required this.onOpacityChanged,
+    required this.onStrokeWidthChanged,
+    required this.onEraserModeChanged,
+  });
+
+  @override
+  State<HighlightEditView> createState() => _HighlightEditViewState();
+}
+
+class _HighlightEditViewState extends State<HighlightEditView> {
+  bool _showSettings = false;
+
+  void _toggleSettings() {
+    HapticFeedback.selectionClick();
+    setState(() {
+      _showSettings = !_showSettings;
+    });
+  }
+
+  void _closeSettings() {
+    if (_showSettings) {
+      setState(() {
+        _showSettings = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return Column(
+      children: [
+        _buildHeader(isDark),
+        Expanded(
+          child: Stack(
+            children: [
+              _buildImageArea(isDark),
+              if (_showSettings) _buildSettingsOverlay(isDark),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: _buildToolbar(isDark),
+        ),
+        SizedBox(height: MediaQuery.of(context).padding.bottom + 16),
+      ],
+    );
+  }
+
+  Widget _buildHeader(bool isDark) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            '하이라이트 편집',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: isDark ? Colors.white : Colors.black,
+            ),
+          ),
+          GestureDetector(
+            onTap: widget.onComplete,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              decoration: BoxDecoration(
+                color: const Color(0xFF5B7FFF),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: const Text(
+                '완료',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildImageArea(bool isDark) {
+    return GestureDetector(
+      onTap: _closeSettings,
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 16),
+        decoration: BoxDecoration(
+          color: isDark ? Colors.grey[900] : Colors.grey[100],
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(12),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              return InteractiveViewer(
+                minScale: 1.0,
+                maxScale: 3.0,
+                panEnabled: false,
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    widget.imageWidget,
+                    Positioned.fill(
+                      child: HighlightOverlay(
+                        imageSize: Size(
+                          constraints.maxWidth,
+                          constraints.maxHeight,
+                        ),
+                        highlights: widget.highlights,
+                        selectedColor: widget.selectedColor,
+                        selectedOpacity: widget.selectedOpacity,
+                        strokeWidth: widget.selectedStrokeWidth,
+                        isEraserMode: widget.isEraserMode,
+                        onHighlightAdded: widget.onHighlightAdded,
+                        onHighlightRemoved: widget.onHighlightRemoved,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSettingsOverlay(bool isDark) {
+    final color = HighlightColor.toColor(widget.selectedColor);
+
+    return Positioned(
+      left: 32,
+      right: 32,
+      bottom: 16,
+      child: GestureDetector(
+        onTap: () {},
+        child: Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: isDark ? const Color(0xFF2A2A2A) : Colors.white,
+            borderRadius: BorderRadius.circular(16),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: isDark ? 0.5 : 0.2),
+                blurRadius: 20,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  Icon(
+                    CupertinoIcons.sun_min,
+                    size: 16,
+                    color: isDark ? Colors.grey[500] : Colors.grey[400],
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    '투명도',
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: isDark ? Colors.grey[400] : Colors.grey[600],
+                    ),
+                  ),
+                  const Spacer(),
+                  Text(
+                    '${(widget.selectedOpacity * 100).toInt()}%',
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: isDark ? Colors.white : Colors.black,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              SliderTheme(
+                data: SliderThemeData(
+                  activeTrackColor:
+                      color.withValues(alpha: widget.selectedOpacity),
+                  inactiveTrackColor:
+                      isDark ? Colors.grey[700] : Colors.grey[300],
+                  thumbColor: color,
+                  overlayColor: color.withValues(alpha: 0.2),
+                  trackHeight: 4,
+                  thumbShape:
+                      const RoundSliderThumbShape(enabledThumbRadius: 10),
+                ),
+                child: Slider(
+                  value: widget.selectedOpacity,
+                  min: 0.1,
+                  max: 0.8,
+                  onChanged: (value) {
+                    HapticFeedback.selectionClick();
+                    widget.onOpacityChanged(value);
+                  },
+                ),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Container(
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: color,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    '굵기',
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: isDark ? Colors.grey[400] : Colors.grey[600],
+                    ),
+                  ),
+                  const Spacer(),
+                  Text(
+                    '${widget.selectedStrokeWidth.toInt()}px',
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: isDark ? Colors.white : Colors.black,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              SliderTheme(
+                data: SliderThemeData(
+                  activeTrackColor:
+                      color.withValues(alpha: widget.selectedOpacity),
+                  inactiveTrackColor:
+                      isDark ? Colors.grey[700] : Colors.grey[300],
+                  thumbColor: color,
+                  overlayColor: color.withValues(alpha: 0.2),
+                  trackHeight: 4,
+                  thumbShape:
+                      const RoundSliderThumbShape(enabledThumbRadius: 10),
+                ),
+                child: Slider(
+                  value: widget.selectedStrokeWidth,
+                  min: 4.0,
+                  max: 40.0,
+                  onChanged: (value) {
+                    HapticFeedback.selectionClick();
+                    widget.onStrokeWidthChanged(value);
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildToolbar(bool isDark) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: isDark ? const Color(0xFF2A2A2A) : Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: isDark ? 0.3 : 0.1),
+            blurRadius: 12,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          _buildUndoButton(isDark),
+          const SizedBox(width: 8),
+          _buildDivider(isDark),
+          const SizedBox(width: 8),
+          Expanded(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: HighlightColor.colors
+                    .map((color) => _buildColorButton(color, isDark))
+                    .toList(),
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          _buildDivider(isDark),
+          const SizedBox(width: 8),
+          _buildSettingsButton(isDark),
+          const SizedBox(width: 8),
+          _buildEraserButton(isDark),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildUndoButton(bool isDark) {
+    return GestureDetector(
+      onTap: widget.canUndo
+          ? () {
+              HapticFeedback.lightImpact();
+              widget.onUndoTap();
+            }
+          : null,
+      child: Container(
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          color: isDark ? Colors.grey[800] : Colors.grey[100],
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Icon(
+          CupertinoIcons.arrow_uturn_left,
+          size: 18,
+          color: widget.canUndo
+              ? (isDark ? Colors.white : Colors.black)
+              : (isDark ? Colors.grey[600] : Colors.grey[400]),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDivider(bool isDark) {
+    return Container(
+      width: 1,
+      height: 24,
+      color: isDark ? Colors.grey[700] : Colors.grey[300],
+    );
+  }
+
+  Widget _buildColorButton(String colorHex, bool isDark) {
+    final isSelected = widget.selectedColor == colorHex && !widget.isEraserMode;
+    final color = HighlightColor.toColor(colorHex);
+
+    return GestureDetector(
+      onTap: () {
+        HapticFeedback.selectionClick();
+        widget.onEraserModeChanged(false);
+        widget.onColorSelected(colorHex);
+      },
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 3),
+        width: 28,
+        height: 28,
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.7),
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: isSelected ? color : Colors.transparent,
+            width: 3,
+          ),
+          boxShadow: isSelected
+              ? [
+                  BoxShadow(
+                    color: color.withValues(alpha: 0.4),
+                    blurRadius: 6,
+                    spreadRadius: 1,
+                  ),
+                ]
+              : null,
+        ),
+        child: isSelected
+            ? const Icon(Icons.check, size: 16, color: Colors.white)
+            : null,
+      ),
+    );
+  }
+
+  Widget _buildSettingsButton(bool isDark) {
+    return GestureDetector(
+      onTap: _toggleSettings,
+      child: Container(
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          color: _showSettings
+              ? const Color(0xFF5B7FFF)
+              : (isDark ? Colors.grey[800] : Colors.grey[100]),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Icon(
+          CupertinoIcons.slider_horizontal_3,
+          size: 18,
+          color: _showSettings
+              ? Colors.white
+              : (isDark ? Colors.white : Colors.black),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEraserButton(bool isDark) {
+    return GestureDetector(
+      onTap: () {
+        HapticFeedback.selectionClick();
+        widget.onEraserModeChanged(!widget.isEraserMode);
+      },
+      child: Container(
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          color: widget.isEraserMode
+              ? const Color(0xFF5B7FFF)
+              : (isDark ? Colors.grey[800] : Colors.grey[100]),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Icon(
+          Icons.highlight_off,
+          size: 20,
+          color: widget.isEraserMode
+              ? Colors.white
+              : (isDark ? Colors.white : Colors.black),
+        ),
+      ),
+    );
+  }
+}

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1310,7 +1310,7 @@ packages:
     source: hosted
     version: "3.1.5"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   path: ^1.8.3
   mobile_scanner: ^7.1.4
   table_calendar: ^3.1.3
+  uuid: ^4.5.1
 
   # Firebase & FCM
   firebase_core: ^3.6.0

--- a/supabase/migrations/20260123_add_highlights_to_book_images.sql
+++ b/supabase/migrations/20260123_add_highlights_to_book_images.sql
@@ -1,0 +1,4 @@
+ALTER TABLE public.book_images
+ADD COLUMN IF NOT EXISTS highlights jsonb DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN public.book_images.highlights IS 'Highlight rectangles: [{id, rect: {x, y, width, height}, color, opacity}]. Normalized 0-1 coords.';


### PR DESCRIPTION
## 📌 Summary

2026-01-23 일일 작업 통합 - 하이라이트 기능 구현

## 📋 Changes

### 하이라이트 기능 (BYU-278)
- `./supabase/migrations/20260123_add_highlights_to_book_images.sql`: DB 마이그레이션 (highlights JSONB 컬럼)
- `./app/lib/domain/models/highlight_data.dart`: 하이라이트 데이터 모델
- `./app/lib/ui/book_detail/widgets/highlight/highlight_overlay.dart`: 하이라이트 드로잉 오버레이
- `./app/lib/ui/book_detail/widgets/highlight/highlight_painter.dart`: 하이라이트 렌더링
- `./app/lib/ui/book_detail/widgets/highlight/highlight_toolbar.dart`: 하이라이트 툴바
- `./app/lib/ui/core/widgets/highlight_edit_view.dart`: Core UI 컴포넌트로 추출
- `./app/lib/data/services/highlight_settings_service.dart`: 설정 저장 (shared_preferences)

### 모달 수정
- `./app/lib/ui/book_detail/widgets/modals/add_memorable_page_modal.dart`: 하이라이트 모드 통합
- `./app/lib/ui/book_detail/widgets/modals/existing_image_modal.dart`: 하이라이트 모드 통합

### 기타
- `./app/lib/ui/book_detail/widgets/draggable_dismiss_image.dart`: 전체화면에서 하이라이트 표시
- `./app/lib/ui/core/widgets/full_text_view_modal.dart`: 높이 확장

## 🧠 Context & Background

- 사용자가 책 이미지에 자유롭게 하이라이트를 그릴 수 있는 기능 추가
- 컬러, 굵기, 투명도 설정 가능하며 다음 사용 시 이전 설정 유지
- 이미지 로딩 완료 후 하이라이트가 표시되도록 수정

## ✅ How to Test

1. 책 상세 → 기억에 남는 페이지 추가
2. 이미지 선택 후 "하이라이트" 버튼 탭
3. 자유롭게 드로잉 → 컬러/굵기/투명도 조절
4. 완료 후 저장 → 썸네일과 전체화면에서 하이라이트 확인

## 🔗 Related Issues

- Closes: BYU-278