### PR TITLE
feature/BOK-362-home-card-goal-display

### DIFF
--- a/app/lib/ui/book_list/widgets/book_list_card.dart
+++ b/app/lib/ui/book_list/widgets/book_list_card.dart
@@ -96,6 +96,7 @@ class BookListCard extends StatelessWidget {
 
   Widget _buildBookInfo(bool isDark, int daysLeft, double pageProgress,
       bool isCompleted, AppLocalizations l10n) {
+    final isReading = book.status == BookStatus.reading.value && !isCompleted;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -111,8 +112,53 @@ class BookListCard extends StatelessWidget {
         ),
         const SizedBox(height: 6),
         _buildDdayAndPages(isDark, daysLeft, isCompleted, l10n),
+        if (isReading) ...[
+          const SizedBox(height: 6),
+          _buildGoalAndTargetDate(isDark, daysLeft, l10n),
+        ],
         const SizedBox(height: 8),
         _buildProgressBar(isDark, pageProgress, isCompleted),
+      ],
+    );
+  }
+
+  Widget _buildGoalAndTargetDate(
+      bool isDark, int daysLeft, AppLocalizations l10n) {
+    final pagesLeft = book.totalPages - book.currentPage;
+    final dailyTarget = book.dailyTargetPages ??
+        (daysLeft > 0 ? (pagesLeft / daysLeft).ceil() : pagesLeft);
+    final targetDateStr =
+        '${book.targetDate.year}.${book.targetDate.month.toString().padLeft(2, '0')}.${book.targetDate.day.toString().padLeft(2, '0')}';
+
+    return Row(
+      children: [
+        if (dailyTarget > 0) ...[
+          Text(
+            l10n.todayGoalWithPages(dailyTarget),
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: BLabColors.success,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 6),
+            child: Text(
+              '·',
+              style: TextStyle(
+                fontSize: 11,
+                color: isDark ? Colors.grey[600] : Colors.grey[400],
+              ),
+            ),
+          ),
+        ],
+        Text(
+          '${l10n.bookDetailTargetDate} $targetDateStr',
+          style: TextStyle(
+            fontSize: 11,
+            color: isDark ? Colors.grey[400] : Colors.grey[500],
+          ),
+        ),
       ],
     );
   }


### PR DESCRIPTION
## 📌 Summary

홈 화면 독서 중 카드에 오늘 목표 페이지수와 목표일을 표시합니다.

## 📋 Changes

- `./app/lib/ui/book_list/widgets/book_list_card.dart`: 독서 중 상태 카드에 오늘 목표 페이지수 + 목표일 행 추가

## 🧠 Context & Background

현재 독서 중 카드에는 D-day와 페이지 진행률만 표시됩니다. 사용자가 홈 화면에서 바로 오늘의 목표 페이지수와 목표일을 확인할 수 있도록 정보를 추가합니다.

## ✅ How to Test

1. 홈 화면(독서 목록)의 "독서 중" 탭으로 이동
2. 독서 중인 책 카드에 D-day 뱃지/페이지수 아래에 "오늘 목표: Xp · 목표일 YYYY.MM.DD" 텍스트가 표시되는지 확인
3. 읽을 예정/완독 탭의 카드에는 해당 텍스트가 표시되지 않는지 확인

## 🔗 Related Issues

- Closes: BOK-362