### PR TITLE
feature/BOK-366-swap-bottom-bar-button-order

### DIFF
--- a/app/lib/ui/book_detail/widgets/floating_action_bar.dart
+++ b/app/lib/ui/book_detail/widgets/floating_action_bar.dart
@@ -200,7 +200,7 @@ class _ReadingModeBarState extends State<_ReadingModeBar> {
     _showMenu(
       context: context,
       buttonKey: _startReadingKey,
-      alignment: Alignment.bottomRight,
+      alignment: Alignment.bottomLeft,
       items: items,
       onSelected: _handleStartReadingSelection,
     );
@@ -217,7 +217,7 @@ class _ReadingModeBarState extends State<_ReadingModeBar> {
     _showMenu(
       context: context,
       buttonKey: _recordKey,
-      alignment: Alignment.bottomLeft,
+      alignment: Alignment.bottomRight,
       items: items,
       onSelected: _handleRecordSelection,
     );
@@ -233,7 +233,7 @@ class _ReadingModeBarState extends State<_ReadingModeBar> {
     _showMenu(
       context: context,
       buttonKey: _startReadingKey,
-      alignment: Alignment.bottomRight,
+      alignment: Alignment.bottomLeft,
       items: items,
       onSelected: _handleStartReadingSelection,
     );
@@ -249,7 +249,7 @@ class _ReadingModeBarState extends State<_ReadingModeBar> {
     _showMenu(
       context: context,
       buttonKey: _recordKey,
-      alignment: Alignment.bottomLeft,
+      alignment: Alignment.bottomRight,
       items: items,
       onSelected: _handleRecordSelection,
     );
@@ -271,21 +271,6 @@ class _ReadingModeBarState extends State<_ReadingModeBar> {
     return Row(
       children: [
         Expanded(
-          flex: 3,
-          child: _GlassPillButton(
-            key: _recordKey,
-            isDark: widget.isDark,
-            icon: CupertinoIcons.pencil,
-            label: l10n.bottomBarRecord,
-            onTap: () => _onRecordTap(context),
-            onLongPressStart: (details) =>
-                _onRecordLongPressStart(context, details),
-            onLongPressMoveUpdate: _onLongPressMoveUpdate,
-            onLongPressEnd: _onLongPressEnd,
-          ),
-        ),
-        const SizedBox(width: 12),
-        Expanded(
           flex: 7,
           child: _GlassPillButton(
             key: _startReadingKey,
@@ -295,6 +280,21 @@ class _ReadingModeBarState extends State<_ReadingModeBar> {
             onTap: () => _onStartReadingTap(context),
             onLongPressStart: (details) =>
                 _onStartReadingLongPressStart(context, details),
+            onLongPressMoveUpdate: _onLongPressMoveUpdate,
+            onLongPressEnd: _onLongPressEnd,
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          flex: 3,
+          child: _GlassPillButton(
+            key: _recordKey,
+            isDark: widget.isDark,
+            icon: CupertinoIcons.pencil,
+            label: l10n.bottomBarRecord,
+            onTap: () => _onRecordTap(context),
+            onLongPressStart: (details) =>
+                _onRecordLongPressStart(context, details),
             onLongPressMoveUpdate: _onLongPressMoveUpdate,
             onLongPressEnd: _onLongPressEnd,
           ),

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -753,18 +753,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1286,10 +1286,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   timezone:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## 📌 Summary

> 독서 상세 화면 바텀 버튼의 순서를 '기록/독서 시작' → '독서 시작/기록'으로 변경합니다.

## 📋 Changes

> - `./app/lib/ui/book_detail/widgets/floating_action_bar.dart`: 바텀 버튼 순서 스왑 및 드롭다운 alignment 수정

## 🧠 Context & Background

> 기존에는 왼쪽에 '기록(flex:3)', 오른쪽에 '독서 시작(flex:7)'이 배치되어 있었습니다.
> 자주 사용하는 '독서 시작' 버튼이 오른쪽에 있어 UX가 어색하다는 피드백에 따라 순서를 반대로 변경합니다.
> 드롭다운 메뉴 alignment도 버튼이 이동한 위치에 맞게 함께 수정되었습니다.

## ✅ How to Test

> 1. 독서 중인 책의 상세 화면 진입
> 2. 하단 바텀 바 확인 — 왼쪽에 '독서 시작(넓은 버튼)', 오른쪽에 '기록(좁은 버튼)' 배치 확인
> 3. 각 버튼 탭 및 길게 누르기로 드롭다운 메뉴 정상 작동 확인

## 🔗 Related Issues

> - Related: BOK-366