### PR TITLE
feature/BOK-365-refactor-bottom-bar

### DIFF
--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1636,6 +1636,24 @@
            "pageSwipeHint": "◀ Swipe to update page ▶",
            "@pageSwipeHint": {"description": "Hint text for swipe to update page gesture"},
 
-           "webviewLoadError": "Unable to load page",
-           "@webviewLoadError": {"description": "Error message when webview fails to load a page"}
+            "webviewLoadError": "Unable to load page",
+            "@webviewLoadError": {"description": "Error message when webview fails to load a page"},
+
+            "bottomBarStartReading": "Start Reading",
+            "@bottomBarStartReading": {"description": "Start reading button in floating action bar"},
+
+            "bottomBarRecord": "Record",
+            "@bottomBarRecord": {"description": "Record button in floating action bar"},
+
+            "bottomBarTimerStart": "Start Timer",
+            "@bottomBarTimerStart": {"description": "Start timer menu item in floating action bar"},
+
+            "bottomBarPageUpdate": "Update Page",
+            "@bottomBarPageUpdate": {"description": "Update page menu item in floating action bar"},
+
+            "bottomBarAddRecord": "Add Record",
+            "@bottomBarAddRecord": {"description": "Add record menu item in floating action bar"},
+
+            "bottomBarAiRecordSearch": "AI Record Search",
+            "@bottomBarAiRecordSearch": {"description": "AI record search menu item in floating action bar"}
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3178,5 +3178,23 @@
          "@pageSwipeHint": {"description": "Hint text for swipe to update page gesture"},
 
          "webviewLoadError": "페이지를 불러올 수 없습니다",
-         "@webviewLoadError": {"description": "Error message when webview fails to load a page"}
+         "@webviewLoadError": {"description": "Error message when webview fails to load a page"},
+
+         "bottomBarStartReading": "독서 시작",
+         "@bottomBarStartReading": {"description": "Start reading button in floating action bar"},
+
+         "bottomBarRecord": "기록",
+         "@bottomBarRecord": {"description": "Record button in floating action bar"},
+
+         "bottomBarTimerStart": "타이머 시작",
+         "@bottomBarTimerStart": {"description": "Start timer menu item in floating action bar"},
+
+         "bottomBarPageUpdate": "페이지 업데이트",
+         "@bottomBarPageUpdate": {"description": "Update page menu item in floating action bar"},
+
+         "bottomBarAddRecord": "기록 추가",
+         "@bottomBarAddRecord": {"description": "Add record menu item in floating action bar"},
+
+         "bottomBarAiRecordSearch": "AI 기록 검색",
+         "@bottomBarAiRecordSearch": {"description": "AI record search menu item in floating action bar"}
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -6712,6 +6712,42 @@ abstract class AppLocalizations {
   /// In ko, this message translates to:
   /// **'페이지를 불러올 수 없습니다'**
   String get webviewLoadError;
+
+  /// Start reading button in floating action bar
+  ///
+  /// In ko, this message translates to:
+  /// **'독서 시작'**
+  String get bottomBarStartReading;
+
+  /// Record button in floating action bar
+  ///
+  /// In ko, this message translates to:
+  /// **'기록'**
+  String get bottomBarRecord;
+
+  /// Start timer menu item in floating action bar
+  ///
+  /// In ko, this message translates to:
+  /// **'타이머 시작'**
+  String get bottomBarTimerStart;
+
+  /// Update page menu item in floating action bar
+  ///
+  /// In ko, this message translates to:
+  /// **'페이지 업데이트'**
+  String get bottomBarPageUpdate;
+
+  /// Add record menu item in floating action bar
+  ///
+  /// In ko, this message translates to:
+  /// **'기록 추가'**
+  String get bottomBarAddRecord;
+
+  /// AI record search menu item in floating action bar
+  ///
+  /// In ko, this message translates to:
+  /// **'AI 기록 검색'**
+  String get bottomBarAiRecordSearch;
 }
 
 class _AppLocalizationsDelegate

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -3672,4 +3672,22 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get webviewLoadError => 'Unable to load page';
+
+  @override
+  String get bottomBarStartReading => 'Start Reading';
+
+  @override
+  String get bottomBarRecord => 'Record';
+
+  @override
+  String get bottomBarTimerStart => 'Start Timer';
+
+  @override
+  String get bottomBarPageUpdate => 'Update Page';
+
+  @override
+  String get bottomBarAddRecord => 'Add Record';
+
+  @override
+  String get bottomBarAiRecordSearch => 'AI Record Search';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -3586,4 +3586,22 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get webviewLoadError => '페이지를 불러올 수 없습니다';
+
+  @override
+  String get bottomBarStartReading => '독서 시작';
+
+  @override
+  String get bottomBarRecord => '기록';
+
+  @override
+  String get bottomBarTimerStart => '타이머 시작';
+
+  @override
+  String get bottomBarPageUpdate => '페이지 업데이트';
+
+  @override
+  String get bottomBarAddRecord => '기록 추가';
+
+  @override
+  String get bottomBarAiRecordSearch => 'AI 기록 검색';
 }

