### PR TITLE
feature/BOK-361-fix-tos-privacy-pages

### DIFF
--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1517,6 +1517,12 @@
            "myPageTermsAndPolicy": "Terms & Policy",
            "@myPageTermsAndPolicy": {"description": "Terms and policy in my page"},
 
+           "myPageTermsOfService": "Terms of Service",
+           "@myPageTermsOfService": {"description": "Terms of service in my page"},
+
+           "myPagePrivacyPolicy": "Privacy Policy",
+           "@myPagePrivacyPolicy": {"description": "Privacy policy in my page"},
+
            "myPageVersion": "Version",
            "@myPageVersion": {"description": "Version in my page"},
 

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1629,5 +1629,8 @@
            "@loginSocialApple": {"description": "Continue with Apple button"},
 
            "pageSwipeHint": "◀ Swipe to update page ▶",
-           "@pageSwipeHint": {"description": "Hint text for swipe to update page gesture"}
+           "@pageSwipeHint": {"description": "Hint text for swipe to update page gesture"},
+
+           "webviewLoadError": "Unable to load page",
+           "@webviewLoadError": {"description": "Error message when webview fails to load a page"}
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3052,8 +3052,14 @@
          "myPageWrongCurrentPassword": "현재 비밀번호가 올바르지 않습니다",
          "@myPageWrongCurrentPassword": {"description": "Wrong current password error"},
 
-         "myPageTermsAndPolicy": "약관 및 정책",
-         "@myPageTermsAndPolicy": {"description": "Terms and policy in my page"},
+     "myPageTermsAndPolicy": "약관 및 정책",
+     "@myPageTermsAndPolicy": {"description": "Terms and policy in my page"},
+
+     "myPageTermsOfService": "이용약관",
+     "@myPageTermsOfService": {"description": "Terms of service in my page"},
+
+     "myPagePrivacyPolicy": "개인정보처리방침",
+     "@myPagePrivacyPolicy": {"description": "Privacy policy in my page"},
 
          "myPageVersion": "버전",
          "@myPageVersion": {"description": "Version in my page"},

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3168,5 +3168,8 @@
          "@loginSocialApple": {"description": "Continue with Apple button"},
 
          "pageSwipeHint": "◀ 밀어서 페이지 업데이트 ▶",
