### PR TITLE
feature/BOK-362-card-progress-redesign

### DIFF
--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1332,6 +1332,10 @@
            "chartConsecutiveDays": "Consecutive Days",
            "chartMinDaily": "Min Daily",
            "chartTodayGoal": "Today's Goal",
+           "bookListCardOverallProgress": "Progress",
+           "@bookListCardOverallProgress": {
+               "description": "Label for overall reading progress bar on book list card"
+           },
            "chartDailyPages": "Daily Pages",
            "chartCumulativePages": "Cumulative Pages",
            "chartDailyReadPages": "Daily Read Pages",

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2872,6 +2872,10 @@
         "chartConsecutiveDays": "연속 일수",
         "chartMinDaily": "최소 일일",
         "chartTodayGoal": "오늘 목표",
+        "bookListCardOverallProgress": "전체 진행",
+        "@bookListCardOverallProgress": {
+            "description": "Label for overall reading progress bar on book list card"
+        },
         "chartDailyPages": "일일 페이지",
         "chartCumulativePages": "누적 페이지",
         "chartDailyReadPages": "일별 읽은 페이지",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -5872,6 +5872,12 @@ abstract class AppLocalizations {
   /// **'오늘 목표'**
   String get chartTodayGoal;
 
+  /// Label for overall reading progress bar on book list card
+  ///
+  /// In ko, this message translates to:
+  /// **'전체 진행'**
+  String get bookListCardOverallProgress;
+
   /// No description provided for @chartDailyPages.
   ///
   /// In ko, this message translates to:

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -3210,6 +3210,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chartTodayGoal => 'Today\'s Goal';
 
   @override
+  String get bookListCardOverallProgress => 'Progress';
+
+  @override
   String get chartDailyPages => 'Daily Pages';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -3134,6 +3134,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get chartTodayGoal => '오늘 목표';
 
   @override
+  String get bookListCardOverallProgress => '전체 진행';
+
+  @override
   String get chartDailyPages => '일일 페이지';
 
   @override

--- a/app/lib/ui/book_list/widgets/book_list_card.dart
+++ b/app/lib/ui/book_list/widgets/book_list_card.dart
@@ -112,23 +112,20 @@ class BookListCard extends StatelessWidget {
         ),
         const SizedBox(height: 6),
         _buildDdayAndPages(isDark, daysLeft, isCompleted, l10n),
-        if (isReading) ...[
-          const SizedBox(height: 6),
-          _buildGoalAndTargetDate(isDark, daysLeft, l10n),
-        ],
         const SizedBox(height: 8),
-        _buildProgressBar(isDark, pageProgress, isCompleted),
+        if (isReading)
+          _buildDualProgressBars(isDark, daysLeft, pageProgress, l10n)
+        else
+          _buildProgressBar(isDark, pageProgress, isCompleted),
       ],
     );
   }
 
-  Widget _buildGoalAndTargetDate(
-      bool isDark, int daysLeft, AppLocalizations l10n) {
+  Widget _buildDualProgressBars(
+      bool isDark, int daysLeft, double pageProgress, AppLocalizations l10n) {
     final pagesLeft = book.totalPages - book.currentPage;
     final dailyTarget = book.dailyTargetPages ??
         (daysLeft > 0 ? (pagesLeft / daysLeft).ceil() : pagesLeft);
-    final targetDateStr =
-        '${book.targetDate.year}.${book.targetDate.month.toString().padLeft(2, '0')}.${book.targetDate.day.toString().padLeft(2, '0')}';
 
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
@@ -143,54 +140,75 @@ class BookListCard extends StatelessWidget {
     final scheduleProgress = expectedPage > 0
         ? (book.currentPage / expectedPage).clamp(0.0, 1.0)
         : 1.0;
+    final schedulePercent = (scheduleProgress * 100).toStringAsFixed(0);
+    final overallPercent = (pageProgress * 100).toStringAsFixed(0);
 
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          children: [
-            if (dailyTarget > 0) ...[
-              Text(
-                l10n.todayGoalWithPages(dailyTarget),
-                style: const TextStyle(
-                  fontSize: 11,
-                  fontWeight: FontWeight.w600,
-                  color: BLabColors.success,
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 6),
-                child: Text(
-                  '·',
-                  style: TextStyle(
-                    fontSize: 11,
-                    color: isDark ? Colors.grey[600] : Colors.grey[400],
-                  ),
-                ),
-              ),
-            ],
-            Text(
-              '${l10n.bookDetailTargetDate} $targetDateStr',
-              style: TextStyle(
-                fontSize: 11,
-                color: isDark ? Colors.grey[400] : Colors.grey[500],
-              ),
-            ),
-          ],
+        _buildLabeledProgressRow(
+          label: l10n.chartTodayGoal,
+          percent: '$schedulePercent%',
+          progress: scheduleProgress,
+          color: BLabColors.success,
+          isDark: isDark,
         ),
-        if (dailyTarget > 0) ...[
-          const SizedBox(height: 4),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(2),
-            child: LinearProgressIndicator(
-              value: scheduleProgress,
-              backgroundColor: BLabColors.success.withValues(alpha: 0.12),
-              valueColor:
-                  const AlwaysStoppedAnimation<Color>(BLabColors.success),
-              minHeight: 3,
+        const SizedBox(height: 6),
+        _buildLabeledProgressRow(
+          label: l10n.bookListCardOverallProgress,
+          percent: '$overallPercent%',
+          progress: pageProgress,
+          color: BLabColors.primary,
+          isDark: isDark,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildLabeledProgressRow({
+    required String label,
+    required String percent,
+    required double progress,
+    required Color color,
+    required bool isDark,
+  }) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 52,
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 10,
+              fontWeight: FontWeight.w500,
+              color: isDark ? Colors.grey[500] : Colors.grey[500],
             ),
           ),
-        ],
+        ),
+        const SizedBox(width: 6),
+        Expanded(
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(3),
+            child: LinearProgressIndicator(
+              value: progress,
+              backgroundColor: isDark ? Colors.grey[800] : Colors.grey[200],
+              valueColor: AlwaysStoppedAnimation<Color>(color),
+              minHeight: 5,
+            ),
+          ),
+        ),
+        const SizedBox(width: 6),
+        SizedBox(
+          width: 32,
+          child: Text(
+            percent,
+            textAlign: TextAlign.right,
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: color,
+            ),
+          ),
+        ),
       ],
     );
   }


### PR DESCRIPTION
## 📌 Summary

홈 독서 카드의 프로그레스 바를 오늘 목표/전체 진행 듀얼 바 형태로 리디자인합니다.

## 📋 Changes

- `./app/lib/ui/book_list/widgets/book_list_card.dart`: 듀얼 프로그레스 바 (라벨 + 바 + 퍼센트) 구현
- `./app/lib/l10n/app_ko.arb`: `bookListCardOverallProgress` 키 추가 (전체 진행)
- `./app/lib/l10n/app_en.arb`: `bookListCardOverallProgress` 키 추가 (Progress)

## 🧠 Context & Background

기존에는 오늘 목표 게이지(3px)와 전체 진행률 바(6px)가 서로 다른 높이/스타일이었고, 어떤 바가 무엇을 나타내는지 라벨이 없었습니다.

## ✅ How to Test

1. 홈 > 독서 중 탭의 카드 확인
2. 두 프로그레스 바가 동일 높이(5px)로 표시되는지 확인
3. 각 바에 라벨(오늘 목표/전체 진행)과 퍼센트가 표시되는지 확인
4. 읽을 예정/완독 카드에서는 기존 단일 바만 표시되는지 확인

## 🔗 Related Issues

- Related: BOK-362