### PR TITLE
feature/BOK-357-timer-mandatory-page-update

### DIFF
--- a/app/lib/data/services/book_service.dart
+++ b/app/lib/data/services/book_service.dart
@@ -161,6 +161,7 @@ class BookService {
     String bookId,
     int currentPage, {
     int? previousPage,
+    int? readingTime,
   }) async {
     try {
       int prevPage = previousPage ?? 0;
@@ -225,6 +226,8 @@ class BookService {
               'book_id': bookId,
               'page': currentPage,
               'previous_page': prevPage,
+              if (readingTime != null && readingTime > 0)
+                'reading_time': readingTime,
             });
             debugPrint('📖 [BookService] 히스토리 기록 성공: $prevPage → $currentPage');
           }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -548,6 +548,7 @@
        "pageUpdateNewPageLabel": "New Page Number",
        "pageUpdateCancel": "Cancel",
        "pageUpdateButton": "Update",
+       "timerDidNotRead": "I didn't read",
        "imageSourceDocumentScan": "Document Scan",
        "imageSourceDocumentScanDesc": "Auto-detects documents and corrects distortion",
        "imageSourceAutoCorrection": "Flatten & Auto Correct",

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -1224,6 +1224,9 @@
      "pageUpdateButton": "업데이트",
      "@pageUpdateButton": {"description": "Update button"},
      
+     "timerDidNotRead": "안읽었어요",
+     "@timerDidNotRead": {"description": "Did not read button after timer - cancels timer session"},
+     
      "imageSourceDocumentScan": "문서 스캔",
      "@imageSourceDocumentScan": {"description": "Document scan option"},
      

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -2193,6 +2193,12 @@ abstract class AppLocalizations {
   /// **'업데이트'**
   String get pageUpdateButton;
 
+  /// Did not read button after timer - cancels timer session
+  ///
+  /// In ko, this message translates to:
+  /// **'안읽었어요'**
+  String get timerDidNotRead;
+
   /// Document scan option
   ///
   /// In ko, this message translates to:

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -1176,6 +1176,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pageUpdateButton => 'Update';
 
   @override
+  String get timerDidNotRead => 'I didn\'t read';
+
+  @override
   String get imageSourceDocumentScan => 'Document Scan';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -1131,6 +1131,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get pageUpdateButton => '업데이트';
 
   @override
+  String get timerDidNotRead => '안읽었어요';
+
+  @override
   String get imageSourceDocumentScan => '문서 스캔';
 
   @override

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -486,6 +486,8 @@ class _BookDetailContentState extends State<_BookDetailContent>
                                   startDate: book.startDate,
                                   targetDate: book.targetDate,
                                   bookId: book.id ?? '',
+                                  dailySessionDurations:
+                                      progressVm.dailySessionDurations,
                                 );
                               },
                             ),

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -598,37 +598,29 @@ class _BookDetailContentState extends State<_BookDetailContent>
     final effectiveDuration =
         readingDuration ?? (isTimerActiveForThisBook ? timerVm.elapsed : null);
 
