### PR TITLE
fix/BOK-362-label-overflow

### DIFF
--- a/app/lib/ui/book_detail/widgets/dashboard_progress_widget.dart
+++ b/app/lib/ui/book_detail/widgets/dashboard_progress_widget.dart
@@ -91,7 +91,10 @@ class DashboardProgressWidget extends StatelessWidget {
   }
 
   Widget _buildProgressColumn(
-      BuildContext context, bool isDark, String progressPercent) {
+    BuildContext context,
+    bool isDark,
+    String progressPercent,
+  ) {
     return Column(
       children: [
         SizedBox(
@@ -145,7 +148,8 @@ class DashboardProgressWidget extends StatelessWidget {
   }
 
   Widget _buildDailyTargetButton(BuildContext context, bool isDark) {
-    final dailyTarget = dailyTargetPages ??
+    final dailyTarget =
+        dailyTargetPages ??
         (daysLeft > 0 ? (pagesLeft / daysLeft).ceil() : pagesLeft);
     if (dailyTarget <= 0) return const SizedBox.shrink();
 
@@ -165,14 +169,17 @@ class DashboardProgressWidget extends StatelessWidget {
               children: [
                 Flexible(
                   child: Text(
-                    AppLocalizations.of(context)
-                        .todayGoalWithPages(dailyTarget),
+                    AppLocalizations.of(
+                      context,
+                    ).todayGoalWithPages(dailyTarget),
                     style: const TextStyle(
                       fontSize: 14,
                       fontWeight: FontWeight.w600,
                       color: BLabColors.success,
                     ),
-                    overflow: TextOverflow.ellipsis,
+                    maxLines: 1,
+                    softWrap: false,
+                    overflow: TextOverflow.visible,
                   ),
                 ),
                 const SizedBox(width: 6),

--- a/app/lib/ui/book_list/widgets/book_list_card.dart
+++ b/app/lib/ui/book_list/widgets/book_list_card.dart
@@ -10,11 +10,7 @@ class BookListCard extends StatelessWidget {
   final Book book;
   final VoidCallback onTap;
 
-  const BookListCard({
-    super.key,
-    required this.book,
-    required this.onTap,
-  });
+  const BookListCard({super.key, required this.book, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +20,10 @@ class BookListCard extends StatelessWidget {
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
     final target = DateTime(
-        book.targetDate.year, book.targetDate.month, book.targetDate.day);
+      book.targetDate.year,
+      book.targetDate.month,
+      book.targetDate.day,
+    );
     final daysLeft = target.difference(today).inDays;
     final pageProgress = book.totalPages > 0
         ? (book.currentPage / book.totalPages).clamp(0.0, 1.0)
@@ -59,7 +58,12 @@ class BookListCard extends StatelessWidget {
                 const SizedBox(width: 16),
                 Expanded(
                   child: _buildBookInfo(
-                      isDark, daysLeft, pageProgress, isCompleted, l10n),
+                    isDark,
+                    daysLeft,
+                    pageProgress,
+                    isCompleted,
+                    l10n,
+                  ),
                 ),
                 Icon(
                   Icons.arrow_forward_ios,
@@ -86,16 +90,18 @@ class BookListCard extends StatelessWidget {
       ),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(4),
-        child: BookImageWidget(
-          imageUrl: book.imageUrl,
-          iconSize: 30,
-        ),
+        child: BookImageWidget(imageUrl: book.imageUrl, iconSize: 30),
       ),
     );
   }
 
-  Widget _buildBookInfo(bool isDark, int daysLeft, double pageProgress,
-      bool isCompleted, AppLocalizations l10n) {
+  Widget _buildBookInfo(
+    bool isDark,
+    int daysLeft,
+    double pageProgress,
+    bool isCompleted,
+    AppLocalizations l10n,
+  ) {
     final isReading = book.status == BookStatus.reading.value && !isCompleted;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -122,17 +128,27 @@ class BookListCard extends StatelessWidget {
   }
 
   Widget _buildDualProgressBars(
-      bool isDark, int daysLeft, double pageProgress, AppLocalizations l10n) {
+    bool isDark,
+    int daysLeft,
+    double pageProgress,
+    AppLocalizations l10n,
+  ) {
     final pagesLeft = book.totalPages - book.currentPage;
-    final dailyTarget = book.dailyTargetPages ??
+    final dailyTarget =
+        book.dailyTargetPages ??
         (daysLeft > 0 ? (pagesLeft / daysLeft).ceil() : pagesLeft);
 
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
-    final start =
-        DateTime(book.startDate.year, book.startDate.month, book.startDate.day);
-    final totalDays =
-        book.targetDate.difference(book.startDate).inDays.clamp(1, 99999);
+    final start = DateTime(
+      book.startDate.year,
+      book.startDate.month,
+      book.startDate.day,
+    );
+    final totalDays = book.targetDate
+        .difference(book.startDate)
+        .inDays
+        .clamp(1, 99999);
     final daysPassed = today.difference(start).inDays;
     final expectedPage = ((daysPassed + 1) * book.totalPages / totalDays)
         .ceil()
@@ -174,9 +190,12 @@ class BookListCard extends StatelessWidget {
     return Row(
       children: [
         SizedBox(
-          width: 52,
+          width: 62,
           child: Text(
             label,
+            maxLines: 1,
+            softWrap: false,
+            overflow: TextOverflow.ellipsis,
             style: TextStyle(
               fontSize: 10,
               fontWeight: FontWeight.w500,
@@ -214,7 +233,11 @@ class BookListCard extends StatelessWidget {
   }
 
   Widget _buildDdayAndPages(
-      bool isDark, int daysLeft, bool isCompleted, AppLocalizations l10n) {
+    bool isDark,
+    int daysLeft,
+    bool isCompleted,
+    AppLocalizations l10n,
+  ) {
     return Row(
       children: [
         Container(


### PR DESCRIPTION
## 📌 Summary

영문 환경에서 'Today's Goal' 라벨이 두 줄로 끊기고, 상세 대시보드에서 'Today's goal: ...'이 잘리는 문제를 수정합니다.

## 📋 Changes

- `book_list_card.dart`: 프로그레스 라벨 SizedBox 52→62px, maxLines: 1 + overflow: ellipsis
- `dashboard_progress_widget.dart`: 오늘 목표 텍스트 overflow visible + maxLines: 1

## ✅ How to Test

1. 언어를 영어로 변경
2. 홈 독서 중 카드에서 "Today's Goal" 라벨이 한 줄로 표시되는지 확인
3. 상세 대시보드에서 "Today's goal: 22p" 텍스트가 잘리지 않는지 확인