-         "@pageSwipeHint": {"description": "Hint text for swipe to update page gesture"}
+         "@pageSwipeHint": {"description": "Hint text for swipe to update page gesture"},
+
+         "webviewLoadError": "페이지를 불러올 수 없습니다",
+         "@webviewLoadError": {"description": "Error message when webview fails to load a page"}
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -6497,6 +6497,18 @@ abstract class AppLocalizations {
   /// **'약관 및 정책'**
   String get myPageTermsAndPolicy;
 
+  /// Terms of service in my page
+  ///
+  /// In ko, this message translates to:
+  /// **'이용약관'**
+  String get myPageTermsOfService;
+
+  /// Privacy policy in my page
+  ///
+  /// In ko, this message translates to:
+  /// **'개인정보처리방침'**
+  String get myPagePrivacyPolicy;
+
   /// Version in my page
   ///
   /// In ko, this message translates to:

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -6694,6 +6694,12 @@ abstract class AppLocalizations {
   /// In ko, this message translates to:
   /// **'◀ 밀어서 페이지 업데이트 ▶'**
   String get pageSwipeHint;
+
+  /// Error message when webview fails to load a page
+  ///
+  /// In ko, this message translates to:
+  /// **'페이지를 불러올 수 없습니다'**
+  String get webviewLoadError;
 }
 
 class _AppLocalizationsDelegate

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -3663,4 +3663,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get pageSwipeHint => '◀ Swipe to update page ▶';
+
+  @override
+  String get webviewLoadError => 'Unable to load page';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -3558,6 +3558,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get myPageTermsAndPolicy => 'Terms & Policy';
 
   @override
+  String get myPageTermsOfService => 'Terms of Service';
+
+  @override
+  String get myPagePrivacyPolicy => 'Privacy Policy';
+
+  @override
   String get myPageVersion => 'Version';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -3577,4 +3577,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get pageSwipeHint => '◀ 밀어서 페이지 업데이트 ▶';
+
+  @override
+  String get webviewLoadError => '페이지를 불러올 수 없습니다';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -3475,6 +3475,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get myPageTermsAndPolicy => '약관 및 정책';
 
   @override
+  String get myPageTermsOfService => '이용약관';
+
+  @override
+  String get myPagePrivacyPolicy => '개인정보처리방침';
+
+  @override
   String get myPageVersion => '버전';
 
   @override

--- a/app/lib/ui/auth/utils/legal_content.dart
+++ b/app/lib/ui/auth/utils/legal_content.dart
@@ -1,0 +1,330 @@
+class LegalContent {
+  LegalContent._();
+
+  static String _baseStyle(bool isDark) {
+    final bg = isDark ? '#121418' : '#ffffff';
+    final text = isDark ? '#e0e0e0' : '#333333';
+    final heading = isDark ? '#ffffff' : '#111111';
+    final border = isDark ? '#2a2d35' : '#e5e7eb';
+    return '''
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background-color: $bg;
+        color: $text;
+        padding: 24px 20px 48px;
+        margin: 0;
+        font-size: 15px;
+        line-height: 1.7;
+        word-break: keep-all;
+      }
+      h1 {
+        font-size: 22px;
+        font-weight: 700;
+        color: $heading;
+        margin: 0 0 8px;
+      }
+      h2 {
+        font-size: 17px;
+        font-weight: 600;
+        color: $heading;
+        margin: 28px 0 12px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid $border;
+      }
+      p, li { margin: 6px 0; }
+      ul { padding-left: 20px; }
+      .subtitle {
+        font-size: 13px;
+        color: ${isDark ? '#888' : '#999'};
+        margin-bottom: 24px;
+      }
+      .empty {
+        text-align: center;
+        padding: 80px 20px;
+        color: ${isDark ? '#666' : '#aaa'};
+        font-size: 16px;
+      }
+    ''';
+  }
+
+  static String termsOfService(String locale, bool isDark) {
+    if (locale == 'ko') {
+      return '''
+<!DOCTYPE html>
+<html lang="ko">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>${_baseStyle(isDark)}</style></head>
+<body>
+<h1>서비스 이용약관</h1>
+<p class="subtitle">시행일: 2026년 1월 1일</p>
+
+<h2>제1조 (목적)</h2>
+<p>본 약관은 북골라스(이하 "서비스")가 제공하는 독서 기록 및 관리 서비스의 이용 조건과 절차, 회사와 이용자 간의 권리·의무 및 책임사항을 규정함을 목적으로 합니다.</p>
+
+<h2>제2조 (서비스 내용)</h2>
+<p>서비스는 다음과 같은 기능을 제공합니다:</p>
+<ul>
+<li>독서 기록 및 진행률 관리</li>
+<li>독서 목표 설정 및 달성 추적</li>
+<li>하이라이트, 메모, 사진 기록</li>
+<li>AI 기반 독서 기록 검색 및 분석</li>
+<li>독후감 작성 및 관리</li>
+<li>독서 통계 및 인사이트</li>
+</ul>
+
+<h2>제3조 (이용자의 의무)</h2>
+<ul>
+<li>이용자는 관계 법령, 본 약관의 규정, 이용안내 및 서비스와 관련하여 공지한 사항을 준수하여야 합니다.</li>
+<li>이용자는 서비스를 이용하여 얻은 정보를 서비스의 사전 동의 없이 복제, 배포, 방송 또는 상업적으로 이용할 수 없습니다.</li>
+<li>이용자는 타인의 개인정보를 침해하거나 서비스의 정상적인 운영을 방해하는 행위를 하여서는 안 됩니다.</li>
+<li>이용자는 자신의 계정 정보를 안전하게 관리할 책임이 있습니다.</li>
+</ul>
+
+<h2>제4조 (서비스의 변경 및 중단)</h2>
+<p>서비스는 운영상, 기술상의 필요에 따라 제공하는 서비스의 전부 또는 일부를 변경하거나 중단할 수 있습니다. 이 경우 변경 또는 중단 사유와 내용을 사전에 공지합니다.</p>
+
+<h2>제5조 (면책조항)</h2>
+<ul>
+<li>서비스는 천재지변, 전쟁, 기간통신사업자의 서비스 중지 등 불가항력적인 사유로 서비스를 제공할 수 없는 경우 책임이 면제됩니다.</li>
+<li>서비스는 이용자의 귀책사유로 인한 서비스 이용 장애에 대하여 책임을 지지 않습니다.</li>
+<li>서비스에 게재된 독서 기록 및 콘텐츠의 정확성, 신뢰성에 대해서는 이용자 본인에게 책임이 있습니다.</li>
+</ul>
+
+<h2>제6조 (유료 서비스)</h2>
+<p>서비스의 일부 기능은 유료로 제공될 수 있으며, 유료 서비스의 이용 요금 및 결제 방법은 해당 서비스 내에 별도로 안내됩니다. 구독 및 결제는 Apple App Store의 정책을 따릅니다.</p>
+
+<h2>제7조 (기타)</h2>
+<ul>
+<li>본 약관에서 정하지 아니한 사항에 대해서는 관계 법령 및 상관례에 따릅니다.</li>
+<li>본 약관은 대한민국 법률에 따라 해석되고 적용됩니다.</li>
+<li>서비스 이용과 관련된 분쟁은 서비스의 본사 소재지를 관할하는 법원을 합의 관할로 합니다.</li>
+</ul>
+</body></html>
+''';
+    }
+    return '''
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>${_baseStyle(isDark)}</style></head>
+<body>
+<h1>Terms of Service</h1>
+<p class="subtitle">Effective Date: January 1, 2026</p>
+
+<h2>1. Purpose</h2>
+<p>These Terms of Service govern your use of Bookgolas (the "Service"), a reading record and management application. By using the Service, you agree to be bound by these terms.</p>
+
+<h2>2. Service Description</h2>
+<p>The Service provides the following features:</p>
+<ul>
+<li>Reading record and progress tracking</li>
+<li>Reading goal setting and achievement tracking</li>
+<li>Highlights, memos, and photo records</li>
+<li>AI-powered reading record search and analysis</li>
+<li>Book review writing and management</li>
+<li>Reading statistics and insights</li>
+</ul>
+
+<h2>3. User Obligations</h2>
+<ul>
+<li>Users must comply with applicable laws, these terms, and any guidelines published by the Service.</li>
+<li>Users may not reproduce, distribute, broadcast, or commercially exploit information obtained through the Service without prior consent.</li>
+<li>Users must not infringe upon the personal information of others or interfere with the normal operation of the Service.</li>
+<li>Users are responsible for maintaining the security of their account credentials.</li>
+</ul>
+
+<h2>4. Service Modifications and Interruptions</h2>
+<p>The Service may modify or discontinue all or part of its features for operational or technical reasons. Users will be notified in advance of any such changes.</p>
+
+<h2>5. Disclaimer</h2>
+<ul>
+<li>The Service is not liable for interruptions caused by force majeure events such as natural disasters, wars, or telecommunications service outages.</li>
+<li>The Service is not responsible for service disruptions caused by the user's own actions.</li>
+<li>Users are responsible for the accuracy and reliability of their reading records and content.</li>
+</ul>
+
+<h2>6. Paid Services</h2>
+<p>Some features may be offered as paid services. Pricing and payment methods are described within the Service. Subscriptions and payments are processed through the Apple App Store and are subject to its policies.</p>
+
+<h2>7. General</h2>
+<ul>
+<li>Matters not specified in these terms are governed by applicable laws and customary practices.</li>
+<li>These terms are interpreted and applied under the laws of the Republic of Korea.</li>
+<li>Disputes related to the Service shall be resolved by the competent court in the jurisdiction of the Service's headquarters.</li>
+</ul>
+</body></html>
+''';
+  }
+
+  static String privacyPolicy(String locale, bool isDark) {
+    if (locale == 'ko') {
+      return '''
+<!DOCTYPE html>
+<html lang="ko">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>${_baseStyle(isDark)}</style></head>
+<body>
+<h1>개인정보처리방침</h1>
+<p class="subtitle">시행일: 2026년 1월 1일</p>
+
+<h2>제1조 (수집하는 개인정보)</h2>
+<p>서비스는 다음과 같은 개인정보를 수집합니다:</p>
+<ul>
+<li><strong>필수 정보:</strong> 이메일 주소, 비밀번호(암호화 저장)</li>
+<li><strong>선택 정보:</strong> 닉네임, 프로필 사진</li>
+<li><strong>자동 수집:</strong> 서비스 이용 기록, 기기 정보(OS 버전, 기기 모델)</li>
+<li><strong>소셜 로그인 시:</strong> 소셜 계정에서 제공하는 이메일, 이름, 프로필 사진</li>
+</ul>
+
+<h2>제2조 (이용 목적)</h2>
+<p>수집된 개인정보는 다음과 같은 목적으로 이용됩니다:</p>
+<ul>
+<li>회원 가입 및 본인 확인</li>
+<li>독서 기록 저장 및 동기화</li>
+<li>AI 기반 독서 분석 및 추천 서비스 제공</li>
+<li>알림 서비스 제공(독서 리마인더, 목표 알림 등)</li>
+<li>서비스 개선 및 새로운 기능 개발</li>
+<li>고객 지원 및 문의 응답</li>
+</ul>
+
+<h2>제3조 (보관 기간)</h2>
+<ul>
+<li>회원 탈퇴 시 개인정보는 즉시 파기됩니다.</li>
+<li>단, 관계 법령에 의해 보존이 필요한 경우 해당 기간 동안 보관합니다.</li>
+<li>전자상거래 등에서의 소비자보호에 관한 법률에 따라 계약 또는 청약 철회에 관한 기록은 5년간 보관합니다.</li>
+</ul>
+
+<h2>제4조 (제3자 제공)</h2>
+<p>서비스는 이용자의 개인정보를 원칙적으로 제3자에게 제공하지 않습니다. 다만, 다음의 경우에는 예외로 합니다:</p>
+<ul>
+<li>이용자가 사전에 동의한 경우</li>
+<li>법령의 규정에 의거하거나 수사 목적으로 법정 절차에 따라 요청이 있는 경우</li>
+</ul>
+<p>서비스는 다음과 같은 외부 서비스를 이용합니다:</p>
+<ul>
+<li><strong>Supabase:</strong> 데이터 저장 및 인증 (AWS 클라우드)</li>
+<li><strong>Firebase:</strong> 푸시 알림 서비스</li>
+<li><strong>Apple App Store:</strong> 구독 결제 처리</li>
+</ul>
+
+<h2>제5조 (이용자의 권리)</h2>
+<p>이용자는 다음과 같은 권리를 행사할 수 있습니다:</p>
+<ul>
+<li>개인정보 열람, 수정, 삭제 요청</li>
+<li>개인정보 처리 정지 요청</li>
+<li>계정 삭제를 통한 모든 개인정보 파기 요청</li>
+<li>앱 내 마이페이지에서 프로필 정보 직접 수정 가능</li>
+</ul>
+
+<h2>제6조 (개인정보의 안전성 확보 조치)</h2>
+<ul>
+<li>비밀번호는 암호화되어 저장됩니다.</li>
+<li>개인정보에 대한 접근 권한을 최소한으로 제한합니다.</li>
+<li>SSL/TLS 암호화 통신을 사용합니다.</li>
+</ul>
+
+<h2>제7조 (문의)</h2>
+<p>개인정보 처리에 관한 문의는 앱 내 설정 또는 이메일을 통해 접수할 수 있습니다.</p>
+</body></html>
+''';
+    }
+    return '''
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>${_baseStyle(isDark)}</style></head>
+<body>
+<h1>Privacy Policy</h1>
+<p class="subtitle">Effective Date: January 1, 2026</p>
+
+<h2>1. Personal Information Collected</h2>
+<p>The Service collects the following personal information:</p>
+<ul>
+<li><strong>Required:</strong> Email address, password (stored encrypted)</li>
+<li><strong>Optional:</strong> Nickname, profile photo</li>
+<li><strong>Automatically collected:</strong> Service usage logs, device information (OS version, device model)</li>
+<li><strong>Social login:</strong> Email, name, and profile photo provided by the social account</li>
+</ul>
+
+<h2>2. Purpose of Use</h2>
+<p>Collected personal information is used for the following purposes:</p>
+<ul>
+<li>Account registration and identity verification</li>
+<li>Reading record storage and synchronization</li>
+<li>AI-based reading analysis and recommendation services</li>
+<li>Notification services (reading reminders, goal alerts, etc.)</li>
+<li>Service improvement and new feature development</li>
+<li>Customer support and inquiry response</li>
+</ul>
+
+<h2>3. Retention Period</h2>
+<ul>
+<li>Personal information is deleted immediately upon account deletion.</li>
+<li>However, if retention is required by law, data is kept for the legally mandated period.</li>
+<li>Records related to contracts or subscription cancellations are retained for 5 years in accordance with consumer protection laws.</li>
+</ul>
+
+<h2>4. Disclosure to Third Parties</h2>
+<p>The Service does not, in principle, provide personal information to third parties. Exceptions include:</p>
+<ul>
+<li>When the user has given prior consent</li>
+<li>When required by law or through legal procedures for investigative purposes</li>
+</ul>
+<p>The Service uses the following external services:</p>
+<ul>
+<li><strong>Supabase:</strong> Data storage and authentication (AWS Cloud)</li>
+<li><strong>Firebase:</strong> Push notification service</li>
+<li><strong>Apple App Store:</strong> Subscription payment processing</li>
+</ul>
+
+<h2>5. User Rights</h2>
+<p>Users may exercise the following rights:</p>
+<ul>
+<li>Request to view, modify, or delete personal information</li>
+<li>Request to suspend processing of personal information</li>
+<li>Request deletion of all personal information by deleting their account</li>
+<li>Directly modify profile information through the My Page section in the app</li>
+</ul>
+
+<h2>6. Security Measures</h2>
+<ul>
+<li>Passwords are stored in encrypted form.</li>
+<li>Access to personal information is restricted to the minimum necessary.</li>
+<li>SSL/TLS encrypted communication is used.</li>
+</ul>
+
+<h2>7. Contact</h2>
+<p>Inquiries regarding personal information processing can be submitted through the app settings or via email.</p>
+</body></html>
+''';
+  }
+
+  static String announcements(String locale, bool isDark) {
+    if (locale == 'ko') {
+      return '''
+<!DOCTYPE html>
+<html lang="ko">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>${_baseStyle(isDark)}</style></head>
+<body>
+<div class="empty">
+<p>📢</p>
+<p>현재 공지사항이 없습니다.</p>
+</div>
+</body></html>
+''';
+    }
+    return '''
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>${_baseStyle(isDark)}</style></head>
+<body>
+<div class="empty">
+<p>📢</p>
+<p>No announcements at this time.</p>
+</div>
+</body></html>
+''';
+  }
+}

--- a/app/lib/ui/auth/widgets/my_page_screen.dart
+++ b/app/lib/ui/auth/widgets/my_page_screen.dart
@@ -26,6 +26,7 @@ import 'package:book_golas/ui/core/widgets/liquid_glass_text_field.dart';
 
 import 'login_screen.dart';
 import 'terms_webview_screen.dart';
+import 'package:book_golas/ui/auth/utils/legal_content.dart';
 import 'package:book_golas/ui/subscription/view_model/subscription_view_model.dart';
 import 'package:book_golas/ui/subscription/widgets/subscription_screen.dart';
 
@@ -263,8 +264,7 @@ class _MyPageContentState extends State<_MyPageContent> {
     );
   }
 