+    final isTimerCompleted = readingDuration != null;
+
     await PageUpdateModal.show(
       context: context,
       currentPage: book.currentPage,
       totalPages: book.totalPages,
       readingDuration: effectiveDuration,
+      requirePageUpdate: isTimerCompleted,
       onUpdate: (newPage) async {
-        await _updateCurrentPage(bookVm, newPage);
-        if (effectiveDuration != null) {
-          final progressVm = context.read<ReadingProgressViewModel>();
-          await progressVm.addProgressRecord(
-            page: newPage,
-            previousPage: book.currentPage,
-            readingTime: effectiveDuration.inSeconds,
-          );
-        }
+        await _updateCurrentPage(
+          bookVm,
+          newPage,
+          readingTime: effectiveDuration?.inSeconds,
+        );
       },
-      onSkip: effectiveDuration != null
-          ? () {
-              final progressVm = context.read<ReadingProgressViewModel>();
-              progressVm.addProgressRecord(
-                page: book.currentPage,
-                previousPage: book.currentPage,
-                readingTime: effectiveDuration.inSeconds,
-              );
-            }
-          : null,
     );
   }
 
   Future<void> _updateCurrentPage(
-      BookDetailViewModel bookVm, int newPage) async {
+    BookDetailViewModel bookVm,
+    int newPage, {
+    int? readingTime,
+  }) async {
     final oldPage = bookVm.currentBook.currentPage;
     final totalPages = bookVm.currentBook.totalPages;
     final oldProgress = oldPage / totalPages;
@@ -637,7 +629,8 @@ class _BookDetailContentState extends State<_BookDetailContent>
     final wasCompleted = oldPage >= totalPages;
     final isNowCompleted = newPage >= totalPages;
 
-    final success = await bookVm.updateCurrentPage(newPage);
+    final success =
+        await bookVm.updateCurrentPage(newPage, readingTime: readingTime);
     if (success && mounted) {
       _animateProgress(oldProgress, newProgress);
       _scrollController.animateTo(0,

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -600,22 +600,23 @@ class _BookDetailContentState extends State<_BookDetailContent>
     final effectiveDuration =
         readingDuration ?? (isTimerActiveForThisBook ? timerVm.elapsed : null);
 
-    final isTimerCompleted = readingDuration != null;
+    final isTimerFlow = readingDuration != null;
 
-    await PageUpdateModal.show(
+    final result = await PageUpdateModal.show(
       context: context,
       currentPage: book.currentPage,
       totalPages: book.totalPages,
       readingDuration: effectiveDuration,
-      requirePageUpdate: isTimerCompleted,
-      onUpdate: (newPage) async {
-        await _updateCurrentPage(
-          bookVm,
-          newPage,
-          readingTime: effectiveDuration?.inSeconds,
-        );
-      },
+      isTimerFlow: isTimerFlow,
     );
+
+    if (result.page != null && mounted) {
+      await _updateCurrentPage(
+        bookVm,
+        result.page!,
+        readingTime: effectiveDuration?.inSeconds,
+      );
+    }
   }
 
   Future<void> _updateCurrentPage(

--- a/app/lib/ui/book_detail/view_model/book_detail_view_model.dart
+++ b/app/lib/ui/book_detail/view_model/book_detail_view_model.dart
@@ -138,7 +138,8 @@ class BookDetailViewModel extends BaseViewModel {
 
       final dailyPages = <String, int>{};
       for (final record in response) {
-        final createdAt = DateTime.parse(record['created_at'] as String).toLocal();
+        final createdAt =
+            DateTime.parse(record['created_at'] as String).toLocal();
         final dateKey =
             '${createdAt.year}-${createdAt.month.toString().padLeft(2, '0')}-${createdAt.day.toString().padLeft(2, '0')}';
         final pagesRead =
@@ -189,7 +190,7 @@ class BookDetailViewModel extends BaseViewModel {
     }
   }
 
-  Future<bool> updateCurrentPage(int newPage) async {
+  Future<bool> updateCurrentPage(int newPage, {int? readingTime}) async {
     try {
       final previousPage = _currentBook.currentPage;
       debugPrint(
@@ -201,6 +202,7 @@ class BookDetailViewModel extends BaseViewModel {
         _currentBook.id!,
         newPage,
         previousPage: previousPage,
+        readingTime: readingTime,
       );
 
       if (updatedBook != null) {

--- a/app/lib/ui/book_detail/view_model/reading_progress_view_model.dart
+++ b/app/lib/ui/book_detail/view_model/reading_progress_view_model.dart
@@ -5,8 +5,10 @@ class ReadingProgressViewModel extends BaseViewModel {
   String _bookId;
 
   List<Map<String, dynamic>>? _progressHistory;
+  Map<String, int> _dailySessionDurations = {};
 
   List<Map<String, dynamic>>? get progressHistory => _progressHistory;
+  Map<String, int> get dailySessionDurations => _dailySessionDurations;
 
   ReadingProgressViewModel({required String bookId}) : _bookId = bookId;
 
@@ -17,19 +19,38 @@ class ReadingProgressViewModel extends BaseViewModel {
   Future<List<Map<String, dynamic>>> fetchProgressHistory() async {
     setLoading(true);
     try {
-      final response = await Supabase.instance.client
-          .from('reading_progress_history')
-          .select()
-          .eq('book_id', _bookId)
-          .order('created_at', ascending: true);
+      final client = Supabase.instance.client;
 
-      _progressHistory = (response as List).map((record) {
+      final responses = await Future.wait([
+        client
+            .from('reading_progress_history')
+            .select()
+            .eq('book_id', _bookId)
+            .order('created_at', ascending: true),
+        client
+            .from('reading_sessions')
+            .select('duration_seconds, created_at')
+            .eq('book_id', _bookId),
+      ]);
+
+      _progressHistory = (responses[0] as List).map((record) {
         final map = Map<String, dynamic>.from(record as Map);
         if (map['created_at'] != null && map['created_at'] is String) {
           map['created_at'] = DateTime.parse(map['created_at'] as String);
         }
         return map;
       }).toList();
+
+      _dailySessionDurations = {};
+      for (final session in responses[1] as List) {
+        final createdAt =
+            DateTime.parse(session['created_at'] as String).toLocal();
+        final dateKey =
+            '${createdAt.year}-${createdAt.month.toString().padLeft(2, '0')}-${createdAt.day.toString().padLeft(2, '0')}';
+        final duration = session['duration_seconds'] as int? ?? 0;
+        _dailySessionDurations[dateKey] =
+            (_dailySessionDurations[dateKey] ?? 0) + duration;
+      }
 
       notifyListeners();
       return _progressHistory!;

--- a/app/lib/ui/book_detail/widgets/tabs/progress_history_tab.dart
+++ b/app/lib/ui/book_detail/widgets/tabs/progress_history_tab.dart
@@ -20,6 +20,7 @@ class ProgressHistoryTab extends StatefulWidget {
   final DateTime startDate;
   final DateTime targetDate;
   final String bookId;
+  final Map<String, int> dailySessionDurations;
 
   const ProgressHistoryTab({
     super.key,
@@ -31,6 +32,7 @@ class ProgressHistoryTab extends StatefulWidget {
     required this.startDate,
     required this.targetDate,
     required this.bookId,
+    this.dailySessionDurations = const {},
   });
 
   @override
@@ -99,7 +101,7 @@ class _ProgressHistoryTabState extends State<ProgressHistoryTab> {
 
     final maxPage = data.isNotEmpty
         ? (data.map((e) => e['page'] as int).reduce((a, b) => a > b ? a : b))
-              .toDouble()
+            .toDouble()
         : 100.0;
 
     final dailyPagesSpots = data.asMap().entries.map((entry) {
@@ -307,9 +309,8 @@ class _ProgressHistoryTabState extends State<ProgressHistoryTab> {
             LineChartData(
               lineTouchData: LineTouchData(
                 touchTooltipData: LineTouchTooltipData(
-                  tooltipBgColor: isDark
-                      ? BLabColors.elevatedDark
-                      : Colors.white,
+                  tooltipBgColor:
+                      isDark ? BLabColors.elevatedDark : Colors.white,
                   tooltipBorder: BorderSide(
                     color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
                     width: 1,
@@ -457,9 +458,9 @@ class _ProgressHistoryTabState extends State<ProgressHistoryTab> {
                     },
                     interval: data.length > 5
                         ? ((data.length - 1) / 4).ceilToDouble().clamp(
-                            1,
-                            data.length.toDouble(),
-                          )
+                              1,
+                              data.length.toDouble(),
+                            )
                         : 1,
                   ),
                 ),
@@ -601,9 +602,8 @@ class _ProgressHistoryTabState extends State<ProgressHistoryTab> {
     final maxMinutes = readingTimeMinutes.isNotEmpty
         ? readingTimeMinutes.reduce((a, b) => a > b ? a : b)
         : 10.0;
-    final scaledMaxY = maxMinutes > 0
-        ? (maxMinutes * 1.3).ceilToDouble()
-        : 10.0;
+    final scaledMaxY =
+        maxMinutes > 0 ? (maxMinutes * 1.3).ceilToDouble() : 10.0;
 
     return SizedBox(
       height: 250,
@@ -618,9 +618,8 @@ class _ProgressHistoryTabState extends State<ProgressHistoryTab> {
             BarChartData(
               barTouchData: BarTouchData(
                 touchTooltipData: BarTouchTooltipData(
-                  tooltipBgColor: isDark
-                      ? BLabColors.elevatedDark
-                      : Colors.white,
+                  tooltipBgColor:
+                      isDark ? BLabColors.elevatedDark : Colors.white,
                   tooltipBorder: BorderSide(
                     color: isDark ? Colors.grey[700]! : Colors.grey[300]!,
                     width: 1,
@@ -720,9 +719,9 @@ class _ProgressHistoryTabState extends State<ProgressHistoryTab> {
                     },
                     interval: data.length > 5
                         ? ((data.length - 1) / 4).ceilToDouble().clamp(
-                            1,
-                            data.length.toDouble(),
-                          )
+                              1,
+                              data.length.toDouble(),
+                            )
                         : 1,
                   ),
                 ),
@@ -1002,9 +1001,8 @@ class _ProgressHistoryTabState extends State<ProgressHistoryTab> {
     final totalDays = widget.targetDate.difference(widget.startDate).inDays + 1;
     final elapsedDays = DateTime.now().difference(widget.startDate).inDays;
 
-    final expectedProgress = elapsedDays > 0
-        ? (elapsedDays / totalDays * 100).clamp(0, 100)
-        : 0.0;
+    final expectedProgress =
+        elapsedDays > 0 ? (elapsedDays / totalDays * 100).clamp(0, 100) : 0.0;
     final progressDiff = widget.progressPercentage - expectedProgress;
 
     if (widget.progressPercentage >= 100) {
@@ -1305,6 +1303,14 @@ class _ProgressHistoryTabState extends State<ProgressHistoryTab> {
       final currentPage = aggregatedList[i]['page'] as int;
       aggregatedList[i]['daily_page'] = currentPage - prevPage;
       prevPage = currentPage;
+
+      final date = aggregatedList[i]['created_at'] as DateTime;
+      final dateKey =
+          '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+      final sessionDuration = widget.dailySessionDurations[dateKey] ?? 0;
+      if (sessionDuration > 0) {
+        aggregatedList[i]['reading_time'] = sessionDuration;
+      }
     }
 
     return aggregatedList;

--- a/app/lib/ui/core/widgets/floating_timer_bar.dart
+++ b/app/lib/ui/core/widgets/floating_timer_bar.dart
@@ -296,6 +296,8 @@ class _FloatingTimerBarState extends State<FloatingTimerBar>
     if (book == null || !mounted) return;
 
     final currentPage = book.currentPage;
+    bool pageUpdated = false;
+    int? updatedPage;
 
     await PageUpdateModal.show(
       context: context,
@@ -309,24 +311,26 @@ class _FloatingTimerBarState extends State<FloatingTimerBar>
           newPage,
           readingTime: duration.inSeconds,
         );
-
-        if (mounted) {
-          if (!isInBookDetailScreen) {
-            await _navigateToBookDetail(bookId);
-          }
-
-          if (mounted) {
-            CustomSnackbar.show(
-              context,
-              message: l10n.pageUpdateSuccess(newPage),
-              type: BLabSnackbarType.success,
-              rootOverlay: true,
-              bottomOffset: 100,
-            );
-          }
-        }
+        pageUpdated = true;
+        updatedPage = newPage;
       },
     );
+
+    if (pageUpdated && mounted) {
+      if (!isInBookDetailScreen) {
+        await _navigateToBookDetail(bookId);
+      }
+
+      if (mounted && updatedPage != null) {
+        CustomSnackbar.show(
+          context,
+          message: l10n.pageUpdateSuccess(updatedPage!),
+          type: BLabSnackbarType.success,
+          rootOverlay: true,
+          bottomOffset: 100,
+        );
+      }
+    }
   }
 
   @override

--- a/app/lib/ui/core/widgets/floating_timer_bar.dart
+++ b/app/lib/ui/core/widgets/floating_timer_bar.dart
@@ -295,40 +295,37 @@ class _FloatingTimerBarState extends State<FloatingTimerBar>
 
     if (book == null || !mounted) return;
 
-    final currentPage = book.currentPage;
-    bool pageUpdated = false;
-    int? updatedPage;
-
-    await PageUpdateModal.show(
+    final result = await PageUpdateModal.show(
       context: context,
-      currentPage: currentPage,
+      currentPage: book.currentPage,
       totalPages: book.totalPages,
       readingDuration: duration,
-      requirePageUpdate: true,
-      onUpdate: (newPage) async {
-        await bookService.updateCurrentPage(
-          bookId,
-          newPage,
-          readingTime: duration.inSeconds,
-        );
-        pageUpdated = true;
-        updatedPage = newPage;
-      },
+      isTimerFlow: true,
     );
 
-    if (pageUpdated && mounted) {
-      if (!isInBookDetailScreen) {
-        await _navigateToBookDetail(bookId);
-      }
+    if (!mounted) return;
 
-      if (mounted && updatedPage != null) {
-        CustomSnackbar.show(
-          context,
-          message: l10n.pageUpdateSuccess(updatedPage!),
-          type: BLabSnackbarType.success,
-          rootOverlay: true,
-          bottomOffset: 100,
-        );
+    if (result.page != null) {
+      await bookService.updateCurrentPage(
+        bookId,
+        result.page!,
+        readingTime: duration.inSeconds,
+      );
+
+      if (mounted) {
+        if (!isInBookDetailScreen) {
+          await _navigateToBookDetail(bookId);
+        }
+
+        if (mounted) {
+          CustomSnackbar.show(
+            context,
+            message: l10n.pageUpdateSuccess(result.page!),
+            type: BLabSnackbarType.success,
+            rootOverlay: true,
+            bottomOffset: 100,
+          );
+        }
       }
     }
   }

--- a/app/lib/ui/core/widgets/floating_timer_bar.dart
+++ b/app/lib/ui/core/widgets/floating_timer_bar.dart
@@ -302,8 +302,13 @@ class _FloatingTimerBarState extends State<FloatingTimerBar>
       currentPage: currentPage,
       totalPages: book.totalPages,
       readingDuration: duration,
+      requirePageUpdate: true,
       onUpdate: (newPage) async {
-        await bookService.updateCurrentPage(bookId, newPage);
+        await bookService.updateCurrentPage(
+          bookId,
+          newPage,
+          readingTime: duration.inSeconds,
+        );
 
         if (mounted) {
           if (!isInBookDetailScreen) {
@@ -320,13 +325,6 @@ class _FloatingTimerBarState extends State<FloatingTimerBar>
             );
           }
         }
-      },
-      onSkip: () {
-        bookService.recordReadingTime(
-          bookId: bookId,
-          currentPage: currentPage,
-          readingTimeSeconds: duration.inSeconds,
-        );
       },
     );
   }

--- a/app/lib/ui/core/widgets/page_update_modal.dart
+++ b/app/lib/ui/core/widgets/page_update_modal.dart
@@ -3,40 +3,36 @@ import 'package:flutter/material.dart';
 import 'package:book_golas/l10n/app_localizations.dart';
 import 'package:book_golas/ui/core/theme/app_colors.dart';
 
-/// 페이지 업데이트 모달
-///
-/// 플로팅 타이머와 독서 상세 화면에서 공통으로 사용하는 페이지 업데이트 모달
+class PageUpdateResult {
+  final int? page;
+  final bool didNotRead;
+
+  const PageUpdateResult({this.page, this.didNotRead = false});
+
+  static const cancelled = PageUpdateResult();
+  static const notRead = PageUpdateResult(didNotRead: true);
+}
+
 class PageUpdateModal {
   static const Color _darkBg = Color(0xFF1C1C1E);
 
-  /// 페이지 업데이트 모달 표시
-  ///
-  /// [context] - BuildContext
-  /// [currentPage] - 현재 페이지 (optional, 유효성 검사용)
-  /// [totalPages] - 총 페이지 (optional, 유효성 검사용)
-  /// [readingDuration] - 독서 시간 (optional, 표시용)
-  /// [onUpdate] - 업데이트 완료 콜백 (새 페이지 번호 전달)
-  /// [onSkip] - 나중에 하기 콜백 (optional)
-  /// [requirePageUpdate] - true면 스킵/취소 버튼 숨김 (타이머 완료 후 필수 업데이트)
-  static Future<void> show({
+  static Future<PageUpdateResult> show({
     required BuildContext context,
     int? currentPage,
     int? totalPages,
     Duration? readingDuration,
-    required Future<void> Function(int newPage) onUpdate,
-    VoidCallback? onSkip,
-    bool requirePageUpdate = false,
+    bool isTimerFlow = false,
   }) async {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final TextEditingController pageController = TextEditingController();
     final l10n = AppLocalizations.of(context);
-    final rootNavigator = Navigator.of(context, rootNavigator: true);
 
-    await showModalBottomSheet(
+    final result = await showModalBottomSheet<PageUpdateResult>(
       context: context,
       backgroundColor: Colors.transparent,
       isScrollControlled: true,
       isDismissible: false,
+      enableDrag: false,
       useRootNavigator: true,
       builder: (sheetContext) => Padding(
         padding: EdgeInsets.only(
@@ -60,14 +56,13 @@ class PageUpdateModal {
             currentPage: currentPage,
             totalPages: totalPages,
             readingDuration: readingDuration,
-            onUpdate: onUpdate,
-            onSkip: onSkip,
-            requirePageUpdate: requirePageUpdate,
-            rootNavigator: rootNavigator,
+            isTimerFlow: isTimerFlow,
           ),
         ),
       ),
     );
+
+    return result ?? PageUpdateResult.cancelled;
   }
 }
 
@@ -78,10 +73,7 @@ class _PageUpdateModalContent extends StatefulWidget {
   final int? currentPage;
   final int? totalPages;
   final Duration? readingDuration;
-  final Future<void> Function(int newPage) onUpdate;
-  final VoidCallback? onSkip;
-  final bool requirePageUpdate;
-  final NavigatorState rootNavigator;
+  final bool isTimerFlow;
 
   const _PageUpdateModalContent({
     required this.isDark,
@@ -90,10 +82,7 @@ class _PageUpdateModalContent extends StatefulWidget {
     this.currentPage,
     this.totalPages,
     this.readingDuration,
-    required this.onUpdate,
-    this.onSkip,
-    this.requirePageUpdate = false,
-    required this.rootNavigator,
+    this.isTimerFlow = false,
   });
 
   @override
@@ -102,7 +91,6 @@ class _PageUpdateModalContent extends StatefulWidget {
 }
 
 class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
-  bool _isLoading = false;
   String? _errorText;
 
   String _formatReadingComplete(Duration duration) {
@@ -132,7 +120,7 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
     return null;
   }
 
-  Future<void> _handleUpdate() async {
+  void _handleUpdate() {
     final pageText = widget.pageController.text.trim();
     final page = int.tryParse(pageText);
 
@@ -144,22 +132,8 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
       return;
     }
 
-    setState(() {
-      _isLoading = true;
-      _errorText = null;
-    });
-
-    try {
-      await widget.onUpdate(page).timeout(const Duration(seconds: 15));
-      widget.rootNavigator.pop();
-    } catch (e) {
-      if (mounted) {
-        setState(() {
-          _isLoading = false;
-          _errorText = widget.l10n.pageUpdateFailed;
-        });
-      }
-    }
+    Navigator.of(context, rootNavigator: true)
+        .pop(PageUpdateResult(page: page));
   }
 
   @override
@@ -169,7 +143,6 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        // Drag handle
         Container(
           width: 40,
           height: 4,
@@ -179,8 +152,6 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
           ),
         ),
         const SizedBox(height: 24),
-
-        // Reading complete badge (if duration provided)
         if (widget.readingDuration != null) ...[
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -199,8 +170,6 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
           ),
           const SizedBox(height: 24),
         ],
-
-        // Title
         Text(
           widget.l10n.pageUpdateDialogTitle,
           style: TextStyle(
@@ -210,8 +179,6 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
           ),
         ),
         const SizedBox(height: 8),
-
-        // Subtitle with current/total page info
         if (hasPageInfo)
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -243,8 +210,6 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
             ),
           ),
         const SizedBox(height: 24),
-
-        // Page input
         TextField(
           controller: widget.pageController,
           keyboardType: TextInputType.number,
@@ -255,6 +220,7 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
               _errorText = _validatePage(value);
             });
           },
+          onSubmitted: (_) => _handleUpdate(),
           style: TextStyle(
             fontSize: 24,
             fontWeight: FontWeight.bold,
@@ -294,69 +260,57 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
           ),
         ),
         const SizedBox(height: 24),
-
-        // Update button
         SizedBox(
           width: double.infinity,
           child: GestureDetector(
-            onTap: _isLoading ? null : _handleUpdate,
+            onTap: _handleUpdate,
             child: Container(
               padding: const EdgeInsets.symmetric(vertical: 16),
               decoration: BoxDecoration(
-                color: _isLoading
-                    ? BLabColors.primary.withValues(alpha: 0.5)
-                    : BLabColors.primary,
+                color: BLabColors.primary,
                 borderRadius: BorderRadius.circular(12),
               ),
-              child: _isLoading
-                  ? const Center(
-                      child: SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: Colors.white,
-                        ),
-                      ),
-                    )
-                  : Text(
-                      widget.l10n.pageUpdateButton,
-                      textAlign: TextAlign.center,
-                      style: const TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w600,
-                        color: Colors.white,
-                      ),
-                    ),
-            ),
-          ),
-        ),
-        if (!widget.requirePageUpdate) ...[
-          const SizedBox(height: 8),
-          SizedBox(
-            width: double.infinity,
-            child: GestureDetector(
-              onTap: () {
-                widget.rootNavigator.pop();
-                widget.onSkip?.call();
-              },
-              child: Container(
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                child: Text(
-                  widget.onSkip != null
-                      ? widget.l10n.pageUpdateLater
-                      : widget.l10n.commonCancel,
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                    color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
-                  ),
+              child: Text(
+                widget.l10n.pageUpdateButton,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: Colors.white,
                 ),
               ),
             ),
           ),
-        ],
+        ),
+        const SizedBox(height: 8),
+        SizedBox(
+          width: double.infinity,
+          child: GestureDetector(
+            onTap: () {
+              if (widget.isTimerFlow) {
+                Navigator.of(context, rootNavigator: true)
+                    .pop(PageUpdateResult.notRead);
+              } else {
+                Navigator.of(context, rootNavigator: true)
+                    .pop(PageUpdateResult.cancelled);
+              }
+            },
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              child: Text(
+                widget.isTimerFlow
+                    ? widget.l10n.timerDidNotRead
+                    : widget.l10n.commonCancel,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                  color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
+                ),
+              ),
+            ),
+          ),
+        ),
       ],
     );
   }

--- a/app/lib/ui/core/widgets/page_update_modal.dart
+++ b/app/lib/ui/core/widgets/page_update_modal.dart
@@ -30,6 +30,7 @@ class PageUpdateModal {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final TextEditingController pageController = TextEditingController();
     final l10n = AppLocalizations.of(context);
+    final rootNavigator = Navigator.of(context, rootNavigator: true);
 
     await showModalBottomSheet(
       context: context,
@@ -62,6 +63,7 @@ class PageUpdateModal {
             onUpdate: onUpdate,
             onSkip: onSkip,
             requirePageUpdate: requirePageUpdate,
+            rootNavigator: rootNavigator,
           ),
         ),
       ),
@@ -79,6 +81,7 @@ class _PageUpdateModalContent extends StatefulWidget {
   final Future<void> Function(int newPage) onUpdate;
   final VoidCallback? onSkip;
   final bool requirePageUpdate;
+  final NavigatorState rootNavigator;
 
   const _PageUpdateModalContent({
     required this.isDark,
@@ -90,6 +93,7 @@ class _PageUpdateModalContent extends StatefulWidget {
     required this.onUpdate,
     this.onSkip,
     this.requirePageUpdate = false,
+    required this.rootNavigator,
   });
 
   @override
@@ -147,9 +151,7 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
 
     try {
       await widget.onUpdate(page).timeout(const Duration(seconds: 15));
-      if (mounted) {
-        Navigator.pop(context);
-      }
+      widget.rootNavigator.pop();
     } catch (e) {
       if (mounted) {
         setState(() {
@@ -335,7 +337,7 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
             width: double.infinity,
             child: GestureDetector(
               onTap: () {
-                Navigator.pop(context);
+                widget.rootNavigator.pop();
                 widget.onSkip?.call();
               },
               child: Container(

--- a/app/lib/ui/core/widgets/page_update_modal.dart
+++ b/app/lib/ui/core/widgets/page_update_modal.dart
@@ -17,6 +17,7 @@ class PageUpdateModal {
   /// [readingDuration] - 독서 시간 (optional, 표시용)
   /// [onUpdate] - 업데이트 완료 콜백 (새 페이지 번호 전달)
   /// [onSkip] - 나중에 하기 콜백 (optional)
+  /// [requirePageUpdate] - true면 스킵/취소 버튼 숨김 (타이머 완료 후 필수 업데이트)
   static Future<void> show({
     required BuildContext context,
     int? currentPage,
@@ -24,6 +25,7 @@ class PageUpdateModal {
     Duration? readingDuration,
     required Future<void> Function(int newPage) onUpdate,
     VoidCallback? onSkip,
+    bool requirePageUpdate = false,
   }) async {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final TextEditingController pageController = TextEditingController();
@@ -59,6 +61,7 @@ class PageUpdateModal {
             readingDuration: readingDuration,
             onUpdate: onUpdate,
             onSkip: onSkip,
+            requirePageUpdate: requirePageUpdate,
           ),
         ),
       ),
@@ -75,6 +78,7 @@ class _PageUpdateModalContent extends StatefulWidget {
   final Duration? readingDuration;
   final Future<void> Function(int newPage) onUpdate;
   final VoidCallback? onSkip;
+  final bool requirePageUpdate;
 
   const _PageUpdateModalContent({
     required this.isDark,
@@ -85,6 +89,7 @@ class _PageUpdateModalContent extends StatefulWidget {
     this.readingDuration,
     required this.onUpdate,
     this.onSkip,
+    this.requirePageUpdate = false,
   });
 
   @override
@@ -324,32 +329,32 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
             ),
           ),
         ),
-        const SizedBox(height: 8),
-
-        // Skip/Cancel button
-        SizedBox(
-          width: double.infinity,
-          child: GestureDetector(
-            onTap: () {
-              Navigator.pop(context);
-              widget.onSkip?.call();
-            },
-            child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 16),
-              child: Text(
-                widget.onSkip != null
-                    ? widget.l10n.pageUpdateLater
-                    : widget.l10n.commonCancel,
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
-                  color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
+        if (!widget.requirePageUpdate) ...[
+          const SizedBox(height: 8),
+          SizedBox(
+            width: double.infinity,
+            child: GestureDetector(
+              onTap: () {
+                Navigator.pop(context);
+                widget.onSkip?.call();
+              },
+              child: Container(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: Text(
+                  widget.onSkip != null
+                      ? widget.l10n.pageUpdateLater
+                      : widget.l10n.commonCancel,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                    color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
+                  ),
                 ),
               ),
             ),
           ),
-        ),
+        ],
       ],
     );
   }


### PR DESCRIPTION
## 📌 Summary

독서 타이머 완료 후 페이지 업데이트 필수화 + 히스토리 탭 독서 시간 표시 개선

## 📋 Changes

- `./app/lib/ui/core/widgets/page_update_modal.dart`: PageUpdateResult 리턴 구조로 전면 리팩토링. 타이머 후 "업데이트" + "안읽었어요" 버튼, 일반 "업데이트" + "취소" 버튼
- `./app/lib/ui/core/widgets/floating_timer_bar.dart`: 모달 결과 기반 DB 업데이트 + 네비게이션 (무한로딩 수정)
- `./app/lib/ui/book_detail/book_detail_screen.dart`: readingTime 파라미터 전달 + 중복 addProgressRecord 제거
- `./app/lib/ui/book_detail/view_model/book_detail_view_model.dart`: readingTime 파라미터 전달
- `./app/lib/data/services/book_service.dart`: updateCurrentPage에 readingTime 파라미터 추가
- `./app/lib/ui/book_detail/view_model/reading_progress_view_model.dart`: reading_sessions 테이블 병렬 조회하여 일별 독서 시간 집계
- `./app/lib/ui/book_detail/widgets/tabs/progress_history_tab.dart`: dailySessionDurations로 실제 독서 시간 표시
- `./app/lib/l10n/app_ko.arb`, `./app/lib/l10n/app_en.arb`: timerDidNotRead 키 추가

## 🧠 Context & Background

BOK-357: 타이머 완료 시 페이지 업데이트 필수화 + 히스토리 탭 독서 시간 차트/일별 기록 표시

## ✅ How to Test

1. 독서 상세에서 타이머 시작 → 정지 → 페이지 업데이트 모달에서 "업데이트" 또는 "안읽었어요" 확인
2. 히스토리 탭에서 "독서 시간" 차트 탭 전환 → 일별 독서 시간 그래프 확인
3. 일별 기록 카드에 독서 시간 표시 확인

## 🔗 Related Issues

- BOK-357