### PR TITLE
feature/fix-widget-double-navigation

### DIFF
--- a/app/lib/data/services/deep_link_service.dart
+++ b/app/lib/data/services/deep_link_service.dart
@@ -32,6 +32,7 @@ class DeepLinkService {
   static GlobalKey<NavigatorState>? _navigatorKey;
   static const _deepLinkChannel = MethodChannel('com.bookgolas.app/deep_link');
   static final Set<String> _handledAuthUrls = {};
+  static final Map<String, DateTime> _recentlyHandledDeepLinks = {};
 
   static DeepLinkResult? parseUri(Uri uri) {
     if (uri.scheme != 'bookgolas') return null;
@@ -192,6 +193,17 @@ class DeepLinkService {
       {bool useReplacement = false}) async {
     debugPrint('🔗 딥링크 수신: $uri (useReplacement=$useReplacement)');
 
+    final uriKey = uri.toString();
+    final now = DateTime.now();
+    final lastHandled = _recentlyHandledDeepLinks[uriKey];
+    if (lastHandled != null &&
+        now.difference(lastHandled).inMilliseconds < 800) {
+      debugPrint(
+          '🔗 중복 딥링크 무시 (${now.difference(lastHandled).inMilliseconds}ms 이내): $uri');
+      return;
+    }
+    _recentlyHandledDeepLinks[uriKey] = now;
+
     if (uri.host == 'login-callback' || uri.host == 'reset-callback') {
       if (uri.query.contains('error=') || uri.fragment.contains('error=')) {
         debugPrint('🔗 인증 콜백 에러 파라미터 감지 — 무시: $uri');
@@ -315,5 +327,6 @@ class DeepLinkService {
     _widgetClickSubscription?.cancel();
     _widgetClickSubscription = null;
     _navigatorKey = null;
+    _recentlyHandledDeepLinks.clear();
   }
 }


### PR DESCRIPTION
## 📌 Summary

홈 위젯 버튼(책/스캔/추가) 탭 시 네비게이터 푸시가 2번 발생하는 버그 수정

## 📋 Changes

- `./app/lib/data/services/deep_link_service.dart`: `_recentlyHandledDeepLinks` Map 추가 및 `_handleDeepLink`에 800ms 이내 중복 URI 차단 로직 추가

## 🧠 Context & Background

iOS 홈 위젯 버튼 탭 시, 같은 딥링크 URL이 두 채널로 동시에 발화됨:
- `HomeWidget.widgetClicked` 스트림 (home_widget 패키지)
- `app_links.uriLinkStream` 스트림 (app_links 패키지)

이로 인해 `_handleDeepLink()`가 두 번 호출되어 `Navigator.push`가 2번 실행됨.
콜드스타트 시에도 `initiallyLaunchedFromHomeWidget()` + `getInitialLink()` 양쪽에서 동일 URL을 반환해 동일 문제 발생.

## ✅ How to Test

1. 앱이 포그라운드/백그라운드 상태에서 홈 화면 위젯의 책/스캔/추가 버튼 탭
2. 해당 화면으로 1번만 이동하는지 확인 (이전: 같은 화면이 스택에 2번 쌓임)
3. 백 버튼으로 돌아올 때 올바르게 홈으로 돌아오는지 확인

## 🔗 Related Issues

- Related: 홈 위젯 더블 네비게이션 버그 수정