### PR TITLE
daily/2026-03-18

### DIFF
--- a/app/lib/data/services/deep_link_service.dart
+++ b/app/lib/data/services/deep_link_service.dart
@@ -32,6 +32,7 @@ class DeepLinkService {
   static GlobalKey<NavigatorState>? _navigatorKey;
   static const _deepLinkChannel = MethodChannel('com.bookgolas.app/deep_link');
   static final Set<String> _handledAuthUrls = {};
+  static final Map<String, DateTime> _recentlyHandledDeepLinks = {};
 
   static DeepLinkResult? parseUri(Uri uri) {
     if (uri.scheme != 'bookgolas') return null;
@@ -192,6 +193,17 @@ class DeepLinkService {
       {bool useReplacement = false}) async {
     debugPrint('🔗 딥링크 수신: $uri (useReplacement=$useReplacement)');
 
+    final uriKey = uri.toString();
+    final now = DateTime.now();
+    final lastHandled = _recentlyHandledDeepLinks[uriKey];
+    if (lastHandled != null &&
+        now.difference(lastHandled).inMilliseconds < 800) {
+      debugPrint(
+          '🔗 중복 딥링크 무시 (${now.difference(lastHandled).inMilliseconds}ms 이내): $uri');
+      return;
+    }
+    _recentlyHandledDeepLinks[uriKey] = now;
+
     if (uri.host == 'login-callback' || uri.host == 'reset-callback') {
       if (uri.query.contains('error=') || uri.fragment.contains('error=')) {
         debugPrint('🔗 인증 콜백 에러 파라미터 감지 — 무시: $uri');
@@ -315,5 +327,6 @@ class DeepLinkService {
     _widgetClickSubscription?.cancel();
     _widgetClickSubscription = null;
     _navigatorKey = null;
+    _recentlyHandledDeepLinks.clear();
   }
 }


### PR DESCRIPTION
## 📌 Summary

daily/2026-03-18 작업 통합 — 홈 위젯 더블 네비게이션 버그 수정

## 📋 Changes

- `./app/lib/data/services/deep_link_service.dart`: 홈 위젯 딥링크 중복 처리 방지 로직 추가

## 🧠 Context & Background

홈 위젯 버튼(책/스캔/추가) 탭 시 Navigator.push가 2번 발생하는 버그 수정 포함.
PR #198 에서 상세 내용 확인 가능.

## ✅ How to Test

1. 홈 화면 위젯의 버튼 탭
2. 해당 화면이 1번만 푸시되는지 확인

## 🔗 Related Issues

- Closes: #198