### PR TITLE
feature/BOK-364-complete-sns-sharing

### DIFF
--- a/app/lib/data/services/book_share_service.dart
+++ b/app/lib/data/services/book_share_service.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:path_provider/path_provider.dart';
@@ -17,107 +19,141 @@ class BookShareService {
     required Book book,
     required int highlightCount,
   }) async {
-    final repaintKey = GlobalKey();
-    OverlayEntry? entry;
-
-    try {
-      entry = OverlayEntry(
-        builder: (_) => Positioned(
-          left: -2000,
-          top: -2000,
-          child: Material(
-            color: Colors.transparent,
-            child: RepaintBoundary(
-              key: repaintKey,
-              child: BookShareCard(book: book, highlightCount: highlightCount),
-            ),
-          ),
-        ),
-      );
-
-      if (!context.mounted) return;
-      Overlay.of(context).insert(entry);
-
-      await Future.delayed(const Duration(milliseconds: 300));
-
-      final boundary =
-          repaintKey.currentContext?.findRenderObject()
-              as RenderRepaintBoundary?;
-      if (boundary == null) return;
-
-      final image = await boundary.toImage(pixelRatio: 3.0);
-      final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
-      if (byteData == null) return;
-
-      final bytes = byteData.buffer.asUint8List();
-      final dir = await getTemporaryDirectory();
-      final file = File(
-        '${dir.path}/bookgolas_share_${DateTime.now().millisecondsSinceEpoch}.png',
-      );
-      await file.writeAsBytes(bytes);
-
-      if (!context.mounted) return;
-      await Share.shareXFiles([
-        XFile(file.path, mimeType: 'image/png'),
-      ], subject: book.title);
-    } catch (e) {
-      debugPrint('Failed to share book card: $e');
-    } finally {
-      entry?.remove();
-    }
+    await _shareCard(
+      context: context,
+      filePrefix: 'bookgolas_share',
+      subject: book.title,
+      precache: () => _precacheBookCover(context, book.imageUrl),
+      child: BookShareCard(book: book, highlightCount: highlightCount),
+    );
   }
 
   static Future<void> shareStatsCard({
     required BuildContext context,
     required ReadingChartViewModel vm,
   }) async {
+    await _shareCard(
+      context: context,
+      filePrefix: 'bookgolas_stats',
+      child: ReadingStatsShareCard(vm: vm),
+    );
+  }
+
+  static Future<void> _shareCard({
+    required BuildContext context,
+    required String filePrefix,
+    required Widget child,
+    Future<void> Function()? precache,
+    String? subject,
+  }) async {
     final repaintKey = GlobalKey();
     OverlayEntry? entry;
 
     try {
+      if (precache != null) {
+        await precache();
+      }
+
+      if (!context.mounted) return;
+      final mediaQuery = MediaQuery.of(context);
+      final directionality = Directionality.of(context);
+      final overlay = Overlay.maybeOf(context, rootOverlay: true);
+      if (overlay == null) return;
+
       entry = OverlayEntry(
         builder: (_) => Positioned(
-          left: -2000,
-          top: -2000,
-          child: Material(
-            color: Colors.transparent,
-            child: RepaintBoundary(
-              key: repaintKey,
-              child: ReadingStatsShareCard(vm: vm),
+          left: -10000,
+          top: -10000,
+          child: IgnorePointer(
+            child: MediaQuery(
+              data: mediaQuery.copyWith(
+                textScaler: const TextScaler.linear(1),
+              ),
+              child: Directionality(
+                textDirection: directionality,
+                child: Material(
+                  type: MaterialType.transparency,
+                  child: RepaintBoundary(
+                    key: repaintKey,
+                    child: child,
+                  ),
+                ),
+              ),
             ),
           ),
         ),
       );
 
-      if (!context.mounted) return;
-      Overlay.of(context).insert(entry);
+      overlay.insert(entry);
 
-      await Future.delayed(const Duration(milliseconds: 300));
+      final bytes = await _capturePngBytes(
+        repaintKey: repaintKey,
+        pixelRatio: _sharePixelRatio(mediaQuery),
+      );
+      if (bytes == null) return;
 
-      final boundary =
-          repaintKey.currentContext?.findRenderObject()
-              as RenderRepaintBoundary?;
-      if (boundary == null) return;
-
-      final image = await boundary.toImage(pixelRatio: 3.0);
-      final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
-      if (byteData == null) return;
-
-      final bytes = byteData.buffer.asUint8List();
       final dir = await getTemporaryDirectory();
       final file = File(
-        '${dir.path}/bookgolas_stats_${DateTime.now().millisecondsSinceEpoch}.png',
+        '${dir.path}/${filePrefix}_${DateTime.now().millisecondsSinceEpoch}.png',
       );
-      await file.writeAsBytes(bytes);
+      await file.writeAsBytes(bytes, flush: true);
 
       if (!context.mounted) return;
-      await Share.shareXFiles([
-        XFile(file.path, mimeType: 'image/png'),
-      ]);
+      await Share.shareXFiles(
+        [XFile(file.path, mimeType: 'image/png')],
+        subject: subject,
+      );
     } catch (e) {
-      debugPrint('Failed to share stats card: $e');
+      debugPrint('Failed to share card: $e');
     } finally {
       entry?.remove();
     }
+  }
+
+  static Future<void> _precacheBookCover(
+    BuildContext context,
+    String? imageUrl,
+  ) async {
+    if (imageUrl == null || imageUrl.isEmpty) return;
+
+    try {
+      await precacheImage(CachedNetworkImageProvider(imageUrl), context);
+    } catch (e) {
+      debugPrint('Failed to precache share cover: $e');
+    }
+  }
+
+  static Future<Uint8List?> _capturePngBytes({
+    required GlobalKey repaintKey,
+    required double pixelRatio,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    await WidgetsBinding.instance.endOfFrame;
+    await Future<void>.delayed(const Duration(milliseconds: 32));
+
+    final boundary =
+        repaintKey.currentContext?.findRenderObject() as RenderRepaintBoundary?;
+    if (boundary == null) return null;
+
+    if (boundary.debugNeedsPaint) {
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      return _capturePngBytes(
+        repaintKey: repaintKey,
+        pixelRatio: pixelRatio,
+      );
+    }
+
+    final image = await boundary.toImage(pixelRatio: pixelRatio);
+    final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+    return byteData?.buffer.asUint8List();
+  }
+
+  static double _sharePixelRatio(MediaQueryData mediaQuery) {
+    final targetWidth = mediaQuery.size.width * mediaQuery.devicePixelRatio;
+    const logicalWidth =
+        BookShareCard.cardWidth > ReadingStatsShareCard.cardWidth
+            ? BookShareCard.cardWidth
+            : ReadingStatsShareCard.cardWidth;
+    return (targetWidth / logicalWidth).clamp(3.0, 6.0);
   }
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1624,11 +1624,41 @@
            "shareStatusPlanned": "To Read",
            "@shareStatusPlanned": {"description": "Planned status label on share card"},
 
-           "shareStatusWillRetry": "Re-reading",
-           "@shareStatusWillRetry": {"description": "Will retry status label on share card"},
+            "shareStatusWillRetry": "Re-reading",
+            "@shareStatusWillRetry": {"description": "Will retry status label on share card"},
 
-           "loginSocialGoogle": "Continue with Google",
-           "@loginSocialGoogle": {"description": "Continue with Google button"},
+            "shareBrandName": "Bookgolas",
+            "@shareBrandName": {"description": "Brand name shown in shared cards"},
+
+            "shareReadingRecordTitle": "My Reading Record",
+            "@shareReadingRecordTitle": {"description": "Title shown on the reading stats share card"},
+
+            "shareGoalAchievement": "Goal achievement",
+            "@shareGoalAchievement": {"description": "Label for the goal completion rate on the stats share card"},
+
+            "shareMostReadGenres": "Top genres",
+            "@shareMostReadGenres": {"description": "Label for the top genres row on the stats share card"},
+
+            "shareCompletedBooksLabel": "Books finished",
+            "@shareCompletedBooksLabel": {"description": "Label for completed books stat on the stats share card"},
+
+            "shareRecordsLabel": "Records",
+            "@shareRecordsLabel": {"description": "Label for the records stat on shared cards"},
+
+            "sharePhotosLabel": "Photos",
+            "@sharePhotosLabel": {"description": "Label for the photos stat on the stats share card"},
+
+            "shareStartedOn": "Started {date}",
+            "@shareStartedOn": {"description": "Short stat text for the reading start date on the book share card","placeholders": {"date": {}}},
+
+            "shareCompletedInDays": "Finished in {days} days",
+            "@shareCompletedInDays": {"description": "Short stat text for how many days it took to complete a book on the book share card","placeholders": {"days": {"type": "int"}}},
+
+            "shareHighlightCount": "{count} records",
+            "@shareHighlightCount": {"description": "Short stat text for the number of highlights or records on the book share card","placeholders": {"count": {"type": "int"}}},
+
+            "loginSocialGoogle": "Continue with Google",
+            "@loginSocialGoogle": {"description": "Continue with Google button"},
 
            "loginSocialApple": "Continue with Apple",
            "@loginSocialApple": {"description": "Continue with Apple button"},

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3165,8 +3165,37 @@
          "@shareStatusPlanned": {"description": "Planned status label on share card"},
 
          "shareStatusWillRetry": "다시 도전",
-         "shareStatusWillRetry": "다시 도전",
          "@shareStatusWillRetry": {"description": "Will retry status label on share card"},
+
+         "shareBrandName": "북골라스",
+         "@shareBrandName": {"description": "Brand name shown in shared cards"},
+
+         "shareReadingRecordTitle": "나의 독서 기록",
+         "@shareReadingRecordTitle": {"description": "Title shown on the reading stats share card"},
+
+         "shareGoalAchievement": "목표 달성률",
+         "@shareGoalAchievement": {"description": "Label for the goal completion rate on the stats share card"},
+
+         "shareMostReadGenres": "많이 읽은 장르",
+         "@shareMostReadGenres": {"description": "Label for the top genres row on the stats share card"},
+
+         "shareCompletedBooksLabel": "완독한 책",
+         "@shareCompletedBooksLabel": {"description": "Label for completed books stat on the stats share card"},
+
+         "shareRecordsLabel": "기록",
+         "@shareRecordsLabel": {"description": "Label for the records stat on shared cards"},
+
+         "sharePhotosLabel": "사진",
+         "@sharePhotosLabel": {"description": "Label for the photos stat on the stats share card"},
+
+         "shareStartedOn": "{date} 시작",
+         "@shareStartedOn": {"description": "Short stat text for the reading start date on the book share card","placeholders": {"date": {}}},
+
+         "shareCompletedInDays": "{days}일 완독",
+         "@shareCompletedInDays": {"description": "Short stat text for how many days it took to complete a book on the book share card","placeholders": {"days": {"type": "int"}}},
+
+         "shareHighlightCount": "{count} 기록",
+         "@shareHighlightCount": {"description": "Short stat text for the number of highlights or records on the book share card","placeholders": {"count": {"type": "int"}}},
 
          "loginSocialGoogle": "Google로 계속하기",
          "@loginSocialGoogle": {"description": "Continue with Google button"},

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -6689,6 +6689,66 @@ abstract class AppLocalizations {
   /// **'다시 도전'**
   String get shareStatusWillRetry;
 
+  /// Brand name shown in shared cards
+  ///
+  /// In ko, this message translates to:
+  /// **'북골라스'**
+  String get shareBrandName;
+
+  /// Title shown on the reading stats share card
+  ///
+  /// In ko, this message translates to:
+  /// **'나의 독서 기록'**
+  String get shareReadingRecordTitle;
+
+  /// Label for the goal completion rate on the stats share card
+  ///
+  /// In ko, this message translates to:
+  /// **'목표 달성률'**
+  String get shareGoalAchievement;
+
+  /// Label for the top genres row on the stats share card
+  ///
+  /// In ko, this message translates to:
+  /// **'많이 읽은 장르'**
+  String get shareMostReadGenres;
+
+  /// Label for completed books stat on the stats share card
+  ///
+  /// In ko, this message translates to:
+  /// **'완독한 책'**
+  String get shareCompletedBooksLabel;
+
+  /// Label for the records stat on shared cards
+  ///
+  /// In ko, this message translates to:
+  /// **'기록'**
+  String get shareRecordsLabel;
+
+  /// Label for the photos stat on the stats share card
+  ///
+  /// In ko, this message translates to:
+  /// **'사진'**
+  String get sharePhotosLabel;
+
+  /// Short stat text for the reading start date on the book share card
+  ///
+  /// In ko, this message translates to:
+  /// **'{date} 시작'**
+  String shareStartedOn(Object date);
+
+  /// Short stat text for how many days it took to complete a book on the book share card
+  ///
+  /// In ko, this message translates to:
+  /// **'{days}일 완독'**
+  String shareCompletedInDays(int days);
+
+  /// Short stat text for the number of highlights or records on the book share card
+  ///
+  /// In ko, this message translates to:
+  /// **'{count} 기록'**
+  String shareHighlightCount(int count);
+
   /// Continue with Google button
   ///
   /// In ko, this message translates to:

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -3662,6 +3662,42 @@ class AppLocalizationsEn extends AppLocalizations {
   String get shareStatusWillRetry => 'Re-reading';
 
   @override
+  String get shareBrandName => 'Bookgolas';
+
+  @override
+  String get shareReadingRecordTitle => 'My Reading Record';
+
+  @override
+  String get shareGoalAchievement => 'Goal achievement';
+
+  @override
+  String get shareMostReadGenres => 'Top genres';
+
+  @override
+  String get shareCompletedBooksLabel => 'Books finished';
+
+  @override
+  String get shareRecordsLabel => 'Records';
+
+  @override
+  String get sharePhotosLabel => 'Photos';
+
+  @override
+  String shareStartedOn(Object date) {
+    return 'Started $date';
+  }
+
+  @override
+  String shareCompletedInDays(int days) {
+    return 'Finished in $days days';
+  }
+
+  @override
+  String shareHighlightCount(int count) {
+    return '$count records';
+  }
+
+  @override
   String get loginSocialGoogle => 'Continue with Google';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -3576,6 +3576,42 @@ class AppLocalizationsKo extends AppLocalizations {
   String get shareStatusWillRetry => '다시 도전';
 
   @override
+  String get shareBrandName => '북골라스';
+
+  @override
+  String get shareReadingRecordTitle => '나의 독서 기록';
+
+  @override
+  String get shareGoalAchievement => '목표 달성률';
+
+  @override
+  String get shareMostReadGenres => '많이 읽은 장르';
+
+  @override
+  String get shareCompletedBooksLabel => '완독한 책';
+
+  @override
+  String get shareRecordsLabel => '기록';
+
+  @override
+  String get sharePhotosLabel => '사진';
+
+  @override
+  String shareStartedOn(Object date) {
+    return '$date 시작';
+  }
+
+  @override
+  String shareCompletedInDays(int days) {
+    return '$days일 완독';
+  }
+
+  @override
+  String shareHighlightCount(int count) {
+    return '$count 기록';
+  }
+
+  @override
   String get loginSocialGoogle => 'Google로 계속하기';
 
   @override

--- a/app/lib/ui/book_detail/widgets/book_share_card.dart
+++ b/app/lib/ui/book_detail/widgets/book_share_card.dart
@@ -4,6 +4,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:intl/intl.dart';
 
 import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/l10n/app_localizations.dart';
 import 'package:book_golas/ui/core/theme/design_system.dart';
 
 class BookShareCard extends StatelessWidget {
@@ -29,6 +30,8 @@ class BookShareCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return SizedBox(
       width: cardWidth,
       height: cardHeight,
@@ -45,7 +48,7 @@ class BookShareCard extends StatelessWidget {
             const SizedBox(height: 28),
             _buildCoverWithGlow(),
             const SizedBox(height: 18),
-            _buildStatusBadge(),
+            _buildStatusBadge(l10n),
             const SizedBox(height: 10),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 32),
@@ -54,12 +57,12 @@ class BookShareCard extends StatelessWidget {
             const SizedBox(height: 16),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 28),
-              child: _buildMainContent(),
+              child: _buildMainContent(l10n),
             ),
             const Spacer(),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 28),
-              child: _buildMiniStats(),
+              child: _buildMiniStats(l10n),
             ),
             const SizedBox(height: 14),
             Padding(
@@ -69,7 +72,7 @@ class BookShareCard extends StatelessWidget {
             const SizedBox(height: 14),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 28),
-              child: _buildFooter(),
+              child: _buildFooter(l10n),
             ),
             const SizedBox(height: 20),
           ],
@@ -79,7 +82,7 @@ class BookShareCard extends StatelessWidget {
   }
 
   Widget _buildCoverWithGlow() {
-    final config = _statusConfig;
+    final config = _statusConfig(null);
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(10),
@@ -124,8 +127,8 @@ class BookShareCard extends StatelessWidget {
     );
   }
 
-  Widget _buildStatusBadge() {
-    final config = _statusConfig;
+  Widget _buildStatusBadge(AppLocalizations? l10n) {
+    final config = _statusConfig(l10n);
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
       decoration: BoxDecoration(
@@ -188,7 +191,7 @@ class BookShareCard extends StatelessWidget {
     );
   }
 
-  Widget _buildMainContent() {
+  Widget _buildMainContent(AppLocalizations? l10n) {
     switch (book.status) {
       case 'reading':
         return _buildReadingProgress();
@@ -346,8 +349,8 @@ class BookShareCard extends StatelessWidget {
     );
   }
 
-  Widget _buildMiniStats() {
-    final stats = _buildStats();
+  Widget _buildMiniStats(AppLocalizations? l10n) {
+    final stats = _buildStats(l10n);
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: stats.asMap().entries.map((entry) {
@@ -379,7 +382,7 @@ class BookShareCard extends StatelessWidget {
     );
   }
 
-  Widget _buildFooter() {
+  Widget _buildFooter(AppLocalizations? l10n) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
@@ -395,9 +398,9 @@ class BookShareCard extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 7),
-            const Text(
-              '북골라스',
-              style: TextStyle(
+            Text(
+              l10n?.shareBrandName ?? '북골라스',
+              style: const TextStyle(
                 color: _textSecondary,
                 fontSize: 13,
                 fontWeight: FontWeight.w600,
@@ -414,27 +417,40 @@ class BookShareCard extends StatelessWidget {
     );
   }
 
-  List<_StatItem> _buildStats() {
+  List<_StatItem> _buildStats(AppLocalizations? l10n) {
     switch (book.status) {
       case 'reading':
         return [
           _StatItem(
             icon: '📅',
-            value: '${DateFormat('MM.dd').format(book.startDate)} 시작',
+            value: l10n?.shareStartedOn(
+                    DateFormat('MM.dd').format(book.startDate)) ??
+                '${DateFormat('MM.dd').format(book.startDate)} 시작',
           ),
-          _StatItem(icon: '💡', value: '$highlightCount 기록'),
+          _StatItem(
+            icon: '💡',
+            value: l10n?.shareHighlightCount(highlightCount) ??
+                '$highlightCount 기록',
+          ),
         ];
       case 'completed':
         final readDays = book.updatedAt != null
             ? book.updatedAt!.difference(book.startDate).inDays + 1
             : DateTime.now().difference(book.startDate).inDays + 1;
         return [
-          _StatItem(icon: '📅', value: '$readDays일 완독'),
+          _StatItem(
+            icon: '📅',
+            value: l10n?.shareCompletedInDays(readDays) ?? '$readDays일 완독',
+          ),
           _StatItem(
             icon: '📄',
             value: book.totalPages > 0 ? '${book.totalPages}p' : '-',
           ),
-          _StatItem(icon: '💡', value: '$highlightCount 기록'),
+          _StatItem(
+            icon: '💡',
+            value: l10n?.shareHighlightCount(highlightCount) ??
+                '$highlightCount 기록',
+          ),
         ];
       case 'planned':
         return [
@@ -468,35 +484,35 @@ class BookShareCard extends StatelessWidget {
     }
   }
 
-  _StatusConfig get _statusConfig {
+  _StatusConfig _statusConfig(AppLocalizations? l10n) {
     switch (book.status) {
       case 'reading':
-        return const _StatusConfig(
-          label: '독서 중',
+        return _StatusConfig(
+          label: l10n?.shareStatusReading ?? '독서 중',
           icon: CupertinoIcons.book,
           color: BLabColors.primary,
         );
       case 'completed':
-        return const _StatusConfig(
-          label: '완독',
+        return _StatusConfig(
+          label: l10n?.shareStatusCompleted ?? '완독',
           icon: CupertinoIcons.checkmark_circle_fill,
           color: BLabColors.success,
         );
       case 'planned':
-        return const _StatusConfig(
-          label: '읽을 예정',
+        return _StatusConfig(
+          label: l10n?.shareStatusPlanned ?? '읽을 예정',
           icon: CupertinoIcons.bookmark_fill,
           color: BLabColors.warning,
         );
       case 'will_retry':
-        return const _StatusConfig(
-          label: '다시 도전',
+        return _StatusConfig(
+          label: l10n?.shareStatusWillRetry ?? '다시 도전',
           icon: CupertinoIcons.arrow_2_circlepath,
           color: BLabColors.purple,
         );
       default:
-        return const _StatusConfig(
-          label: '독서 중',
+        return _StatusConfig(
+          label: l10n?.shareStatusReading ?? '독서 중',
           icon: CupertinoIcons.book,
           color: BLabColors.primary,
         );

--- a/app/lib/ui/reading_chart/widgets/reading_stats_share_card.dart
+++ b/app/lib/ui/reading_chart/widgets/reading_stats_share_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import 'package:book_golas/l10n/app_localizations.dart';
 import 'package:book_golas/ui/core/theme/design_system.dart';
 import 'package:book_golas/ui/reading_chart/view_model/reading_chart_view_model.dart';
 
@@ -8,7 +9,7 @@ class ReadingStatsShareCard extends StatelessWidget {
   final ReadingChartViewModel vm;
 
   static const double cardWidth = 400.0;
-  static const double cardHeight = 520.0;
+  static const double cardHeight = 560.0;
 
   static const Color _bgColor = Color(0xFF121418);
   static const Color _surfaceColor = Color(0xFF1C1F26);
@@ -21,6 +22,8 @@ class ReadingStatsShareCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
     return SizedBox(
       width: cardWidth,
       height: cardHeight,
@@ -30,54 +33,59 @@ class ReadingStatsShareCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _buildHeader(),
+            _buildHeader(l10n),
             const SizedBox(height: 22),
             _buildDivider(),
             const SizedBox(height: 22),
-            _buildMainStats(),
+            _buildMainStats(l10n),
             const SizedBox(height: 20),
-            _buildGoalBar(),
+            _buildGoalBar(l10n),
             const SizedBox(height: 20),
-            _buildGenreRow(),
+            _buildGenreRow(l10n),
             const Spacer(),
             _buildDivider(),
             const SizedBox(height: 16),
-            _buildFooter(),
+            _buildFooter(l10n),
           ],
         ),
       ),
     );
   }
 
-  Widget _buildHeader() {
+  Widget _buildHeader(AppLocalizations? l10n) {
     final year = DateTime.now().year;
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              '$year',
-              style: const TextStyle(
-                color: BLabColors.primary,
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-                letterSpacing: 1.5,
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '$year',
+                style: const TextStyle(
+                  color: BLabColors.primary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 1.5,
+                ),
               ),
-            ),
-            const SizedBox(height: 4),
-            const Text(
-              '나의 독서 기록',
-              style: TextStyle(
-                color: _textPrimary,
-                fontSize: 22,
-                fontWeight: FontWeight.w800,
+              const SizedBox(height: 4),
+              Text(
+                l10n?.shareReadingRecordTitle ?? '나의 독서 기록',
+                style: const TextStyle(
+                  color: _textPrimary,
+                  fontSize: 22,
+                  fontWeight: FontWeight.w800,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
               ),
-            ),
-          ],
+            ],
+          ),
         ),
+        const SizedBox(width: 16),
         Container(
           width: 44,
           height: 44,
@@ -100,14 +108,14 @@ class ReadingStatsShareCard extends StatelessWidget {
     return Container(height: 1, color: _dividerColor);
   }
 
-  Widget _buildMainStats() {
+  Widget _buildMainStats(AppLocalizations? l10n) {
     return Row(
       children: [
         Expanded(
           child: _buildMainStatBox(
             icon: '✅',
             value: '${vm.completedBooks}',
-            label: '완독한 책',
+            label: l10n?.shareCompletedBooksLabel ?? '완독한 책',
             color: BLabColors.success,
           ),
         ),
@@ -116,7 +124,7 @@ class ReadingStatsShareCard extends StatelessWidget {
           child: _buildMainStatBox(
             icon: '💡',
             value: '${vm.totalHighlights + vm.totalNotes}',
-            label: '기록',
+            label: l10n?.shareRecordsLabel ?? '기록',
             color: BLabColors.primary,
           ),
         ),
@@ -125,7 +133,7 @@ class ReadingStatsShareCard extends StatelessWidget {
           child: _buildMainStatBox(
             icon: '📸',
             value: '${vm.totalPhotos}',
-            label: '사진',
+            label: l10n?.sharePhotosLabel ?? '사진',
             color: BLabColors.warningAlt,
           ),
         ),
@@ -172,7 +180,7 @@ class ReadingStatsShareCard extends StatelessWidget {
     );
   }
 
-  Widget _buildGoalBar() {
+  Widget _buildGoalBar(AppLocalizations? l10n) {
     final goalRate = vm.goalRate.clamp(0.0, 1.0);
     final percent = (goalRate * 100).toStringAsFixed(0);
 
@@ -188,13 +196,16 @@ class ReadingStatsShareCard extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              const Row(
+              Row(
                 children: [
-                  Text('🎯', style: TextStyle(fontSize: 14)),
-                  SizedBox(width: 6),
+                  const Text('🎯', style: TextStyle(fontSize: 14)),
+                  const SizedBox(width: 6),
                   Text(
-                    '목표 달성률',
-                    style: TextStyle(color: _textSecondary, fontSize: 13),
+                    l10n?.shareGoalAchievement ?? '목표 달성률',
+                    style: const TextStyle(
+                      color: _textSecondary,
+                      fontSize: 13,
+                    ),
                   ),
                 ],
               ),
@@ -224,7 +235,7 @@ class ReadingStatsShareCard extends StatelessWidget {
     );
   }
 
-  Widget _buildGenreRow() {
+  Widget _buildGenreRow(AppLocalizations? l10n) {
     if (vm.genreDistribution.isEmpty) return const SizedBox.shrink();
 
     final sorted = vm.genreDistribution.entries.toList()
@@ -235,37 +246,40 @@ class ReadingStatsShareCard extends StatelessWidget {
       children: [
         const Text('🏷️', style: TextStyle(fontSize: 14)),
         const SizedBox(width: 8),
-        const Text(
-          '많이 읽은 장르',
-          style: TextStyle(color: _textSecondary, fontSize: 13),
+        Text(
+          l10n?.shareMostReadGenres ?? '많이 읽은 장르',
+          style: const TextStyle(color: _textSecondary, fontSize: 13),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
         ),
         const SizedBox(width: 12),
         Expanded(
-          child: Row(
+          child: Wrap(
+            spacing: 6,
+            runSpacing: 6,
             children: topGenres.asMap().entries.map((entry) {
               final color = BLabColors
                   .chartColors[entry.key % BLabColors.chartColors.length];
-              return Padding(
-                padding: const EdgeInsets.only(right: 6),
-                child: Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-                  decoration: BoxDecoration(
-                    color: color.withValues(alpha: 0.15),
-                    borderRadius: BorderRadius.circular(20),
-                    border: Border.all(
-                        color: color.withValues(alpha: 0.3), width: 1),
+              return Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                decoration: BoxDecoration(
+                  color: color.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(20),
+                  border: Border.all(
+                    color: color.withValues(alpha: 0.3),
+                    width: 1,
                   ),
-                  child: Text(
-                    entry.value.key,
-                    style: TextStyle(
-                      color: color,
-                      fontSize: 11,
-                      fontWeight: FontWeight.w600,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
+                ),
+                child: Text(
+                  entry.value.key,
+                  style: TextStyle(
+                    color: color,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
                   ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
               );
             }).toList(),
@@ -275,7 +289,7 @@ class ReadingStatsShareCard extends StatelessWidget {
     );
   }
 
-  Widget _buildFooter() {
+  Widget _buildFooter(AppLocalizations? l10n) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
@@ -291,9 +305,9 @@ class ReadingStatsShareCard extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 7),
-            const Text(
-              '북골라스',
-              style: TextStyle(
+            Text(
+              l10n?.shareBrandName ?? '북골라스',
+              style: const TextStyle(
                 color: _textSecondary,
                 fontSize: 13,
                 fontWeight: FontWeight.w500,

--- a/app/test/ui/book_detail/widgets/book_share_card_test.dart
+++ b/app/test/ui/book_detail/widgets/book_share_card_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_detail/widgets/book_share_card.dart';
+
+void main() {
+  group('BookShareCard', () {
+    testWidgets('renders localized english share content', (
+      WidgetTester tester,
+    ) async {
+      final book = Book(
+        id: 'book-1',
+        title: 'Atomic Habits',
+        author: 'James Clear',
+        startDate: DateTime(2026, 3, 1),
+        targetDate: DateTime(2026, 3, 31),
+        currentPage: 120,
+        totalPages: 240,
+        status: BookStatus.reading.value,
+      );
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          locale: const Locale('en'),
+          child: BookShareCard(book: book, highlightCount: 7),
+        ),
+      );
+
+      expect(find.text('Reading'), findsOneWidget);
+      expect(find.text('Started 03.01'), findsOneWidget);
+      expect(find.text('7 records'), findsOneWidget);
+      expect(find.text('Bookgolas'), findsOneWidget);
+    });
+
+    testWidgets('renders localized korean completion content', (
+      WidgetTester tester,
+    ) async {
+      final book = Book(
+        id: 'book-2',
+        title: '아주 작은 습관의 힘',
+        author: '제임스 클리어',
+        startDate: DateTime(2026, 3, 1),
+        targetDate: DateTime(2026, 3, 31),
+        updatedAt: DateTime(2026, 3, 5),
+        totalPages: 352,
+        status: BookStatus.completed.value,
+        rating: 5,
+        review: '작은 습관이 큰 변화를 만든다는 점이 인상적이었다.',
+      );
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          locale: const Locale('ko'),
+          child: BookShareCard(book: book, highlightCount: 12),
+        ),
+      );
+
+      expect(find.text('완독'), findsOneWidget);
+      expect(find.text('5일 완독'), findsOneWidget);
+      expect(find.text('12 기록'), findsOneWidget);
+      expect(find.text('북골라스'), findsOneWidget);
+    });
+  });
+}
+
+Widget _buildTestApp({required Locale locale, required Widget child}) {
+  return MaterialApp(
+    locale: locale,
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: Center(child: child)),
+  );
+}

--- a/app/test/ui/reading_chart/widgets/reading_stats_share_card_test.dart
+++ b/app/test/ui/reading_chart/widgets/reading_stats_share_card_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/reading_chart/view_model/reading_chart_view_model.dart';
+import 'package:book_golas/ui/reading_chart/widgets/reading_stats_share_card.dart';
+
+class _MockReadingChartViewModel extends Mock
+    implements ReadingChartViewModel {}
+
+void main() {
+  group('ReadingStatsShareCard', () {
+    testWidgets('renders localized english labels',
+        (WidgetTester tester) async {
+      final vm = _MockReadingChartViewModel();
+      when(() => vm.completedBooks).thenReturn(8);
+      when(() => vm.totalHighlights).thenReturn(14);
+      when(() => vm.totalNotes).thenReturn(6);
+      when(() => vm.totalPhotos).thenReturn(3);
+      when(() => vm.goalRate).thenReturn(0.7);
+      when(() => vm.genreDistribution).thenReturn({
+        'Essay': 4,
+        'Humanities': 2,
+        'Science': 1,
+      });
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          locale: const Locale('en'),
+          child: ReadingStatsShareCard(vm: vm),
+        ),
+      );
+
+      expect(find.text('My Reading Record'), findsOneWidget);
+      expect(find.text('Books finished'), findsOneWidget);
+      expect(find.text('Records'), findsOneWidget);
+      expect(find.text('Photos'), findsOneWidget);
+      expect(find.text('Goal achievement'), findsOneWidget);
+      expect(find.text('Top genres'), findsOneWidget);
+      expect(find.text('Bookgolas'), findsOneWidget);
+    });
+  });
+}
+
+Widget _buildTestApp({required Locale locale, required Widget child}) {
+  return MaterialApp(
+    locale: locale,
+    localizationsDelegates: const [
+      AppLocalizations.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: Center(child: child)),
+  );
+}


### PR DESCRIPTION
## 📌 Summary

> SNS 공유 카드의 이미지 품질과 다국어 완성도를 개선했습니다.

## 📋 Changes

- `./app/lib/data/services/book_share_service.dart`: 공유 캡처 로직을 공통 helper로 정리하고 precache, frame wait, 동적 pixel ratio를 적용했습니다.
- `./app/lib/ui/book_detail/widgets/book_share_card.dart`: 공유 카드 텍스트를 l10n 기반으로 전환하고 공유용 메타 정보 표기를 정리했습니다.
- `./app/lib/ui/reading_chart/widgets/reading_stats_share_card.dart`: 영어 공유 카드에서 발생하던 레이아웃 overflow를 수정하고 l10n을 적용했습니다.
- `./app/lib/l10n/app_en.arb`: 공유 카드용 영문 번역 키를 추가했습니다.
- `./app/lib/l10n/app_ko.arb`: 공유 카드용 국문 번역 키를 추가하고 중복 키를 정리했습니다.
- `./app/test/ui/book_detail/widgets/book_share_card_test.dart`: 책 공유 카드 다국어 렌더링 테스트를 추가했습니다.
- `./app/test/ui/reading_chart/widgets/reading_stats_share_card_test.dart`: 통계 공유 카드 다국어 및 레이아웃 테스트를 추가했습니다.

## 🧠 Context & Background

> 기존 SNS 공유 이미지는 캡처 타이밍과 해상도 처리 한계로 결과물이 아쉽고, 카드 내부 문구도 다국어 적용이 되지 않아 이슈 `BOK-364`를 진행했습니다.

## ✅ How to Test

1. `cd app && flutter analyze lib/data/services/book_share_service.dart lib/ui/book_detail/widgets/book_share_card.dart lib/ui/reading_chart/widgets/reading_stats_share_card.dart test/ui/book_detail/widgets/book_share_card_test.dart test/ui/reading_chart/widgets/reading_stats_share_card_test.dart`
2. `cd app && flutter test test/ui/book_detail/widgets/book_share_card_test.dart test/ui/reading_chart/widgets/reading_stats_share_card_test.dart`
3. 앱에서 책 상세 화면과 독서 차트 화면의 공유 버튼을 눌러 생성된 이미지를 확인합니다.
4. 기기 언어를 한국어/영어로 바꿔 공유 카드 문구와 레이아웃이 자연스러운지 확인합니다.

## 🔗 Related Issues

- Related: BOK-364

## 🙌 Additional Notes (Optional)

> 로컬에서 `pod install`은 worktree 환경의 CocoaPods 권한 문제로 재현 실패했지만, 공유 관련 Flutter analyze/test와 bundle build는 모두 통과했습니다.