### PR TITLE
daily/2026-04-11

### DIFF
--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1685,5 +1685,17 @@
             "@bottomBarAddRecord": {"description": "Add record menu item in floating action bar"},
 
             "bottomBarAiRecordSearch": "AI Record Search",
-            "@bottomBarAiRecordSearch": {"description": "AI record search menu item in floating action bar"}
+            "@bottomBarAiRecordSearch": {"description": "AI record search menu item in floating action bar"},
+
+            "bookDetailStartNow": "Start Now",
+            "@bookDetailStartNow": {"description": "Start now button for planned books"},
+
+            "bookDetailStartNowSubtitle": "Start reading right now",
+            "@bookDetailStartNowSubtitle": {"description": "Subtitle for start now button"},
+
+            "bookDetailStartReadingTitle": "Start Reading",
+            "@bookDetailStartReadingTitle": {"description": "Title for start reading dialog"},
+
+            "bookDetailStartReadingSubtitle": "Set your target completion date",
+            "@bookDetailStartReadingSubtitle": {"description": "Subtitle for start reading dialog"}
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3225,5 +3225,17 @@
          "@bottomBarAddRecord": {"description": "Add record menu item in floating action bar"},
 
          "bottomBarAiRecordSearch": "AI 기록 검색",
-         "@bottomBarAiRecordSearch": {"description": "AI record search menu item in floating action bar"}
+         "@bottomBarAiRecordSearch": {"description": "AI record search menu item in floating action bar"},
+
+         "bookDetailStartNow": "바로 시작",
+         "@bookDetailStartNow": {"description": "Start now button for planned books"},
+
+         "bookDetailStartNowSubtitle": "독서를 지금 바로 시작합니다",
+         "@bookDetailStartNowSubtitle": {"description": "Subtitle for start now button"},
+
+         "bookDetailStartReadingTitle": "독서 시작",
+         "@bookDetailStartReadingTitle": {"description": "Title for start reading dialog"},
+
+         "bookDetailStartReadingSubtitle": "목표 완독일을 설정하세요",
+         "@bookDetailStartReadingSubtitle": {"description": "Subtitle for start reading dialog"}
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -6808,6 +6808,30 @@ abstract class AppLocalizations {
   /// In ko, this message translates to:
   /// **'AI 기록 검색'**
   String get bottomBarAiRecordSearch;
+
+  /// Start now button for planned books
+  ///
+  /// In ko, this message translates to:
+  /// **'바로 시작'**
+  String get bookDetailStartNow;
+
+  /// Subtitle for start now button
+  ///
+  /// In ko, this message translates to:
+  /// **'독서를 지금 바로 시작합니다'**
+  String get bookDetailStartNowSubtitle;
+
+  /// Title for start reading dialog
+  ///
+  /// In ko, this message translates to:
+  /// **'독서 시작'**
+  String get bookDetailStartReadingTitle;
+
+  /// Subtitle for start reading dialog
+  ///
+  /// In ko, this message translates to:
+  /// **'목표 완독일을 설정하세요'**
+  String get bookDetailStartReadingSubtitle;
 }
 
 class _AppLocalizationsDelegate

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -3726,4 +3726,17 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get bottomBarAiRecordSearch => 'AI Record Search';
+
+  @override
+  String get bookDetailStartNow => 'Start Now';
+
+  @override
+  String get bookDetailStartNowSubtitle => 'Start reading right now';
+
+  @override
+  String get bookDetailStartReadingTitle => 'Start Reading';
+
+  @override
+  String get bookDetailStartReadingSubtitle =>
+      'Set your target completion date';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -3640,4 +3640,16 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get bottomBarAiRecordSearch => 'AI 기록 검색';
+
+  @override
+  String get bookDetailStartNow => '바로 시작';
+
+  @override
+  String get bookDetailStartNowSubtitle => '독서를 지금 바로 시작합니다';
+
+  @override
+  String get bookDetailStartReadingTitle => '독서 시작';
+
+  @override
+  String get bookDetailStartReadingSubtitle => '목표 완독일을 설정하세요';
 }

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -381,6 +381,8 @@ class _BookDetailContentState extends State<_BookDetailContent>
                               if (_isBookPlanned(book)) ...[
                                 const SizedBox(height: 12),
                                 _buildPlannedBookInfo(context, book, bookVm),
+                                const SizedBox(height: 8),
+                                _buildStartNowButton(context, book, bookVm),
                               ],
                               if (_isBookPaused(book)) ...[
                                 const SizedBox(height: 12),
@@ -1417,6 +1419,115 @@ class _BookDetailContentState extends State<_BookDetailContent>
           if (!paywallSuccess && mounted) {
             CustomSnackbar.show(context,
                 message: AppLocalizations.of(context).subscriptionUnavailable,
+                type: BLabSnackbarType.info);
+          }
+        }
+      },
+    );
+  }
+
+  Widget _buildStartNowButton(
+      BuildContext context, Book book, BookDetailViewModel bookVm) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return GestureDetector(
+      onTap: () => _showStartNowDialog(bookVm),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        decoration: BoxDecoration(
+          color: isDark ? BLabColors.surfaceDark : Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: isDark ? 0.2 : 0.04),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 40,
+                  height: 40,
+                  decoration: BoxDecoration(
+                    color: BLabColors.success.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: const Icon(
+                    Icons.play_arrow_rounded,
+                    color: BLabColors.success,
+                    size: 22,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      AppLocalizations.of(context).bookDetailStartNow,
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                        color: isDark ? Colors.white : Colors.black,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      AppLocalizations.of(context).bookDetailStartNowSubtitle,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: isDark ? Colors.grey[400] : Colors.grey[600],
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            Icon(
+              CupertinoIcons.chevron_right,
+              color: isDark ? Colors.grey[400] : Colors.grey[500],
+              size: 20,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showStartNowDialog(BookDetailViewModel bookVm) async {
+    final book = bookVm.currentBook;
+    final defaultTarget =
+        book.targetDate ?? DateTime.now().add(const Duration(days: 14));
+
+    await UpdateTargetDateDialog.show(
+      context: context,
+      currentTargetDate: defaultTarget,
+      nextAttemptCount: 1,
+      title: AppLocalizations.of(context).bookDetailStartReadingTitle,
+      subtitle: AppLocalizations.of(context).bookDetailStartReadingSubtitle,
+      onConfirm: (newDate, newAttempt) async {
+        final success = await bookVm.startPlannedReading(newDate);
+        if (success && mounted) {
+          _scrollController.animateTo(0,
+              duration: const Duration(milliseconds: 500),
+              curve: Curves.easeOutCubic);
+          CustomSnackbar.show(context,
+              message: AppLocalizations.of(context)
+                  .bookDetailAttemptStarted(1),
+              type: BLabSnackbarType.success,
+              icon: Icons.play_arrow_rounded);
+        } else if (!success && mounted && bookVm.shouldShowPaywall) {
+          bookVm.clearPaywallState();
+          final paywallSuccess =
+              await SubscriptionService().showPaywall(context);
+          if (!paywallSuccess && mounted) {
+            CustomSnackbar.show(context,
+                message:
+                    AppLocalizations.of(context).subscriptionUnavailable,
                 type: BLabSnackbarType.info);
           }
         }

--- a/app/lib/ui/book_detail/view_model/book_detail_view_model.dart
+++ b/app/lib/ui/book_detail/view_model/book_detail_view_model.dart
@@ -351,6 +351,31 @@ class BookDetailViewModel extends BaseViewModel {
     }
   }
 
+  Future<bool> startPlannedReading(DateTime targetDate) async {
+    try {
+      final updatedBook = await _bookService.resumeReading(
+        _currentBook.id!,
+        newTargetDate: targetDate,
+        incrementAttempt: false,
+      );
+
+      if (updatedBook != null) {
+        _currentBook = updatedBook;
+        _attemptCount = updatedBook.attemptCount;
+        notifyListeners();
+        return true;
+      }
+      return false;
+    } on ConcurrentReadingLimitException {
+      _shouldShowPaywall = true;
+      notifyListeners();
+      return false;
+    } catch (e) {
+      setError('독서 시작에 실패했습니다: $e');
+      return false;
+    }
+  }
+
   Future<bool> pauseReading() async {
     try {
       final updatedBook = await _bookService.pauseReading(_currentBook.id!);

--- a/app/lib/ui/book_detail/widgets/dialogs/update_target_date_dialog.dart
+++ b/app/lib/ui/book_detail/widgets/dialogs/update_target_date_dialog.dart
@@ -9,12 +9,16 @@ class UpdateTargetDateDialog extends StatefulWidget {
   final DateTime currentTargetDate;
   final int nextAttemptCount;
   final Future<void> Function(DateTime newDate, int newAttempt) onConfirm;
+  final String? title;
+  final String? subtitle;
 
   const UpdateTargetDateDialog({
     super.key,
     required this.currentTargetDate,
     required this.nextAttemptCount,
     required this.onConfirm,
+    this.title,
+    this.subtitle,
   });
 
   static Future<void> show({
@@ -22,6 +26,8 @@ class UpdateTargetDateDialog extends StatefulWidget {
     required DateTime currentTargetDate,
     required int nextAttemptCount,
     required Future<void> Function(DateTime newDate, int newAttempt) onConfirm,
+    String? title,
+    String? subtitle,
   }) async {
     await showModalBottomSheet(
       context: context,
@@ -31,6 +37,8 @@ class UpdateTargetDateDialog extends StatefulWidget {
         currentTargetDate: currentTargetDate,
         nextAttemptCount: nextAttemptCount,
         onConfirm: onConfirm,
+        title: title,
+        subtitle: subtitle,
       ),
     );
   }
@@ -97,7 +105,7 @@ class _UpdateTargetDateDialogState extends State<UpdateTargetDateDialog> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                AppLocalizations.of(context).changeTargetDateTitle,
+                widget.title ?? AppLocalizations.of(context).changeTargetDateTitle,
                 style: TextStyle(
                   fontWeight: FontWeight.bold,
                   fontSize: 20,
@@ -105,8 +113,7 @@ class _UpdateTargetDateDialogState extends State<UpdateTargetDateDialog> {
                 ),
               ),
               Text(
-                AppLocalizations.of(context)
-                    .attemptChangeMessage(widget.nextAttemptCount),
+                widget.subtitle ?? AppLocalizations.of(context).attemptChangeMessage(widget.nextAttemptCount),
                 style: TextStyle(
                   fontSize: 13,
                   color: isDark ? Colors.grey[400] : Colors.grey[600],


### PR DESCRIPTION
## 📌 Summary

> daily/2026-04-11 하루 작업 통합

## 📋 Changes

> 오늘 머지된 이슈 PR 목록:
> - #223: feature/BOK-368-start-now-button — planned 상태 책 상세 화면에 "바로 시작" 버튼 추가

## 🧠 Context & Background

> planned 상태의 책에서 바로 독서를 시작할 수 있는 UX 개선

## ✅ How to Test

> 각 이슈 PR에서 개별 테스트 완료됨

## 🔗 Related Issues

- Related: BOK-368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Start Now" button for planned books in the book detail view, allowing users to initiate reading immediately.
  * Users can now set a target completion date when starting a planned book through an updated dialog.
  * Added full localization support for English and Korean languages for the new start reading flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->