--- a/app/lib/ui/book_detail/widgets/floating_action_bar.dart
+++ b/app/lib/ui/book_detail/widgets/floating_action_bar.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 
 import 'package:book_golas/l10n/app_localizations.dart';
 import 'package:book_golas/ui/core/theme/design_system.dart';
-import 'package:book_golas/ui/core/widgets/timer_button.dart';
+import 'package:book_golas/ui/core/widgets/floating_context_dropdown.dart';
 
 class FloatingActionBar extends StatelessWidget {
   final VoidCallback? onUpdatePageTap;
@@ -34,53 +34,268 @@ class FloatingActionBar extends StatelessWidget {
       right: 16,
       bottom: 22,
       child: isReadingMode
-          ? _buildReadingModeLayout(isDark)
-          : _buildCompletedModeLayout(isDark),
+          ? _ReadingModeBar(
+              isDark: isDark,
+              onUpdatePageTap: onUpdatePageTap,
+              onAddMemorablePageTap: onAddMemorablePageTap,
+              onRecallSearchTap: onRecallSearchTap,
+              onTimerTap: onTimerTap,
+            )
+          : _CompletedModeBar(
+              isDark: isDark,
+              onAddMemorablePageTap: onAddMemorablePageTap,
+              onRecallSearchTap: onRecallSearchTap,
+            ),
+    );
+  }
+}
+
+class _ReadingModeBar extends StatelessWidget {
+  final bool isDark;
+  final VoidCallback? onUpdatePageTap;
+  final VoidCallback onAddMemorablePageTap;
+  final VoidCallback? onRecallSearchTap;
+  final VoidCallback? onTimerTap;
+
+  final GlobalKey _startReadingKey = GlobalKey();
+  final GlobalKey _recordKey = GlobalKey();
+
+  _ReadingModeBar({
+    required this.isDark,
+    this.onUpdatePageTap,
+    required this.onAddMemorablePageTap,
+    this.onRecallSearchTap,
+    this.onTimerTap,
+  });
+
+  void _onStartReadingTap(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final items = <FloatingContextDropdownItem<String>>[];
+
+    if (onTimerTap != null) {
+      items.add(FloatingContextDropdownItem(
+        icon: CupertinoIcons.timer,
+        label: l10n.bottomBarTimerStart,
+        value: 'timer',
+      ));
+    }
+
+    if (onUpdatePageTap != null) {
+      items.add(FloatingContextDropdownItem(
+        icon: CupertinoIcons.book_fill,
+        label: l10n.bottomBarPageUpdate,
+        value: 'page_update',
+      ));
+    }
+
+    if (items.length == 1) {
+      if (items.first.value == 'timer') {
+        onTimerTap?.call();
+      } else {
+        onUpdatePageTap?.call();
+      }
+      return;
+    }
+
+    if (items.isEmpty) return;
+
+    final renderBox =
+        _startReadingKey.currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox == null) return;
+    final position = renderBox.localToGlobal(Offset.zero);
+
+    showFloatingContextDropdown<String>(
+      context,
+      buttonPosition: position,
+      buttonWidth: renderBox.size.width,
+      buttonHeight: renderBox.size.height,
+      alignment: Alignment.bottomLeft,
+      items: items,
+      onSelected: (value) {
+        switch (value) {
+          case 'timer':
+            onTimerTap?.call();
+          case 'page_update':
+            onUpdatePageTap?.call();
+        }
+      },
     );
   }
 