-  Future<void> _saveNotificationTime(
-      int hour, int minute, String type) async {
+  Future<void> _saveNotificationTime(int hour, int minute, String type) async {
     final settingsViewModel = context.read<NotificationSettingsViewModel>();
 
     bool success;
@@ -286,8 +286,8 @@ class _MyPageContentState extends State<_MyPageContent> {
           : settingsViewModel.getFormattedDailyReminderTime();
       CustomSnackbar.show(
         context,
-        message: AppLocalizations.of(context)
-            .myPageNotificationTime(formattedTime),
+        message:
+            AppLocalizations.of(context).myPageNotificationTime(formattedTime),
         type: BLabSnackbarType.success,
         bottomOffset: 32,
       );
@@ -699,8 +699,9 @@ class _MyPageContentState extends State<_MyPageContent> {
                           backgroundColor: Colors.transparent,
                           builder: (context) => Container(
                             decoration: BoxDecoration(
-                              color:
-                                  isDark ? BLabColors.surfaceDark : Colors.white,
+                              color: isDark
+                                  ? BLabColors.surfaceDark
+                                  : Colors.white,
                               borderRadius: const BorderRadius.vertical(
                                   top: Radius.circular(24)),
                             ),
@@ -918,7 +919,8 @@ class _MyPageContentState extends State<_MyPageContent> {
                     _buildSettingRow(
                       context: context,
                       icon: Icons.bookmark,
-                    title: AppLocalizations.of(context).myPageNotificationDailyReminder,
+                      title: AppLocalizations.of(context)
+                          .myPageNotificationDailyReminder,
                       subtitle: settings.dailyReminderEnabled
                           ? _formatTime(settings.dailyReminderHour,
                               settings.dailyReminderMinute)
@@ -957,8 +959,7 @@ class _MyPageContentState extends State<_MyPageContent> {
                             ? null
                             : () => _showTimePicker(
                                   initialHour: settings.dailyReminderHour,
-                                  initialMinute:
-                                      settings.dailyReminderMinute,
+                                  initialMinute: settings.dailyReminderMinute,
                                   type: 'dailyReminder',
                                 ),
                       ),
@@ -970,8 +971,8 @@ class _MyPageContentState extends State<_MyPageContent> {
                       title: AppLocalizations.of(context)
                           .myPageNotificationGoalAlarm,
                       subtitle: settings.goalAlarmEnabled
-                          ? _formatTime(settings.goalAlarmHour,
-                              settings.goalAlarmMinute)
+                          ? _formatTime(
+                              settings.goalAlarmHour, settings.goalAlarmMinute)
                           : null,
                       trailing: Switch(
                         value: settings.goalAlarmEnabled,
@@ -998,8 +999,8 @@ class _MyPageContentState extends State<_MyPageContent> {
                     if (settings.goalAlarmEnabled) ...[
                       const SizedBox(height: 8),
                       BLabButton(
-                        text: _formatTime(settings.goalAlarmHour,
-                            settings.goalAlarmMinute),
+                        text: _formatTime(
+                            settings.goalAlarmHour, settings.goalAlarmMinute),
                         icon: Icons.access_time,
                         variant: BLabButtonVariant.secondary,
                         isFullWidth: true,
@@ -1039,14 +1040,17 @@ class _MyPageContentState extends State<_MyPageContent> {
                     _buildSettingRow(
                       context: context,
                       icon: Icons.campaign,
-                    title: AppLocalizations.of(context).myPageNotificationAnnouncements,
+                      title: AppLocalizations.of(context)
+                          .myPageNotificationAnnouncements,
                       trailing: Consumer<MyPageViewModel>(
                         builder: (context, vm, child) {
                           return Switch(
-                      value: vm.isCategoryEnabled(NotificationCategory.announcements),
+                            value: vm.isCategoryEnabled(
+                                NotificationCategory.announcements),
                             onChanged: (value) {
                               HapticFeedback.selectionClick();
-                        vm.toggleCategory(NotificationCategory.announcements, value);
+                              vm.toggleCategory(
+                                  NotificationCategory.announcements, value);
                             },
                             activeTrackColor: BLabColors.primary,
                           );
@@ -1071,8 +1075,8 @@ class _MyPageContentState extends State<_MyPageContent> {
                 if (mounted) {
                   CustomSnackbar.show(
                     context,
-                    message: AppLocalizations.of(context)
-                        .myPageTestNotificationSent,
+                    message:
+                        AppLocalizations.of(context).myPageTestNotificationSent,
                     type: BLabSnackbarType.success,
                     bottomOffset: 32,
                     duration: const Duration(seconds: 3),
@@ -1117,7 +1121,8 @@ class _MyPageContentState extends State<_MyPageContent> {
                 trailing: Icon(
                   Icons.chevron_right,
                   size: 20,
-                color: (isDark ? Colors.white : Colors.black).withValues(alpha: 0.4),
+                  color: (isDark ? Colors.white : Colors.black)
+                      .withValues(alpha: 0.4),
                 ),
               ),
             ),
@@ -1224,6 +1229,7 @@ class _MyPageContentState extends State<_MyPageContent> {
   Widget _buildInfoCard(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final textColor = isDark ? Colors.white : Colors.black;
+    final locale = Localizations.localeOf(context).languageCode;
 
     return BLabCard(
       child: Column(
@@ -1241,14 +1247,36 @@ class _MyPageContentState extends State<_MyPageContent> {
           _buildInfoRow(
             context: context,
             icon: Icons.description,
-            title: AppLocalizations.of(context).myPageTermsAndPolicy,
+            title: AppLocalizations.of(context).myPageTermsOfService,
             onTap: () {
               Navigator.push(
                 context,
                 MaterialPageRoute(
                   builder: (_) => TermsWebViewScreen(
-                    title: AppLocalizations.of(context).myPageTermsAndPolicy,
-                    url: 'https://placeholder.com/terms',
+                    title: AppLocalizations.of(context).myPageTermsOfService,
+                    htmlContent: LegalContent.termsOfService(locale, isDark),
+                  ),
+                ),
+              );
+            },
+          ),
+          Divider(
+            height: 24,
+            color: isDark
+                ? Colors.white.withValues(alpha: 0.1)
+                : Colors.black.withValues(alpha: 0.1),
+          ),
+          _buildInfoRow(
+            context: context,
+            icon: Icons.shield,
+            title: AppLocalizations.of(context).myPagePrivacyPolicy,
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => TermsWebViewScreen(
+                    title: AppLocalizations.of(context).myPagePrivacyPolicy,
+                    htmlContent: LegalContent.privacyPolicy(locale, isDark),
                   ),
                 ),
               );
@@ -1270,7 +1298,7 @@ class _MyPageContentState extends State<_MyPageContent> {
                 MaterialPageRoute(
                   builder: (_) => TermsWebViewScreen(
                     title: AppLocalizations.of(context).myPageAnnouncements,
-                    url: 'https://placeholder.com/announcements',
+                    htmlContent: LegalContent.announcements(locale, isDark),
                   ),
                 ),
               );
@@ -1456,7 +1484,6 @@ class _MyPageContentState extends State<_MyPageContent> {
   }
 }
 
-
 class _PasswordChangeSheet extends StatefulWidget {
   const _PasswordChangeSheet();
 
@@ -1540,10 +1567,9 @@ class _PasswordChangeSheetState extends State<_PasswordChangeSheet> {
       );
       Navigator.pop(context);
     } else {
-      final message =
-          error.contains('same as') || error.contains('different')
-              ? l10n.myPagePasswordSameAsOld
-              : l10n.myPagePasswordChangeErrorDetail(error);
+      final message = error.contains('same as') || error.contains('different')
+          ? l10n.myPagePasswordSameAsOld
+          : l10n.myPagePasswordChangeErrorDetail(error);
       CustomSnackbar.show(
         context,
         message: message,
@@ -1551,8 +1577,8 @@ class _PasswordChangeSheetState extends State<_PasswordChangeSheet> {
         bottomOffset: 32,
       );
     }
-
   }
+
   Widget _buildPasswordField({
     required TextEditingController controller,
     required String hint,

--- a/app/lib/ui/auth/widgets/terms_webview_screen.dart
+++ b/app/lib/ui/auth/widgets/terms_webview_screen.dart
@@ -5,12 +5,14 @@ import 'package:book_golas/ui/core/theme/design_system.dart';
 
 class TermsWebViewScreen extends StatefulWidget {
   final String title;
-  final String url;
+  final String? url;
+  final String? htmlContent;
 
   const TermsWebViewScreen({
     super.key,
     required this.title,
-    required this.url,
+    this.url,
+    this.htmlContent,
   });
 
   @override
@@ -51,8 +53,13 @@ class _TermsWebViewScreenState extends State<TermsWebViewScreen> {
             }
           },
         ),
-      )
-      ..loadRequest(Uri.parse(widget.url));
+      );
+
+    if (widget.htmlContent != null) {
+      _controller.loadHtmlString(widget.htmlContent!);
+    } else if (widget.url != null) {
+      _controller.loadRequest(Uri.parse(widget.url!));
+    }
   }
 
   @override

--- a/app/lib/ui/auth/widgets/terms_webview_screen.dart
+++ b/app/lib/ui/auth/widgets/terms_webview_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
+import 'package:book_golas/l10n/app_localizations.dart';
 import 'package:book_golas/ui/core/theme/design_system.dart';
 
 class TermsWebViewScreen extends StatefulWidget {
@@ -13,7 +14,8 @@ class TermsWebViewScreen extends StatefulWidget {
     required this.title,
     this.url,
     this.htmlContent,
-  });
+  }) : assert(url != null || htmlContent != null,
+            'Either url or htmlContent must be provided');
 
   @override
   State<TermsWebViewScreen> createState() => _TermsWebViewScreenState();
@@ -59,6 +61,9 @@ class _TermsWebViewScreenState extends State<TermsWebViewScreen> {
       _controller.loadHtmlString(widget.htmlContent!);
     } else if (widget.url != null) {
       _controller.loadRequest(Uri.parse(widget.url!));
+    } else {
+      _isLoading = false;
+      _hasError = true;
     }
   }
 
@@ -92,7 +97,7 @@ class _TermsWebViewScreenState extends State<TermsWebViewScreen> {
             child: _hasError
                 ? Center(
                     child: Text(
-                      '페이지를 불러올 수 없습니다',
+                      AppLocalizations.of(context).webviewLoadError,
                       style: TextStyle(
                         fontSize: 16,
                         color: isDark


### PR DESCRIPTION
## 📌 Summary

ToS, Privacy 페이지가 placeholder URL로 인해 로드 실패하던 문제를 로컬 HTML 콘텐츠로 대체하여 수정했습니다.

## 📋 Changes

- `./app/lib/ui/auth/widgets/terms_webview_screen.dart`: url을 optional로 변경, htmlContent 파라미터 추가하여 loadHtmlString 지원
- `./app/lib/ui/auth/utils/legal_content.dart`: 신규 파일 — 한/영, 다크/라이트 모드 지원하는 이용약관, 개인정보처리방침, 공지사항 HTML 콘텐츠
- `./app/lib/ui/auth/widgets/my_page_screen.dart`: 정보 섹션을 이용약관, 개인정보처리방침, 공지사항 3개 항목으로 분리. placeholder URL 제거
- `./app/lib/l10n/app_ko.arb`: myPageTermsOfService, myPagePrivacyPolicy 키 추가
- `./app/lib/l10n/app_en.arb`: myPageTermsOfService, myPagePrivacyPolicy 키 추가

## 🧠 Context & Background

기존 코드에서 이용약관과 공지사항 페이지가 `https://placeholder.com/terms`, `https://placeholder.com/announcements` URL을 사용하여 WebView 로드 실패 → "페이지를 불러올 수 없습니다" 에러 표시됨. 로컬 HTML 콘텐츠로 전환하여 네트워크 의존성 제거.

## ✅ How to Test

1. 마이페이지 → 정보 섹션에서 "이용약관" 탭
2. 한국어/영어 콘텐츠가 정상 로드되는지 확인
3. "개인정보처리방침" 탭 → 콘텐츠 정상 로드 확인
4. "공지사항" 탭 → 안내 메시지 표시 확인
5. 다크모드/라이트모드 전환 후 스타일 정상 확인

## 🔗 Related Issues

- Related: BOK-361