### PR TITLE
daily/2026-03-20

### DIFF
--- a/app/lib/ui/book_detail/widgets/floating_action_bar.dart
+++ b/app/lib/ui/book_detail/widgets/floating_action_bar.dart
@@ -50,17 +50,14 @@ class FloatingActionBar extends StatelessWidget {
   }
 }
 
-class _ReadingModeBar extends StatelessWidget {
+class _ReadingModeBar extends StatefulWidget {
   final bool isDark;
   final VoidCallback? onUpdatePageTap;
   final VoidCallback onAddMemorablePageTap;
   final VoidCallback? onRecallSearchTap;
   final VoidCallback? onTimerTap;
 
-  final GlobalKey _startReadingKey = GlobalKey();
-  final GlobalKey _recordKey = GlobalKey();
-
-  _ReadingModeBar({
+  const _ReadingModeBar({
     required this.isDark,
     this.onUpdatePageTap,
     required this.onAddMemorablePageTap,
@@ -68,11 +65,28 @@ class _ReadingModeBar extends StatelessWidget {
     this.onTimerTap,
   });
 
-  void _onStartReadingTap(BuildContext context) {
+  @override
+  State<_ReadingModeBar> createState() => _ReadingModeBarState();
+}
+
+class _ReadingModeBarState extends State<_ReadingModeBar> {
+  final GlobalKey _startReadingKey = GlobalKey();
+  final GlobalKey _recordKey = GlobalKey();
+
+  FloatingContextDropdownController<String>? _activeMenuController;
+
+  @override
+  void dispose() {
+    _activeMenuController?.dismiss();
+    super.dispose();
+  }
+
+  List<FloatingContextDropdownItem<String>> _buildStartReadingItems(
+      BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final items = <FloatingContextDropdownItem<String>>[];
 
-    if (onTimerTap != null) {
+    if (widget.onTimerTap != null) {
       items.add(FloatingContextDropdownItem(
         icon: CupertinoIcons.timer,
         label: l10n.bottomBarTimerStart,
@@ -80,7 +94,7 @@ class _ReadingModeBar extends StatelessWidget {
       ));
     }
 
-    if (onUpdatePageTap != null) {
+    if (widget.onUpdatePageTap != null) {
       items.add(FloatingContextDropdownItem(
         icon: CupertinoIcons.book_fill,
         label: l10n.bottomBarPageUpdate,
@@ -88,41 +102,11 @@ class _ReadingModeBar extends StatelessWidget {
       ));
     }
 
-    if (items.length == 1) {
-      if (items.first.value == 'timer') {
-        onTimerTap?.call();
-      } else {
-        onUpdatePageTap?.call();
-      }
-      return;
-    }
-
-    if (items.isEmpty) return;
-
-    final renderBox =
-        _startReadingKey.currentContext?.findRenderObject() as RenderBox?;
-    if (renderBox == null) return;
-    final position = renderBox.localToGlobal(Offset.zero);
-
-    showFloatingContextDropdown<String>(
-      context,
-      buttonPosition: position,
-      buttonWidth: renderBox.size.width,
-      buttonHeight: renderBox.size.height,
-      alignment: Alignment.bottomLeft,
-      items: items,
-      onSelected: (value) {
-        switch (value) {
-          case 'timer':
-            onTimerTap?.call();
-          case 'page_update':
-            onUpdatePageTap?.call();
-        }
-      },
-    );
+    return items;
   }
 
-  void _onRecordTap(BuildContext context) {
+  List<FloatingContextDropdownItem<String>> _buildRecordItems(
+      BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final items = <FloatingContextDropdownItem<String>>[
       FloatingContextDropdownItem(
@@ -132,7 +116,7 @@ class _ReadingModeBar extends StatelessWidget {
       ),
     ];
 
-    if (onRecallSearchTap != null) {
+    if (widget.onRecallSearchTap != null) {
       items.add(FloatingContextDropdownItem(
         icon: Icons.auto_awesome,
         label: l10n.bottomBarAiRecordSearch,
@@ -140,32 +124,144 @@ class _ReadingModeBar extends StatelessWidget {
       ));
     }
 
-    if (items.length == 1) {
-      onAddMemorablePageTap();
-      return;
+    return items;
+  }
+
+  void _handleStartReadingSelection(String value) {
+    switch (value) {
+      case 'timer':
+        widget.onTimerTap?.call();
+        return;
+      case 'page_update':
+        widget.onUpdatePageTap?.call();
+        return;
     }
+  }
 
+  void _handleRecordSelection(String value) {
+    switch (value) {
+      case 'add_record':
+        widget.onAddMemorablePageTap();
+        return;
+      case 'ai_search':
+        widget.onRecallSearchTap?.call();
+        return;
+    }
+  }
+
+  void _dismissActiveMenu() {
+    _activeMenuController?.dismiss();
+    _activeMenuController = null;
+  }
+
+  void _showMenu({
+    required BuildContext context,
+    required GlobalKey buttonKey,
+    required Alignment alignment,
+    required List<FloatingContextDropdownItem<String>> items,
+    required ValueChanged<String> onSelected,
+  }) {
     final renderBox =
-        _recordKey.currentContext?.findRenderObject() as RenderBox?;
+        buttonKey.currentContext?.findRenderObject() as RenderBox?;
     if (renderBox == null) return;
-    final position = renderBox.localToGlobal(Offset.zero);
 
-    showFloatingContextDropdown<String>(
+    final position = renderBox.localToGlobal(Offset.zero);
+    _dismissActiveMenu();
+    late final FloatingContextDropdownController<String> controller;
+    controller = showFloatingContextDropdown<String>(
       context,
       buttonPosition: position,
       buttonWidth: renderBox.size.width,
       buttonHeight: renderBox.size.height,
-      alignment: Alignment.bottomRight,
+      alignment: alignment,
       items: items,
-      onSelected: (value) {
-        switch (value) {
-          case 'add_record':
-            onAddMemorablePageTap();
-          case 'ai_search':
-            onRecallSearchTap?.call();
+      onDismissed: () {
+        if (identical(_activeMenuController, controller)) {
+          _activeMenuController = null;
         }
       },
+      onSelected: (value) {
+        _activeMenuController = null;
+        onSelected(value);
+      },
     );
+    _activeMenuController = controller;
+  }
+
+  void _onStartReadingTap(BuildContext context) {
+    final items = _buildStartReadingItems(context);
+    if (items.isEmpty) return;
+
+    if (items.length == 1) {
+      _handleStartReadingSelection(items.first.value);
+      return;
+    }
+
+    _showMenu(
+      context: context,
+      buttonKey: _startReadingKey,
+      alignment: Alignment.bottomRight,
+      items: items,
+      onSelected: _handleStartReadingSelection,
+    );
+  }
+
+  void _onRecordTap(BuildContext context) {
+    final items = _buildRecordItems(context);
+
+    if (items.length == 1) {
+      widget.onAddMemorablePageTap();
+      return;
+    }
+
+    _showMenu(
+      context: context,
+      buttonKey: _recordKey,
+      alignment: Alignment.bottomLeft,
+      items: items,
+      onSelected: _handleRecordSelection,
+    );
+  }
+
+  void _onStartReadingLongPressStart(
+    BuildContext context,
+    LongPressStartDetails details,
+  ) {
+    final items = _buildStartReadingItems(context);
+    if (items.length <= 1) return;
+
+    _showMenu(
+      context: context,
+      buttonKey: _startReadingKey,
+      alignment: Alignment.bottomRight,
+      items: items,
+      onSelected: _handleStartReadingSelection,
+    );
+  }
+
+  void _onRecordLongPressStart(
+    BuildContext context,
+    LongPressStartDetails details,
+  ) {
+    final items = _buildRecordItems(context);
+    if (items.length <= 1) return;
+
+    _showMenu(
+      context: context,
+      buttonKey: _recordKey,
+      alignment: Alignment.bottomLeft,
+      items: items,
+      onSelected: _handleRecordSelection,
+    );
+  }
+
+  void _onLongPressMoveUpdate(LongPressMoveUpdateDetails details) {
+    _activeMenuController?.updateDragPosition(details.globalPosition);
+  }
+
+  void _onLongPressEnd(LongPressEndDetails details) {
+    final controller = _activeMenuController;
+    controller?.completeDragSelection();
   }
 
   @override
@@ -175,24 +271,32 @@ class _ReadingModeBar extends StatelessWidget {
     return Row(
       children: [
         Expanded(
-          flex: 7,
+          flex: 3,
           child: _GlassPillButton(
-            key: _startReadingKey,
-            isDark: isDark,
-            icon: CupertinoIcons.book_fill,
-            label: l10n.bottomBarStartReading,
-            onTap: () => _onStartReadingTap(context),
+            key: _recordKey,
+            isDark: widget.isDark,
+            icon: CupertinoIcons.pencil,
+            label: l10n.bottomBarRecord,
+            onTap: () => _onRecordTap(context),
+            onLongPressStart: (details) =>
+                _onRecordLongPressStart(context, details),
+            onLongPressMoveUpdate: _onLongPressMoveUpdate,
+            onLongPressEnd: _onLongPressEnd,
           ),
         ),
         const SizedBox(width: 12),
         Expanded(
-          flex: 3,
+          flex: 7,
           child: _GlassPillButton(
-            key: _recordKey,
-            isDark: isDark,
-            icon: CupertinoIcons.pencil,
-            label: l10n.bottomBarRecord,
-            onTap: () => _onRecordTap(context),
+            key: _startReadingKey,
+            isDark: widget.isDark,
+            icon: CupertinoIcons.book_fill,
+            label: l10n.bottomBarStartReading,
+            onTap: () => _onStartReadingTap(context),
+            onLongPressStart: (details) =>
+                _onStartReadingLongPressStart(context, details),
+            onLongPressMoveUpdate: _onLongPressMoveUpdate,
+            onLongPressEnd: _onLongPressEnd,
           ),
         ),
       ],
@@ -200,20 +304,34 @@ class _ReadingModeBar extends StatelessWidget {
   }
 }
 
-class _CompletedModeBar extends StatelessWidget {
+class _CompletedModeBar extends StatefulWidget {
   final bool isDark;
   final VoidCallback onAddMemorablePageTap;
   final VoidCallback? onRecallSearchTap;
 
-  final GlobalKey _recordKey = GlobalKey();
-
-  _CompletedModeBar({
+  const _CompletedModeBar({
     required this.isDark,
     required this.onAddMemorablePageTap,
     this.onRecallSearchTap,
   });
 
-  void _onRecordTap(BuildContext context) {
+  @override
+  State<_CompletedModeBar> createState() => _CompletedModeBarState();
+}
+
+class _CompletedModeBarState extends State<_CompletedModeBar> {
+  final GlobalKey _recordKey = GlobalKey();
+
+  FloatingContextDropdownController<String>? _activeMenuController;
+
+  @override
+  void dispose() {
+    _activeMenuController?.dismiss();
+    super.dispose();
+  }
+
+  List<FloatingContextDropdownItem<String>> _buildRecordItems(
+      BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final items = <FloatingContextDropdownItem<String>>[
       FloatingContextDropdownItem(
@@ -223,7 +341,7 @@ class _CompletedModeBar extends StatelessWidget {
       ),
     ];
 
-    if (onRecallSearchTap != null) {
+    if (widget.onRecallSearchTap != null) {
       items.add(FloatingContextDropdownItem(
         icon: Icons.auto_awesome,
         label: l10n.bottomBarAiRecordSearch,
@@ -231,32 +349,76 @@ class _CompletedModeBar extends StatelessWidget {
       ));
     }
 
+    return items;
+  }
+
+  void _handleRecordSelection(String value) {
+    switch (value) {
+      case 'add_record':
+        widget.onAddMemorablePageTap();
+        return;
+      case 'ai_search':
+        widget.onRecallSearchTap?.call();
+        return;
+    }
+  }
+
+  void _dismissActiveMenu() {
+    _activeMenuController?.dismiss();
+    _activeMenuController = null;
+  }
+
+  void _showRecordMenu(BuildContext context) {
+    final items = _buildRecordItems(context);
+
     if (items.length == 1) {
-      onAddMemorablePageTap();
+      widget.onAddMemorablePageTap();
       return;
     }
 
     final renderBox =
         _recordKey.currentContext?.findRenderObject() as RenderBox?;
     if (renderBox == null) return;
-    final position = renderBox.localToGlobal(Offset.zero);
 
-    showFloatingContextDropdown<String>(
+    final position = renderBox.localToGlobal(Offset.zero);
+    _dismissActiveMenu();
+    late final FloatingContextDropdownController<String> controller;
+    controller = showFloatingContextDropdown<String>(
       context,
       buttonPosition: position,
       buttonWidth: renderBox.size.width,
       buttonHeight: renderBox.size.height,
       alignment: Alignment.bottomLeft,
       items: items,
-      onSelected: (value) {
-        switch (value) {
-          case 'add_record':
-            onAddMemorablePageTap();
-          case 'ai_search':
-            onRecallSearchTap?.call();
+      onDismissed: () {
+        if (identical(_activeMenuController, controller)) {
+          _activeMenuController = null;
         }
       },
+      onSelected: (value) {
+        _activeMenuController = null;
+        _handleRecordSelection(value);
+      },
     );
+    _activeMenuController = controller;
+  }
+
+  void _onRecordLongPressStart(
+    BuildContext context,
+    LongPressStartDetails details,
+  ) {
+    final items = _buildRecordItems(context);
+    if (items.length <= 1) return;
+    _showRecordMenu(context);
+  }
+
+  void _onLongPressMoveUpdate(LongPressMoveUpdateDetails details) {
+    _activeMenuController?.updateDragPosition(details.globalPosition);
+  }
+
+  void _onLongPressEnd(LongPressEndDetails details) {
+    final controller = _activeMenuController;
+    controller?.completeDragSelection();
   }
 
   @override
@@ -269,10 +431,14 @@ class _CompletedModeBar extends StatelessWidget {
           flex: 7,
           child: _GlassPillButton(
             key: _recordKey,
-            isDark: isDark,
+            isDark: widget.isDark,
             icon: CupertinoIcons.pencil,
             label: l10n.bottomBarRecord,
-            onTap: () => _onRecordTap(context),
+            onTap: () => _showRecordMenu(context),
+            onLongPressStart: (details) =>
+                _onRecordLongPressStart(context, details),
+            onLongPressMoveUpdate: _onLongPressMoveUpdate,
+            onLongPressEnd: _onLongPressEnd,
           ),
         ),
       ],
@@ -285,6 +451,9 @@ class _GlassPillButton extends StatelessWidget {
   final IconData icon;
   final String label;
   final VoidCallback onTap;
+  final GestureLongPressStartCallback? onLongPressStart;
+  final GestureLongPressMoveUpdateCallback? onLongPressMoveUpdate;
+  final GestureLongPressEndCallback? onLongPressEnd;
 
   const _GlassPillButton({
     super.key,
@@ -292,46 +461,53 @@ class _GlassPillButton extends StatelessWidget {
     required this.icon,
     required this.label,
     required this.onTap,
+    this.onLongPressStart,
+    this.onLongPressMoveUpdate,
+    this.onLongPressEnd,
   });
 
   @override
   Widget build(BuildContext context) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(100),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: onTap,
-            borderRadius: BorderRadius.circular(100),
-            child: Container(
-              height: 62,
-              decoration: BoxDecoration(
+    return GestureDetector(
+      onTap: onTap,
+      onLongPressStart: onLongPressStart,
+      onLongPressMoveUpdate: onLongPressMoveUpdate,
+      onLongPressEnd: onLongPressEnd,
+      behavior: HitTestBehavior.opaque,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(100),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
+          child: Container(
+            height: 62,
+            decoration: BoxDecoration(
+              color: isDark
+                  ? Colors.white.withValues(alpha: 0.12)
+                  : Colors.black.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(100),
+              border: Border.all(
                 color: isDark
-                    ? Colors.white.withValues(alpha: 0.12)
+                    ? Colors.white.withValues(alpha: 0.15)
                     : Colors.black.withValues(alpha: 0.08),
-                borderRadius: BorderRadius.circular(100),
-                border: Border.all(
-                  color: isDark
-                      ? Colors.white.withValues(alpha: 0.15)
-                      : Colors.black.withValues(alpha: 0.08),
-                  width: 0.5,
-                ),
+                width: 0.5,
               ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(
-                    icon,
-                    size: 17,
-                    color: isDark
-                        ? Colors.white.withValues(alpha: 0.85)
-                        : Colors.black.withValues(alpha: 0.65),
-                  ),
-                  const SizedBox(width: 8),
-                  Text(
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  icon,
+                  size: 17,
+                  color: isDark
+                      ? Colors.white.withValues(alpha: 0.85)
+                      : Colors.black.withValues(alpha: 0.65),
+                ),
+                const SizedBox(width: 8),
+                Flexible(
+                  child: Text(
                     label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                     style: TextStyle(
                       fontSize: 15,
                       fontWeight: FontWeight.w600,
@@ -340,8 +516,8 @@ class _GlassPillButton extends StatelessWidget {
                           : Colors.black.withValues(alpha: 0.65),
                     ),
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         ),

--- a/app/lib/ui/core/widgets/floating_context_dropdown.dart
+++ b/app/lib/ui/core/widgets/floating_context_dropdown.dart
@@ -15,7 +15,33 @@ class FloatingContextDropdownItem<T> {
   });
 }
 
-void showFloatingContextDropdown<T>(
+class FloatingContextDropdownController<T> {
+  _FloatingContextDropdownOverlayState<T>? _state;
+
+  void _attach(_FloatingContextDropdownOverlayState<T>? state) {
+    _state = state;
+  }
+
+  void _detach(_FloatingContextDropdownOverlayState<T>? state) {
+    if (identical(_state, state)) {
+      _state = null;
+    }
+  }
+
+  void updateDragPosition(Offset globalPosition) {
+    _state?._updateDragPosition(globalPosition);
+  }
+
+  void completeDragSelection() {
+    _state?._completeDragSelection();
+  }
+
+  void dismiss() {
+    _state?._dismiss();
+  }
+}
+
+FloatingContextDropdownController<T> showFloatingContextDropdown<T>(
   BuildContext context, {
   required Offset buttonPosition,
   required double buttonWidth,
@@ -23,10 +49,25 @@ void showFloatingContextDropdown<T>(
   required List<FloatingContextDropdownItem<T>> items,
   required ValueChanged<T> onSelected,
   Alignment alignment = Alignment.bottomLeft,
+  VoidCallback? onDismissed,
 }) {
   HapticFeedback.selectionClick();
 
+  final controller = FloatingContextDropdownController<T>();
+
   late OverlayEntry entry;
+  var isRemoved = false;
+
+  void removeEntry() {
+    if (isRemoved) return;
+    isRemoved = true;
+    controller._detach(null);
+    if (entry.mounted) {
+      entry.remove();
+    }
+    onDismissed?.call();
+  }
+
   entry = OverlayEntry(
     builder: (context) => _FloatingContextDropdownOverlay<T>(
       buttonPosition: buttonPosition,
@@ -34,15 +75,17 @@ void showFloatingContextDropdown<T>(
       buttonHeight: buttonHeight,
       items: items,
       alignment: alignment,
+      controller: controller,
       onSelected: (value) {
-        entry.remove();
+        removeEntry();
         onSelected(value);
       },
-      onDismiss: () => entry.remove(),
+      onDismiss: removeEntry,
     ),
   );
 
   Overlay.of(context).insert(entry);
+  return controller;
 }
 
 class _FloatingContextDropdownOverlay<T> extends StatefulWidget {
@@ -51,15 +94,18 @@ class _FloatingContextDropdownOverlay<T> extends StatefulWidget {
   final double buttonHeight;
   final List<FloatingContextDropdownItem<T>> items;
   final Alignment alignment;
+  final FloatingContextDropdownController<T> controller;
   final ValueChanged<T> onSelected;
   final VoidCallback onDismiss;
 
   const _FloatingContextDropdownOverlay({
+    super.key,
     required this.buttonPosition,
     required this.buttonWidth,
     required this.buttonHeight,
     required this.items,
     required this.alignment,
+    required this.controller,
     required this.onSelected,
     required this.onDismiss,
   });
@@ -75,10 +121,14 @@ class _FloatingContextDropdownOverlayState<T>
   late AnimationController _controller;
   late Animation<double> _scaleAnimation;
   late Animation<double> _fadeAnimation;
+  late final List<GlobalKey> _itemKeys;
+  int? _highlightedIndex;
 
   @override
   void initState() {
     super.initState();
+    widget.controller._attach(this);
+    _itemKeys = List.generate(widget.items.length, (_) => GlobalKey());
     _controller = AnimationController(
       duration: const Duration(milliseconds: 200),
       vsync: this,
@@ -94,6 +144,7 @@ class _FloatingContextDropdownOverlayState<T>
 
   @override
   void dispose() {
+    widget.controller._detach(this);
     _controller.dispose();
     super.dispose();
   }
@@ -102,10 +153,49 @@ class _FloatingContextDropdownOverlayState<T>
     _controller.reverse().then((_) => widget.onDismiss());
   }
 
+  void _updateDragPosition(Offset globalPosition) {
+    final nextIndex = _indexForGlobalPosition(globalPosition);
+    if (nextIndex != _highlightedIndex) {
+      if (nextIndex != null) {
+        HapticFeedback.selectionClick();
+      }
+      setState(() {
+        _highlightedIndex = nextIndex;
+      });
+    }
+  }
+
+  void _completeDragSelection() {
+    final index = _highlightedIndex;
+    if (index == null) {
+      _dismiss();
+      return;
+    }
+
+    HapticFeedback.selectionClick();
+    widget.onSelected(widget.items[index].value);
+  }
+
+  int? _indexForGlobalPosition(Offset globalPosition) {
+    for (var i = 0; i < _itemKeys.length; i++) {
+      final itemContext = _itemKeys[i].currentContext;
+      if (itemContext == null) continue;
+      final renderBox = itemContext.findRenderObject() as RenderBox?;
+      if (renderBox == null || !renderBox.hasSize) continue;
+
+      final origin = renderBox.localToGlobal(Offset.zero);
+      final rect = origin & renderBox.size;
+      if (rect.contains(globalPosition)) {
+        return i;
+      }
+    }
+    return null;
+  }
+
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    const dropdownWidth = 200.0;
+    final dropdownWidth = widget.buttonWidth;
 
     final dropdownBottom =
         MediaQuery.of(context).size.height - widget.buttonPosition.dy + 8;
@@ -147,36 +237,41 @@ class _FloatingContextDropdownOverlayState<T>
                 ),
               );
             },
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(14),
-              child: BackdropFilter(
-                filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
-                child: Container(
-                  width: dropdownWidth,
-                  decoration: BoxDecoration(
-                    color: isDark
-                        ? Colors.white.withValues(alpha: 0.14)
-                        : Colors.white.withValues(alpha: 0.85),
-                    borderRadius: BorderRadius.circular(14),
-                    border: Border.all(
-                      color: isDark
-                          ? Colors.white.withValues(alpha: 0.15)
-                          : Colors.black.withValues(alpha: 0.08),
-                      width: 0.5,
-                    ),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.15),
-                        blurRadius: 20,
-                        offset: const Offset(0, 8),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minWidth: dropdownWidth),
+              child: IntrinsicWidth(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(14),
+                  child: BackdropFilter(
+                    filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: isDark
+                            ? Colors.white.withValues(alpha: 0.14)
+                            : Colors.white.withValues(alpha: 0.85),
+                        borderRadius: BorderRadius.circular(14),
+                        border: Border.all(
+                          color: isDark
+                              ? Colors.white.withValues(alpha: 0.15)
+                              : Colors.black.withValues(alpha: 0.08),
+                          width: 0.5,
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withValues(alpha: 0.15),
+                            blurRadius: 20,
+                            offset: const Offset(0, 8),
+                          ),
+                        ],
                       ),
-                    ],
-                  ),
-                  child: Material(
-                    type: MaterialType.transparency,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: _buildItems(isDark),
+                      child: Material(
+                        type: MaterialType.transparency,
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: _buildItems(isDark),
+                        ),
+                      ),
                     ),
                   ),
                 ),
@@ -194,9 +289,11 @@ class _FloatingContextDropdownOverlayState<T>
       final item = widget.items[i];
       widgets.add(
         _buildItem(
+          key: _itemKeys[i],
           icon: item.icon,
           label: item.label,
           isDark: isDark,
+          isHighlighted: _highlightedIndex == i,
           onTap: () {
             HapticFeedback.selectionClick();
             widget.onSelected(item.value);
@@ -219,31 +316,45 @@ class _FloatingContextDropdownOverlayState<T>
   }
 
   Widget _buildItem({
+    required GlobalKey key,
     required IconData icon,
     required String label,
     required bool isDark,
+    required bool isHighlighted,
     required VoidCallback onTap,
   }) {
     final textColor = isDark ? Colors.white : Colors.black;
+    final highlightColor = isDark
+        ? Colors.white.withValues(alpha: 0.10)
+        : Colors.black.withValues(alpha: 0.06);
 
     return GestureDetector(
+      key: key,
       onTap: onTap,
       behavior: HitTestBehavior.opaque,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-        child: Row(
-          children: [
-            Icon(icon, size: 18, color: textColor),
-            const SizedBox(width: 10),
-            Text(
-              label,
-              style: TextStyle(
-                fontSize: 14,
-                fontWeight: FontWeight.w500,
-                color: textColor,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 100),
+        color: isHighlighted ? highlightColor : Colors.transparent,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          child: Row(
+            children: [
+              Icon(icon, size: 18, color: textColor),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                    color: textColor,
+                  ),
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## 📌 Summary

> 3월 20일 daily 브랜치에 남아 있던 상세 액션 메뉴 개선 사항을 dev에 다시 반영합니다.

## 📋 Changes

- `./app/lib/ui/book_detail/widgets/floating_action_bar.dart`: 상세 화면 하단 CTA의 액션 메뉴 구조와 제스처 동작을 3월 20일 브랜치 버전으로 반영
- `./app/lib/ui/core/widgets/floating_context_dropdown.dart`: 컨텍스트 드롭다운 폭 계산과 드래그 선택 동작을 3월 20일 브랜치 버전으로 반영

## 🧠 Context & Background

> `daily/2026-03-20`은 한 차례 dev에 머지된 뒤에도 PR #216의 상세 액션 메뉴 개선 커밋을 추가로 포함하고 있었습니다. 현재 dev에도 유사한 변경은 있지만, 사용자가 3월 20일 브랜치 버전이 요구사항을 더 정확히 반영한다고 판단해 해당 변경을 다시 동기화합니다.

## ✅ How to Test

1. 책 상세 화면으로 이동합니다.
2. 하단 CTA를 길게 눌러 컨텍스트 메뉴를 엽니다.
3. 드래그 후 손을 떼어 메뉴가 선택 실행되는지 확인합니다.
4. 독서 시작 / 기록 액션의 위치와 메뉴 폭이 의도대로 보이는지 확인합니다.

## 🔗 Related Issues

- Related: PR #216

## 🙌 Additional Notes (Optional)

> 머지 전 dev 기준 충돌 여부를 확인하고, 충돌 시에는 `daily/2026-03-20` 쪽 구현을 우선으로 반영합니다.