-  Widget _buildReadingModeLayout(bool isDark) {
+  void _onRecordTap(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final items = <FloatingContextDropdownItem<String>>[
+      FloatingContextDropdownItem(
+        icon: CupertinoIcons.plus,
+        label: l10n.bottomBarAddRecord,
+        value: 'add_record',
+      ),
+    ];
+
+    if (onRecallSearchTap != null) {
+      items.add(FloatingContextDropdownItem(
+        icon: Icons.auto_awesome,
+        label: l10n.bottomBarAiRecordSearch,
+        value: 'ai_search',
+      ));
+    }
+
+    if (items.length == 1) {
+      onAddMemorablePageTap();
+      return;
+    }
+
+    final renderBox =
+        _recordKey.currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox == null) return;
+    final position = renderBox.localToGlobal(Offset.zero);
+
+    showFloatingContextDropdown<String>(
+      context,
+      buttonPosition: position,
+      buttonWidth: renderBox.size.width,
+      buttonHeight: renderBox.size.height,
+      alignment: Alignment.bottomRight,
+      items: items,
+      onSelected: (value) {
+        switch (value) {
+          case 'add_record':
+            onAddMemorablePageTap();
+          case 'ai_search':
+            onRecallSearchTap?.call();
+        }
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return Row(
       children: [
-        if (onTimerTap != null) ...[
-          _buildTimerButtonCircle(isDark),
-          const SizedBox(width: 12),
-        ],
-        if (onRecallSearchTap != null) ...[
-          _buildRecallSearchButtonCircle(isDark),
-          const SizedBox(width: 12),
-        ],
-        if (onUpdatePageTap != null)
-          Expanded(
-            child: _buildUpdatePageButton(isDark),
+        Expanded(
+          flex: 7,
+          child: _GlassPillButton(
+            key: _startReadingKey,
+            isDark: isDark,
+            icon: CupertinoIcons.book_fill,
+            label: l10n.bottomBarStartReading,
+            onTap: () => _onStartReadingTap(context),
           ),
+        ),
         const SizedBox(width: 12),
-        _buildAddButton(isDark),
+        Expanded(
+          flex: 3,
+          child: _GlassPillButton(
+            key: _recordKey,
+            isDark: isDark,
+            icon: CupertinoIcons.pencil,
+            label: l10n.bottomBarRecord,
+            onTap: () => _onRecordTap(context),
+          ),
+        ),
       ],
     );
   }
+}
 
-  Widget _buildCompletedModeLayout(bool isDark) {
+class _CompletedModeBar extends StatelessWidget {
+  final bool isDark;
+  final VoidCallback onAddMemorablePageTap;
+  final VoidCallback? onRecallSearchTap;
+
+  final GlobalKey _recordKey = GlobalKey();
+
+  _CompletedModeBar({
+    required this.isDark,
+    required this.onAddMemorablePageTap,
+    this.onRecallSearchTap,
+  });
+
+  void _onRecordTap(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final items = <FloatingContextDropdownItem<String>>[
+      FloatingContextDropdownItem(
+        icon: CupertinoIcons.plus,
+        label: l10n.bottomBarAddRecord,
+        value: 'add_record',
+      ),
+    ];
+
+    if (onRecallSearchTap != null) {
+      items.add(FloatingContextDropdownItem(
+        icon: Icons.auto_awesome,
+        label: l10n.bottomBarAiRecordSearch,
+        value: 'ai_search',
+      ));
+    }
+
+    if (items.length == 1) {
+      onAddMemorablePageTap();
+      return;
+    }
+
+    final renderBox =
+        _recordKey.currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox == null) return;
+    final position = renderBox.localToGlobal(Offset.zero);
+
+    showFloatingContextDropdown<String>(
+      context,
+      buttonPosition: position,
+      buttonWidth: renderBox.size.width,
+      buttonHeight: renderBox.size.height,
+      alignment: Alignment.bottomLeft,
+      items: items,
+      onSelected: (value) {
+        switch (value) {
+          case 'add_record':
+            onAddMemorablePageTap();
+          case 'ai_search':
+            onRecallSearchTap?.call();
+        }
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return Row(
       children: [
-        if (onRecallSearchTap != null)
-          Expanded(
-            child: _buildRecallSearchButtonBar(isDark),
+        Expanded(
+          flex: 7,
+          child: _GlassPillButton(
+            key: _recordKey,
+            isDark: isDark,
+            icon: CupertinoIcons.pencil,
+            label: l10n.bottomBarRecord,
+            onTap: () => _onRecordTap(context),
           ),
-        const SizedBox(width: 12),
-        _buildAddButton(isDark),
+        ),
       ],
     );
   }
+}
 
-  Widget _buildTimerButtonCircle(bool isDark) {
-    return TimerButton(
-      onTap: onTimerTap,
-      isRunning: isTimerRunning,
-    );
-  }
+class _GlassPillButton extends StatelessWidget {
+  final bool isDark;
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
 
-  Widget _buildRecallSearchButtonCircle(bool isDark) {
+  const _GlassPillButton({
+    super.key,
+    required this.isDark,
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
     return ClipRRect(
       borderRadius: BorderRadius.circular(100),
       child: BackdropFilter(
@@ -88,112 +303,7 @@ class FloatingActionBar extends StatelessWidget {
         child: Material(
           color: Colors.transparent,
           child: InkWell(
-            onTap: onRecallSearchTap,
-            borderRadius: BorderRadius.circular(100),
-            child: Container(
-              width: 62,
-              height: 62,
-              decoration: BoxDecoration(
-                color: isDark
-                    ? BLabColors.primary.withValues(alpha: 0.3)
-                    : BLabColors.primary.withValues(alpha: 0.15),
-                shape: BoxShape.circle,
-                border: Border.all(
-                  color: isDark
-                      ? BLabColors.primary.withValues(alpha: 0.5)
-                      : BLabColors.primary.withValues(alpha: 0.3),
-                  width: 0.5,
-                ),
-              ),
-              child: const Stack(
-                alignment: Alignment.center,
-                children: [
-                  Positioned(
-                    left: 14,
-                    child: Icon(
-                      Icons.auto_awesome,
-                      size: 18,
-                      color: BLabColors.primary,
-                    ),
-                  ),
-                  Positioned(
-                    right: 14,
-                    child: Icon(
-                      Icons.search,
-                      size: 18,
-                      color: BLabColors.primary,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildRecallSearchButtonBar(bool isDark) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(100),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: onRecallSearchTap,
-            borderRadius: BorderRadius.circular(100),
-            child: Container(
-              height: 62,
-              decoration: BoxDecoration(
-                color: isDark
-                    ? BLabColors.primary.withValues(alpha: 0.3)
-                    : BLabColors.primary.withValues(alpha: 0.15),
-                borderRadius: BorderRadius.circular(100),
-                border: Border.all(
-                  color: isDark
-                      ? BLabColors.primary.withValues(alpha: 0.5)
-                      : BLabColors.primary.withValues(alpha: 0.3),
-                  width: 0.5,
-                ),
-              ),
-              child: Builder(
-                builder: (context) => Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Icon(
-                      Icons.auto_awesome,
-                      size: 18,
-                      color: BLabColors.primary,
-                    ),
-                    const SizedBox(width: 8),
-                    Text(
-                      AppLocalizations.of(context).searchRecordsButton,
-                      style: const TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w600,
-                        color: BLabColors.primary,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildUpdatePageButton(bool isDark) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(100),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: onUpdatePageTap,
+            onTap: onTap,
             borderRadius: BorderRadius.circular(100),
             child: Container(
               height: 62,
@@ -209,69 +319,28 @@ class FloatingActionBar extends StatelessWidget {
                   width: 0.5,
                 ),
               ),
-              child: Builder(
-                builder: (context) => Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Icon(
-                      CupertinoIcons.book_fill,
-                      size: 17,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    icon,
+                    size: 17,
+                    color: isDark
+                        ? Colors.white.withValues(alpha: 0.85)
+                        : Colors.black.withValues(alpha: 0.65),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
                       color: isDark
                           ? Colors.white.withValues(alpha: 0.85)
                           : Colors.black.withValues(alpha: 0.65),
                     ),
-                    const SizedBox(width: 8),
-                    Text(
-                      AppLocalizations.of(context).pageUpdateButton,
-                      style: TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w600,
-                        color: isDark
-                            ? Colors.white.withValues(alpha: 0.85)
-                            : Colors.black.withValues(alpha: 0.65),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildAddButton(bool isDark) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(100),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: onAddMemorablePageTap,
-            borderRadius: BorderRadius.circular(100),
-            child: Container(
-              width: 62,
-              height: 62,
-              decoration: BoxDecoration(
-                color: isDark
-                    ? Colors.white.withValues(alpha: 0.12)
-                    : Colors.black.withValues(alpha: 0.08),
-                shape: BoxShape.circle,
-                border: Border.all(
-                  color: isDark
-                      ? Colors.white.withValues(alpha: 0.15)
-                      : Colors.black.withValues(alpha: 0.08),
-                  width: 0.5,
-                ),
-              ),
-              child: Icon(
-                CupertinoIcons.plus,
-                size: 22,
-                color: isDark
-                    ? Colors.white.withValues(alpha: 0.9)
-                    : Colors.black.withValues(alpha: 0.7),
+                  ),
+                ],
               ),
             ),
           ),

--- a/app/lib/ui/core/widgets/floating_context_dropdown.dart
+++ b/app/lib/ui/core/widgets/floating_context_dropdown.dart
@@ -1,0 +1,251 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class FloatingContextDropdownItem<T> {
+  final IconData icon;
+  final String label;
+  final T value;
+
+  const FloatingContextDropdownItem({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+}
+
+void showFloatingContextDropdown<T>(
+  BuildContext context, {
+  required Offset buttonPosition,
+  required double buttonWidth,
+  required double buttonHeight,
+  required List<FloatingContextDropdownItem<T>> items,
+  required ValueChanged<T> onSelected,
+  Alignment alignment = Alignment.bottomLeft,
+}) {
+  HapticFeedback.selectionClick();
+
+  late OverlayEntry entry;
+  entry = OverlayEntry(
+    builder: (context) => _FloatingContextDropdownOverlay<T>(
+      buttonPosition: buttonPosition,
+      buttonWidth: buttonWidth,
+      buttonHeight: buttonHeight,
+      items: items,
+      alignment: alignment,
+      onSelected: (value) {
+        entry.remove();
+        onSelected(value);
+      },
+      onDismiss: () => entry.remove(),
+    ),
+  );
+
+  Overlay.of(context).insert(entry);
+}
+
+class _FloatingContextDropdownOverlay<T> extends StatefulWidget {
+  final Offset buttonPosition;
+  final double buttonWidth;
+  final double buttonHeight;
+  final List<FloatingContextDropdownItem<T>> items;
+  final Alignment alignment;
+  final ValueChanged<T> onSelected;
+  final VoidCallback onDismiss;
+
+  const _FloatingContextDropdownOverlay({
+    required this.buttonPosition,
+    required this.buttonWidth,
+    required this.buttonHeight,
+    required this.items,
+    required this.alignment,
+    required this.onSelected,
+    required this.onDismiss,
+  });
+
+  @override
+  State<_FloatingContextDropdownOverlay<T>> createState() =>
+      _FloatingContextDropdownOverlayState<T>();
+}
+
+class _FloatingContextDropdownOverlayState<T>
+    extends State<_FloatingContextDropdownOverlay<T>>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _scaleAnimation;
+  late Animation<double> _fadeAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 200),
+      vsync: this,
+    );
+    _scaleAnimation = Tween<double>(begin: 0.8, end: 1.0).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic),
+    );
+    _fadeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeOut),
+    );
+    _controller.forward();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _dismiss() {
+    _controller.reverse().then((_) => widget.onDismiss());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    const dropdownWidth = 200.0;
+
+    final dropdownBottom =
+        MediaQuery.of(context).size.height - widget.buttonPosition.dy + 8;
+
+    final isRightAligned = widget.alignment == Alignment.bottomRight;
+
+    return Stack(
+      children: [
+        GestureDetector(
+          onTap: _dismiss,
+          behavior: HitTestBehavior.opaque,
+          child: AnimatedBuilder(
+            animation: _fadeAnimation,
+            builder: (context, _) => Container(
+              color:
+                  Colors.black.withValues(alpha: _fadeAnimation.value * 0.15),
+            ),
+          ),
+        ),
+        Positioned(
+          left: isRightAligned ? null : widget.buttonPosition.dx,
+          right: isRightAligned
+              ? MediaQuery.of(context).size.width -
+                  widget.buttonPosition.dx -
+                  widget.buttonWidth
+              : null,
+          bottom: dropdownBottom,
+          child: AnimatedBuilder(
+            animation: _controller,
+            builder: (context, child) {
+              return Transform.scale(
+                scale: _scaleAnimation.value,
+                alignment: isRightAligned
+                    ? Alignment.bottomRight
+                    : Alignment.bottomLeft,
+                child: Opacity(
+                  opacity: _fadeAnimation.value,
+                  child: child,
+                ),
+              );
+            },
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(14),
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
+                child: Container(
+                  width: dropdownWidth,
+                  decoration: BoxDecoration(
+                    color: isDark
+                        ? Colors.white.withValues(alpha: 0.14)
+                        : Colors.white.withValues(alpha: 0.85),
+                    borderRadius: BorderRadius.circular(14),
+                    border: Border.all(
+                      color: isDark
+                          ? Colors.white.withValues(alpha: 0.15)
+                          : Colors.black.withValues(alpha: 0.08),
+                      width: 0.5,
+                    ),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.15),
+                        blurRadius: 20,
+                        offset: const Offset(0, 8),
+                      ),
+                    ],
+                  ),
+                  child: Material(
+                    type: MaterialType.transparency,
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: _buildItems(isDark),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  List<Widget> _buildItems(bool isDark) {
+    final widgets = <Widget>[];
+    for (var i = 0; i < widget.items.length; i++) {
+      final item = widget.items[i];
+      widgets.add(
+        _buildItem(
+          icon: item.icon,
+          label: item.label,
+          isDark: isDark,
+          onTap: () {
+            HapticFeedback.selectionClick();
+            widget.onSelected(item.value);
+          },
+        ),
+      );
+      if (i < widget.items.length - 1) {
+        widgets.add(
+          Divider(
+            height: 0.5,
+            thickness: 0.5,
+            color: isDark
+                ? Colors.white.withValues(alpha: 0.1)
+                : Colors.black.withValues(alpha: 0.08),
+          ),
+        );
+      }
+    }
+    return widgets;
+  }
+
+  Widget _buildItem({
+    required IconData icon,
+    required String label,
+    required bool isDark,
+    required VoidCallback onTap,
+  }) {
+    final textColor = isDark ? Colors.white : Colors.black;
+
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        child: Row(
+          children: [
+            Icon(icon, size: 18, color: textColor),
+            const SizedBox(width: 10),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+                color: textColor,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ui/core/widgets/search_mode_dropdown.dart
+++ b/app/lib/ui/core/widgets/search_mode_dropdown.dart
@@ -1,10 +1,8 @@
-import 'dart:ui';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/core/widgets/floating_context_dropdown.dart';
 
 enum SearchMode { bookSearch, aiRecordSearch }
 
@@ -14,209 +12,26 @@ void showSearchModeDropdown(
   required double buttonSize,
   required void Function(SearchMode mode) onSelected,
 }) {
-  HapticFeedback.selectionClick();
+  final l10n = AppLocalizations.of(context);
 
-  late OverlayEntry entry;
-  entry = OverlayEntry(
-    builder: (context) => _SearchModeDropdownOverlay(
-      buttonPosition: buttonPosition,
-      buttonSize: buttonSize,
-      onSelected: (mode) {
-        entry.remove();
-        onSelected(mode);
-      },
-      onDismiss: () => entry.remove(),
-    ),
-  );
-
-  Overlay.of(context).insert(entry);
-}
-
-class _SearchModeDropdownOverlay extends StatefulWidget {
-  final Offset buttonPosition;
-  final double buttonSize;
-  final void Function(SearchMode mode) onSelected;
-  final VoidCallback onDismiss;
-
-  const _SearchModeDropdownOverlay({
-    required this.buttonPosition,
-    required this.buttonSize,
-    required this.onSelected,
-    required this.onDismiss,
-  });
-
-  @override
-  State<_SearchModeDropdownOverlay> createState() =>
-      _SearchModeDropdownOverlayState();
-}
-
-class _SearchModeDropdownOverlayState extends State<_SearchModeDropdownOverlay>
-    with SingleTickerProviderStateMixin {
-  late AnimationController _controller;
-  late Animation<double> _scaleAnimation;
-  late Animation<double> _fadeAnimation;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = AnimationController(
-      duration: const Duration(milliseconds: 200),
-      vsync: this,
-    );
-    _scaleAnimation = Tween<double>(begin: 0.8, end: 1.0).animate(
-      CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic),
-    );
-    _fadeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
-      CurvedAnimation(parent: _controller, curve: Curves.easeOut),
-    );
-    _controller.forward();
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  void _dismiss() {
-    _controller.reverse().then((_) => widget.onDismiss());
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final l10n = AppLocalizations.of(context);
-
-    const dropdownWidth = 200.0;
-    final dropdownRight = MediaQuery.of(context).size.width -
-        widget.buttonPosition.dx -
-        widget.buttonSize;
-    final dropdownBottom =
-        MediaQuery.of(context).size.height - widget.buttonPosition.dy + 8;
-
-    return Stack(
-      children: [
-        GestureDetector(
-          onTap: _dismiss,
-          behavior: HitTestBehavior.opaque,
-          child: AnimatedBuilder(
-            animation: _fadeAnimation,
-            builder: (context, _) => Container(
-              color:
-                  Colors.black.withValues(alpha: _fadeAnimation.value * 0.15),
-            ),
-          ),
-        ),
-        Positioned(
-          right: dropdownRight,
-          bottom: dropdownBottom,
-          child: AnimatedBuilder(
-            animation: _controller,
-            builder: (context, child) {
-              return Transform.scale(
-                scale: _scaleAnimation.value,
-                alignment: Alignment.bottomRight,
-                child: Opacity(
-                  opacity: _fadeAnimation.value,
-                  child: child,
-                ),
-              );
-            },
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(14),
-              child: BackdropFilter(
-                filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
-                child: Container(
-                  width: dropdownWidth,
-                  decoration: BoxDecoration(
-                    color: isDark
-                        ? Colors.white.withValues(alpha: 0.14)
-                        : Colors.white.withValues(alpha: 0.85),
-                    borderRadius: BorderRadius.circular(14),
-                    border: Border.all(
-                      color: isDark
-                          ? Colors.white.withValues(alpha: 0.15)
-                          : Colors.black.withValues(alpha: 0.08),
-                      width: 0.5,
-                    ),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.15),
-                        blurRadius: 20,
-                        offset: const Offset(0, 8),
-                      ),
-                    ],
-                  ),
-                  child: Material(
-                    type: MaterialType.transparency,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        _buildItem(
-                          icon: CupertinoIcons.search,
-                          label: l10n.searchModeBookSearch,
-                          isDark: isDark,
-                          onTap: () {
-                            HapticFeedback.selectionClick();
-                            widget.onSelected(SearchMode.bookSearch);
-                          },
-                        ),
-                        Divider(
-                          height: 0.5,
-                          thickness: 0.5,
-                          color: isDark
-                              ? Colors.white.withValues(alpha: 0.1)
-                              : Colors.black.withValues(alpha: 0.08),
-                        ),
-                        _buildItem(
-                          icon: Icons.auto_awesome,
-                          label: l10n.searchModeAiRecordSearch,
-                          isDark: isDark,
-                          onTap: () {
-                            HapticFeedback.selectionClick();
-                            widget.onSelected(SearchMode.aiRecordSearch);
-                          },
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildItem({
-    required IconData icon,
-    required String label,
-    required bool isDark,
-    required VoidCallback onTap,
-  }) {
-    final textColor = isDark ? Colors.white : Colors.black;
-
-    return GestureDetector(
-      onTap: onTap,
-      behavior: HitTestBehavior.opaque,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-        child: Row(
-          children: [
-            Icon(icon, size: 18, color: textColor),
-            const SizedBox(width: 10),
-            Text(
-              label,
-              style: TextStyle(
-                fontSize: 14,
-                fontWeight: FontWeight.w500,
-                color: textColor,
-              ),
-            ),
-          ],
-        ),
+  showFloatingContextDropdown<SearchMode>(
+    context,
+    buttonPosition: buttonPosition,
+    buttonWidth: buttonSize,
+    buttonHeight: buttonSize,
+    alignment: Alignment.bottomRight,
+    items: [
+      FloatingContextDropdownItem(
+        icon: CupertinoIcons.search,
+        label: l10n.searchModeBookSearch,
+        value: SearchMode.bookSearch,
       ),
-    );
-  }
+      FloatingContextDropdownItem(
+        icon: Icons.auto_awesome,
+        label: l10n.searchModeAiRecordSearch,
+        value: SearchMode.aiRecordSearch,
+      ),
+    ],
+    onSelected: onSelected,
+  );
 }


### PR DESCRIPTION
## 📌 Summary

독서 상세 화면의 바텀바를 4개 버튼에서 2개 버튼(독서 시작/기록)으로 리팩토링하고, 컨텍스츄얼 드롭다운 메뉴를 공용 위젯으로 추출했습니다.

## 📋 Changes

- `./app/lib/ui/core/widgets/floating_context_dropdown.dart`: 공용 컨텍스츄얼 드롭다운 위젯 신규 생성 (glass morphism, 애니메이션, 제네릭 타입)
- `./app/lib/ui/core/widgets/search_mode_dropdown.dart`: 공용 위젯 활용하도록 리팩토링 (222줄 → 39줄)
- `./app/lib/ui/book_detail/widgets/floating_action_bar.dart`: 4버튼 → 2버튼(독서 시작 7:3 기록) 레이아웃으로 리팩토링
- `./app/lib/l10n/app_ko.arb`: 6개 신규 다국어 키 추가 (한국어)
- `./app/lib/l10n/app_en.arb`: 6개 신규 다국어 키 추가 (영어)
- `./app/lib/l10n/app_localizations.dart`, `app_localizations_en.dart`, `app_localizations_ko.dart`: 자동 생성 l10n 파일

## 🧠 Context & Background

기존 4개 버튼(타이머/AI기록검색/페이지업데이트/기록추가)이 바텀바를 과밀하게 채우고 있어, 2개 그룹으로 정리하여 UX를 개선합니다.
- "독서 시작" → 타이머 시작 / 페이지 업데이트
- "기록" → 기록 추가 / AI 기록 검색

컨텍스츄얼 메뉴 UX는 홈 화면의 검색 버튼 드롭다운과 동일하게 구현했습니다. 기존 search_mode_dropdown의 패턴을 일반화하여 공용 위젯(FloatingContextDropdown)으로 추출하고, 검색 드롭다운도 이를 활용하도록 리팩토링했습니다.

## ✅ How to Test

1. 독서 중인 책의 상세 화면 진입
2. 하단에 "독서 시작" (넓은 버튼)과 "기록" (좁은 버튼) 2개가 보이는지 확인
3. "독서 시작" 탭 → 컨텍스트 메뉴에서 "타이머 시작"과 "페이지 업데이트" 옵션 확인
4. "기록" 탭 → 컨텍스트 메뉴에서 "기록 추가"와 "AI 기록 검색" 옵션 확인
5. 각 메뉴 아이템 선택 시 기존 기능 정상 동작 확인
6. 타이머가 이미 실행 중인 상태에서 "독서 시작" → 페이지 업데이트만 직접 실행되는지 확인
7. 완독 상태 화면에서 "기록" 버튼만 표시되는지 확인
8. 홈 화면 검색 버튼 드롭다운(독서 검색/AI 기록 검색)이 정상 동작하는지 확인

## 🔗 Related Issues

- Related: BOK-365

## 🙌 Additional Notes

- book_detail_screen.dart는 변경 불필요 (FloatingActionBar 생성자 시그니처 호환 유지)
- 메뉴 항목이 1개일 때는 드롭다운 없이 직접 실행