### PR TITLE
fix/BOK-360-widget-double-push-navigation

### DIFF
--- a/app/lib/data/services/deep_link_service.dart
+++ b/app/lib/data/services/deep_link_service.dart
@@ -33,6 +33,7 @@ class DeepLinkService {
   static const _deepLinkChannel = MethodChannel('com.bookgolas.app/deep_link');
   static final Set<String> _handledAuthUrls = {};
   static final Map<String, DateTime> _recentlyHandledDeepLinks = {};
+  static bool _isProcessingDeepLink = false;
 
   static DeepLinkResult? parseUri(Uri uri) {
     if (uri.scheme != 'bookgolas') return null;
@@ -138,7 +139,7 @@ class DeepLinkService {
   static Future<void> _initAppLinks() async {
     try {
       final initialUri = await _appLinks.getInitialLink();
-      if (initialUri != null) {
+      if (initialUri != null && initialUri.scheme != 'bookgolas') {
         await _handleDeepLink(initialUri);
       }
     } catch (e) {
@@ -148,6 +149,7 @@ class DeepLinkService {
     _linkSubscription?.cancel();
     _linkSubscription = _appLinks.uriLinkStream.listen(
       (Uri uri) {
+        if (uri.scheme == 'bookgolas') return;
         _handleDeepLink(uri);
       },
       onError: (e) {
@@ -193,121 +195,131 @@ class DeepLinkService {
       {bool useReplacement = false}) async {
     debugPrint('🔗 딥링크 수신: $uri (useReplacement=$useReplacement)');
 
+    if (_isProcessingDeepLink) {
+      debugPrint('🔗 딥링크 처리 중 — 중복 요청 무시: $uri');
+      return;
+    }
+
     final uriKey = uri.toString();
     final now = DateTime.now();
     final lastHandled = _recentlyHandledDeepLinks[uriKey];
     if (lastHandled != null &&
-        now.difference(lastHandled).inMilliseconds < 800) {
+        now.difference(lastHandled).inMilliseconds < 2000) {
       debugPrint(
           '🔗 중복 딥링크 무시 (${now.difference(lastHandled).inMilliseconds}ms 이내): $uri');
       return;
     }
     _recentlyHandledDeepLinks[uriKey] = now;
+    _isProcessingDeepLink = true;
 
-    if (uri.host == 'login-callback' || uri.host == 'reset-callback') {
-      if (uri.query.contains('error=') || uri.fragment.contains('error=')) {
-        debugPrint('🔗 인증 콜백 에러 파라미터 감지 — 무시: $uri');
+    try {
+      if (uri.host == 'login-callback' || uri.host == 'reset-callback') {
+        if (uri.query.contains('error=') || uri.fragment.contains('error=')) {
+          debugPrint('🔗 인증 콜백 에러 파라미터 감지 — 무시: $uri');
+          return;
+        }
+        final urlKey = uri.toString();
+        if (_handledAuthUrls.contains(urlKey)) {
+          debugPrint('🔗 이미 처리된 인증 콜백 — 무시: $uri');
+          return;
+        }
+        _handledAuthUrls.add(urlKey);
+        debugPrint('🔗 Supabase 인증 콜백: $uri');
+        try {
+          await Supabase.instance.client.auth.getSessionFromUrl(uri);
+          debugPrint('🔗 Supabase 인증 콜백 완료');
+        } catch (e) {
+          debugPrint('🔗 Supabase 인증 콜백 실패: $e');
+        }
         return;
       }
-      final urlKey = uri.toString();
-      if (_handledAuthUrls.contains(urlKey)) {
-        debugPrint('🔗 이미 처리된 인증 콜백 — 무시: $uri');
+
+      final navigator = _navigator;
+      if (navigator == null) {
+        debugPrint('🔗 Navigator 없음 — 딥링크 무시');
         return;
       }
-      _handledAuthUrls.add(urlKey);
-      debugPrint('🔗 Supabase 인증 콜백: $uri');
-      try {
-        await Supabase.instance.client.auth.getSessionFromUrl(uri);
-        debugPrint('🔗 Supabase 인증 콜백 완료');
-      } catch (e) {
-        debugPrint('🔗 Supabase 인증 콜백 실패: $e');
+
+      final result = parseUri(uri);
+      if (result == null) {
+        debugPrint('🔗 유효하지 않은 딥링크: $uri');
+        return;
       }
-      return;
-    }
 
-    final navigator = _navigator;
-    if (navigator == null) {
-      debugPrint('🔗 Navigator 없음 — 딥링크 무시');
-      return;
-    }
+      switch (result.action) {
+        case DeepLinkAction.search:
+          final searchRoute = MaterialPageRoute(
+            builder: (context) => const ReadingStartScreen(),
+          );
+          if (useReplacement) {
+            navigator.pushReplacement(searchRoute);
+          } else {
+            navigator.push(searchRoute);
+          }
+          break;
 
-    final result = parseUri(uri);
-    if (result == null) {
-      debugPrint('🔗 유효하지 않은 딥링크: $uri');
-      return;
-    }
+        case DeepLinkAction.bookDetail:
+          final resolvedId = await _resolveBookId(result.bookId);
+          if (resolvedId == null) return;
+          final book = await _fetchBook(resolvedId);
+          if (book == null) {
+            debugPrint('🔗 책을 찾을 수 없음: $resolvedId');
+            return;
+          }
+          final detailRoute = MaterialPageRoute(
+            builder: (context) => BookDetailScreen(book: book),
+          );
+          if (useReplacement) {
+            navigator.pushReplacement(detailRoute);
+          } else {
+            navigator.push(detailRoute);
+          }
+          break;
 
-    switch (result.action) {
-      case DeepLinkAction.search:
-        final searchRoute = MaterialPageRoute(
-          builder: (context) => const ReadingStartScreen(),
-        );
-        if (useReplacement) {
-          navigator.pushReplacement(searchRoute);
-        } else {
-          navigator.push(searchRoute);
-        }
-        break;
+        case DeepLinkAction.bookRecord:
+          final resolvedRecordId = await _resolveBookId(result.bookId);
+          if (resolvedRecordId == null) return;
+          final recordBook = await _fetchBook(resolvedRecordId);
+          if (recordBook == null) {
+            debugPrint('🔗 책을 찾을 수 없음: $resolvedRecordId');
+            return;
+          }
+          final recordRoute = MaterialPageRoute(
+            builder: (context) => BookDetailScreen(
+              book: recordBook,
+              initialTabIndex: 1,
+            ),
+          );
+          if (useReplacement) {
+            navigator.pushReplacement(recordRoute);
+          } else {
+            navigator.push(recordRoute);
+          }
+          break;
 
-      case DeepLinkAction.bookDetail:
-        final resolvedId = await _resolveBookId(result.bookId);
-        if (resolvedId == null) return;
-        final book = await _fetchBook(resolvedId);
-        if (book == null) {
-          debugPrint('🔗 책을 찾을 수 없음: $resolvedId');
-          return;
-        }
-        final detailRoute = MaterialPageRoute(
-          builder: (context) => BookDetailScreen(book: book),
-        );
-        if (useReplacement) {
-          navigator.pushReplacement(detailRoute);
-        } else {
-          navigator.push(detailRoute);
-        }
-        break;
-
-      case DeepLinkAction.bookRecord:
-        final resolvedRecordId = await _resolveBookId(result.bookId);
-        if (resolvedRecordId == null) return;
-        final recordBook = await _fetchBook(resolvedRecordId);
-        if (recordBook == null) {
-          debugPrint('🔗 책을 찾을 수 없음: $resolvedRecordId');
-          return;
-        }
-        final recordRoute = MaterialPageRoute(
-          builder: (context) => BookDetailScreen(
-            book: recordBook,
-            initialTabIndex: 1,
-          ),
-        );
-        if (useReplacement) {
-          navigator.pushReplacement(recordRoute);
-        } else {
-          navigator.push(recordRoute);
-        }
-        break;
-
-      case DeepLinkAction.bookScan:
-        final resolvedScanId = await _resolveBookId(result.bookId);
-        if (resolvedScanId == null) return;
-        final scanBook = await _fetchBook(resolvedScanId);
-        if (scanBook == null) {
-          debugPrint('🔗 책을 찾을 수 없음: $resolvedScanId');
-          return;
-        }
-        final scanRoute = MaterialPageRoute(
-          builder: (context) => BookDetailScreen(
-            book: scanBook,
-            autoOpenScan: true,
-          ),
-        );
-        if (useReplacement) {
-          navigator.pushReplacement(scanRoute);
-        } else {
-          navigator.push(scanRoute);
-        }
-        break;
+        case DeepLinkAction.bookScan:
+          final resolvedScanId = await _resolveBookId(result.bookId);
+          if (resolvedScanId == null) return;
+          final scanBook = await _fetchBook(resolvedScanId);
+          if (scanBook == null) {
+            debugPrint('🔗 책을 찾을 수 없음: $resolvedScanId');
+            return;
+          }
+          final scanRoute = MaterialPageRoute(
+            builder: (context) => BookDetailScreen(
+              book: scanBook,
+              autoOpenScan: true,
+            ),
+          );
+          if (useReplacement) {
+            navigator.pushReplacement(scanRoute);
+          } else {
+            navigator.push(scanRoute);
+          }
+          break;
+      }
+    } finally {
+      _isProcessingDeepLink = false;
     }
   }
 


### PR DESCRIPTION
## 📌 Summary

위젯에서 책/스캔/추가 기능 수행 시 navigator.push가 2번 발생하여 스택이 꼬이는 문제를 수정했습니다.

## 📋 Changes

- `./app/lib/data/services/deep_link_service.dart`: 
  - `_initAppLinks()`에서 `bookgolas://` 스킴 URL 필터링 추가 (위젯 핸들러와 중복 방지)
  - `_isProcessingDeepLink` 플래그 추가하여 동시 처리 차단
  - 중복 감지 시간 윈도우를 800ms → 2000ms로 확대
  - try-finally로 플래그 리셋 보장

## 🧠 Context & Background

위젯 클릭 시 동일한 `bookgolas://` URL이 3개의 코드 경로(HomeWidget.widgetClicked, AppLinks.uriLinkStream, 네이티브 deepLinkChannel)에서 동시에 수신되어 `_handleDeepLink()`가 중복 실행됨. 기존 800ms 중복 감지 윈도우로는 동일 이벤트 루프에서의 동시 트리거를 잡지 못함.

## ✅ How to Test

1. iOS 위젯에서 책 상세 버튼 탭
2. 앱이 열리면서 책 상세 화면이 1번만 push되는지 확인
3. 뒤로가기 시 홈 화면으로 정상 복귀 확인
4. 앱이 백그라운드인 상태에서 위젯 탭 → 동일하게 1회만 push
5. 앱이 kill된 상태에서 위젯 탭 (콜드스타트) → 동일하게 1회만 push

## 🔗 Related Issues

- Related: BOK-360