### PR TITLE
daily/2026-04-18

### DIFF
--- a/supabase/migrations/20260418000000_create_waitlist.sql
+++ b/supabase/migrations/20260418000000_create_waitlist.sql
@@ -1,0 +1,21 @@
+-- BOK-371: Pre-launch iOS app email waitlist
+CREATE TABLE IF NOT EXISTS public.waitlist (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT NOT NULL UNIQUE CHECK (email ~* '^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$'),
+  locale TEXT NOT NULL DEFAULT 'ko' CHECK (locale IN ('ko', 'en')),
+  user_agent TEXT,
+  source TEXT NOT NULL DEFAULT 'landing',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS waitlist_created_at_idx ON public.waitlist(created_at DESC);
+
+ALTER TABLE public.waitlist ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "waitlist_anon_insert"
+  ON public.waitlist
+  FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (true);
+
+COMMENT ON TABLE public.waitlist IS 'Pre-launch iOS app email waitlist (BOK-371)';

--- a/supabase/migrations/20260419000000_waitlist_admin_policies.sql
+++ b/supabase/migrations/20260419000000_waitlist_admin_policies.sql
@@ -1,0 +1,26 @@
+-- BOK-371: Admin SELECT/DELETE policies for waitlist
+-- Admins (whitelist by email) can read and remove waitlist entries
+
+CREATE POLICY "waitlist_admin_select"
+  ON public.waitlist
+  FOR SELECT
+  TO authenticated
+  USING (
+    (auth.jwt() ->> 'email') IN (
+      'admin@bookgolas.com',
+      'byungsker@naver.com',
+      'extreme0728@gmail.com'
+    )
+  );
+
+CREATE POLICY "waitlist_admin_delete"
+  ON public.waitlist
+  FOR DELETE
+  TO authenticated
+  USING (
+    (auth.jwt() ->> 'email') IN (
+      'admin@bookgolas.com',
+      'byungsker@naver.com',
+      'extreme0728@gmail.com'
+    )
+  );

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1,14 +1,15 @@
 {
   "nav": {
     "appName": "Bookgolas",
-    "download": "Download App"
+    "download": "Download App",
+    "waitlist": "Get Notified"
   },
   "lang": {
     "ko": "한국어",
     "en": "English"
   },
   "hero": {
-    "badge": "Now on iOS · Start Your Reading Journey",
+    "badge": "Launching Soon on iOS · Be the First to Know",
     "headline1": "Where Every Book",
     "headline2": "Becomes a Goal",
     "sub": "Turn the books you want to read into achievable goals. Track your daily reading and build a habit that lasts — with Bookgolas.",
@@ -20,7 +21,8 @@
     "stat3Label": "Completely Free",
     "appStore": "App Store",
     "appStoreSubtitle": "Download on the",
-    "androidComingSoon": "Coming Soon"
+    "androidComingSoon": "Coming Soon",
+    "iosComingSoon": "Coming Soon"
   },
   "features": {
     "label": "Features",
@@ -68,8 +70,22 @@
     "s3Desc": "Record today's pages and watch your progress update automatically"
   },
   "cta": {
-    "title": "Start reading today",
-    "sub": "Free on iOS. Build the reading habit you've always wanted, one book at a time ✨"
+    "title": "Be the First to Know",
+    "sub": "We'll email you the moment Bookgolas hits the App Store. Sign up once and you're set for launch day ✨"
+  },
+  "waitlist": {
+    "title": "Get Launch Notification",
+    "description": "Bookgolas is launching on iOS soon. Be the first to hear when it's live.",
+    "emailLabel": "Email",
+    "emailPlaceholder": "your@email.com",
+    "submit": "Notify Me",
+    "submitting": "Submitting...",
+    "successTitle": "You're on the list!",
+    "successDesc": "We'll email you the moment Bookgolas launches.",
+    "duplicate": "You're already on the list — see you at launch!",
+    "invalid": "Please enter a valid email address.",
+    "error": "Something went wrong. Please try again later.",
+    "privacy": "We'll only email you about the launch — nothing else."
   },
   "footer": {
     "copyright": "© 2026 Bookgolas · Made by",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1,14 +1,15 @@
 {
   "nav": {
     "appName": "북골라스",
-    "download": "앱 다운로드"
+    "download": "앱 다운로드",
+    "waitlist": "출시 알림 받기"
   },
   "lang": {
     "ko": "한국어",
     "en": "English"
   },
   "hero": {
-    "badge": "iOS 출시 · 독서 목표 달성의 시작",
+    "badge": "iOS 출시 예정 · 가장 먼저 알림 받기",
     "headline1": "매일의 독서가",
     "headline2": "목표가 되는 곳",
     "sub": "읽고 싶은 책을 목표로 만들고, 매일의 독서를 기록하세요. 북골라스와 함께라면 독서 습관이 달라집니다.",
@@ -20,7 +21,8 @@
     "stat3Label": "완전 무료",
     "appStore": "App Store",
     "appStoreSubtitle": "Download on the",
-    "androidComingSoon": "개발 중"
+    "androidComingSoon": "개발 중",
+    "iosComingSoon": "곧 출시"
   },
   "features": {
     "label": "Features",
@@ -68,8 +70,22 @@
     "s3Desc": "오늘 읽은 페이지를 기록하면 진행률이 자동으로 업데이트돼요"
   },
   "cta": {
-    "title": "지금 독서를 시작해보세요",
-    "sub": "iOS에서 무료로 이용할 수 있어요. 오늘부터 독서 목표를 향해 한 걸음씩 ✨"
+    "title": "출시 알림을 가장 먼저 받으세요",
+    "sub": "iOS App Store 출시 즉시 이메일로 알려드릴게요. 잠깐의 등록으로 첫날부터 함께해요 ✨"
+  },
+  "waitlist": {
+    "title": "iOS 출시 알림 받기",
+    "description": "곧 App Store에 출시됩니다. 가장 먼저 알림을 받아보세요.",
+    "emailLabel": "이메일",
+    "emailPlaceholder": "your@email.com",
+    "submit": "알림 받기",
+    "submitting": "처리 중...",
+    "successTitle": "신청 완료!",
+    "successDesc": "iOS 출시 시점에 이메일로 알려드릴게요.",
+    "duplicate": "이미 등록된 이메일이에요. 출시 알림은 약속드릴게요!",
+    "invalid": "올바른 이메일을 입력해주세요.",
+    "error": "잠시 후 다시 시도해주세요.",
+    "privacy": "이메일은 출시 알림 외 다른 용도로 사용되지 않아요."
   },
   "footer": {
     "copyright": "© 2026 북골라스 · Made by",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,6 +22,7 @@
         "next-intl": "^4.8.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "resend": "^6.12.0",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -2350,6 +2351,12 @@
       "version": "1.21.5",
       "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
       "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -4981,6 +4988,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -6902,6 +6915,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -7123,6 +7142,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.0.tgz",
+      "integrity": "sha512-CaxEvX1z+/MGbgnhsM/bvmkbnZd1v1sEXELAjBNSDBQNMaB7MgqOyrBgI27CYikEgdaDnBrXghAXYWTBs/h5Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -7494,6 +7534,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -7691,6 +7741,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/tailwind-merge": {
@@ -8132,6 +8192,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "next-intl": "^4.8.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "resend": "^6.12.0",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/web/src/app/[locale]/page.tsx
+++ b/web/src/app/[locale]/page.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { useEffect, useRef, useState, useTransition } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { useRouter, usePathname } from "@/i18n/navigation";
+import { WaitlistModal } from "@/components/waitlist-modal";
 
 function useReveal(threshold = 0.15) {
   const ref = useRef<HTMLDivElement>(null);
@@ -892,6 +893,74 @@ function Step({
   );
 }
 
+function AppStoreWaitlistButton({
+  size = "default",
+  label,
+  subtitle,
+  ctaLabel,
+  onClick,
+}: {
+  size?: "default" | "lg";
+  label: string;
+  subtitle: string;
+  ctaLabel: string;
+  onClick: () => void;
+}) {
+  const Icon = (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="white">
+      <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+    </svg>
+  );
+
+  return (
+    <div className="relative">
+      {size === "lg" ? (
+        <button
+          type="button"
+          onClick={onClick}
+          className="flex items-center justify-center gap-3 px-8 py-4 rounded-2xl font-semibold text-white btn-primary cursor-pointer"
+          style={{ fontFamily: "var(--font-display)" }}
+        >
+          {Icon}
+          {ctaLabel}
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={onClick}
+          className="flex items-center gap-3 px-5 py-3 rounded-2xl transition-all hover:scale-105 hover:-translate-y-0.5 cursor-pointer"
+          style={{
+            background: "rgba(28,31,50,0.85)",
+            border: "1px solid rgba(255,255,255,0.1)",
+            boxShadow: "0 4px 20px rgba(0,0,0,0.4)",
+          }}
+        >
+          {Icon}
+          <div className="text-left">
+            <div className="text-white/45 text-[9px]">{subtitle}</div>
+            <div
+              className="text-white font-semibold text-sm"
+              style={{ fontFamily: "var(--font-display)" }}
+            >
+              {ctaLabel}
+            </div>
+          </div>
+        </button>
+      )}
+      <span
+        className="absolute -top-2 -right-2 text-[9px] font-bold px-2 py-0.5 rounded-full"
+        style={{
+          background: "rgba(255,150,50,0.9)",
+          color: "white",
+          fontFamily: "var(--font-display)",
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
 function GooglePlayDisabled({ label }: { label: string }) {
   return (
     <div className="relative">
@@ -948,6 +1017,13 @@ export default function Page() {
   const cta = useReveal();
   const shots = useReveal();
   const [hero, setHero] = useState(false);
+  const [waitlistOpen, setWaitlistOpen] = useState(false);
+  const [waitlistSource, setWaitlistSource] = useState<string>("nav");
+
+  const openWaitlist = (source: string) => {
+    setWaitlistSource(source);
+    setWaitlistOpen(true);
+  };
 
   useEffect(() => {
     const timer = setTimeout(() => setHero(true), 80);
@@ -990,12 +1066,13 @@ export default function Page() {
         </div>
         <div className="flex items-center gap-3">
           <LanguageSwitcher />
-          <a
-            href="#download"
-            className="hidden sm:flex items-center gap-2 px-5 py-2 rounded-full font-medium text-sm text-white btn-primary"
+          <button
+            type="button"
+            onClick={() => openWaitlist("nav")}
+            className="hidden sm:flex items-center gap-2 px-5 py-2 rounded-full font-medium text-sm text-white btn-primary cursor-pointer"
             style={{ fontFamily: "var(--font-display)" }}
           >
-            {t("nav.download")}
+            {t("nav.waitlist")}
             <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
               <path
                 d="M3 7h8M7 3l4 4-4 4"
@@ -1005,7 +1082,7 @@ export default function Page() {
                 strokeLinejoin="round"
               />
             </svg>
-          </a>
+          </button>
         </div>
       </nav>
 
@@ -1095,30 +1172,13 @@ export default function Page() {
               className="flex flex-col sm:flex-row gap-3 justify-center md:justify-start"
               style={trans(320)}
             >
-              <a
-                href="#"
-                className="flex items-center gap-3 px-5 py-3 rounded-2xl transition-all hover:scale-105 hover:-translate-y-0.5"
-                style={{
-                  background: "rgba(28,31,50,0.85)",
-                  border: "1px solid rgba(255,255,255,0.1)",
-                  boxShadow: "0 4px 20px rgba(0,0,0,0.4)",
-                }}
-              >
-                <svg width="22" height="22" viewBox="0 0 24 24" fill="white">
-                  <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
-                </svg>
-                <div className="text-left">
-                  <div className="text-white/45 text-[9px]">
-                    {t("hero.appStoreSubtitle")}
-                  </div>
-                  <div
-                    className="text-white font-semibold text-sm"
-                    style={{ fontFamily: "var(--font-display)" }}
-                  >
-                    {t("hero.appStore")}
-                  </div>
-                </div>
-              </a>
+              <AppStoreWaitlistButton
+                size="default"
+                label={t("hero.iosComingSoon")}
+                subtitle={t("hero.appStoreSubtitle")}
+                ctaLabel={t("hero.appStore")}
+                onClick={() => openWaitlist("hero")}
+              />
 
               <GooglePlayDisabled label={t("hero.androidComingSoon")} />
             </div>
@@ -1496,20 +1556,15 @@ export default function Page() {
             {t("cta.sub")}
           </p>
 
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <a
-              href="#"
-              className="flex items-center justify-center gap-3 px-8 py-4 rounded-2xl font-semibold text-white btn-primary"
-              style={{ fontFamily: "var(--font-display)" }}
-            >
-              <svg width="22" height="22" viewBox="0 0 24 24" fill="white">
-                <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
-              </svg>
-              App Store
-            </a>
-            <div className="flex justify-center">
-              <GooglePlayDisabled label={t("hero.androidComingSoon")} />
-            </div>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+            <AppStoreWaitlistButton
+              size="lg"
+              label={t("hero.iosComingSoon")}
+              subtitle={t("hero.appStoreSubtitle")}
+              ctaLabel={t("hero.appStore")}
+              onClick={() => openWaitlist("cta")}
+            />
+            <GooglePlayDisabled label={t("hero.androidComingSoon")} />
           </div>
         </div>
       </section>
@@ -1608,6 +1663,13 @@ export default function Page() {
           </div>
         </div>
       </footer>
+
+      <WaitlistModal
+        open={waitlistOpen}
+        onOpenChange={setWaitlistOpen}
+        source={waitlistSource}
+        locale={locale}
+      />
     </div>
   );
 }

--- a/web/src/app/actions/waitlist.ts
+++ b/web/src/app/actions/waitlist.ts
@@ -1,0 +1,40 @@
+"use server";
+
+import { headers } from "next/headers";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+
+const EMAIL_REGEX = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
+
+export type WaitlistResult =
+  | { ok: true }
+  | { ok: false; code: "invalid" | "duplicate" | "unknown" };
+
+export async function joinWaitlist(formData: FormData): Promise<WaitlistResult> {
+  const honeypot = String(formData.get("website") ?? "").trim();
+  if (honeypot.length > 0) {
+    return { ok: true };
+  }
+
+  const email = String(formData.get("email") ?? "").trim().toLowerCase();
+  const localeInput = String(formData.get("locale") ?? "ko");
+  const source = String(formData.get("source") ?? "landing").slice(0, 64);
+
+  if (!EMAIL_REGEX.test(email) || email.length > 254) {
+    return { ok: false, code: "invalid" };
+  }
+
+  const headerStore = await headers();
+  const userAgent = headerStore.get("user-agent")?.slice(0, 500) ?? null;
+  const locale = localeInput === "en" ? "en" : "ko";
+
+  const supabase = await createServerSupabaseClient();
+  const { error } = await supabase
+    .from("waitlist")
+    .insert({ email, locale, user_agent: userAgent, source });
+
+  if (error) {
+    if (error.code === "23505") return { ok: false, code: "duplicate" };
+    return { ok: false, code: "unknown" };
+  }
+  return { ok: true };
+}

--- a/web/src/app/actions/waitlist.ts
+++ b/web/src/app/actions/waitlist.ts
@@ -1,7 +1,9 @@
 "use server";
 
+import { after } from "next/server";
 import { headers } from "next/headers";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { sendWaitlistWelcome } from "@/lib/email/client";
 
 const EMAIL_REGEX = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
 
@@ -36,5 +38,13 @@ export async function joinWaitlist(formData: FormData): Promise<WaitlistResult> 
     if (error.code === "23505") return { ok: false, code: "duplicate" };
     return { ok: false, code: "unknown" };
   }
+
+  after(async () => {
+    const result = await sendWaitlistWelcome(email, locale);
+    if (!result.ok) {
+      console.error("[waitlist] email send failed", { email, reason: result.reason });
+    }
+  });
+
   return { ok: true };
 }

--- a/web/src/app/admin/layout.tsx
+++ b/web/src/app/admin/layout.tsx
@@ -15,6 +15,7 @@ const navItems = [
   { href: "/admin/push-logs", label: "발송 로그", icon: "📋" },
   { href: "/admin/test-push", label: "테스트 발송", icon: "🚀" },
   { href: "/admin/announcements", label: "공지 발송", icon: "📢" },
+  { href: "/admin/waitlist", label: "출시 알림 명단", icon: "📧" },
 ];
 
 export default function AdminLayout({

--- a/web/src/app/admin/waitlist/page.tsx
+++ b/web/src/app/admin/waitlist/page.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+type WaitlistEntry = {
+  id: string;
+  email: string;
+  locale: "ko" | "en";
+  source: string | null;
+  user_agent: string | null;
+  created_at: string;
+};
+
+type LocaleFilter = "all" | "ko" | "en";
+
+const PAGE_SIZE = 50;
+
+export default function WaitlistAdminPage() {
+  const [entries, setEntries] = useState<WaitlistEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [localeFilter, setLocaleFilter] = useState<LocaleFilter>("all");
+  const [page, setPage] = useState(0);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const { data, error: fetchError } = await supabase
+      .from("waitlist")
+      .select("id, email, locale, source, user_agent, created_at")
+      .order("created_at", { ascending: false })
+      .limit(1000);
+
+    if (fetchError) {
+      setError(fetchError.message);
+      setEntries([]);
+    } else {
+      setEntries((data ?? []) as WaitlistEntry[]);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const filtered = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    return entries.filter((entry) => {
+      if (localeFilter !== "all" && entry.locale !== localeFilter) return false;
+      if (term && !entry.email.toLowerCase().includes(term)) return false;
+      return true;
+    });
+  }, [entries, search, localeFilter]);
+
+  const stats = useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const todayCount = entries.filter(
+      (e) => new Date(e.created_at) >= today,
+    ).length;
+    return {
+      total: entries.length,
+      ko: entries.filter((e) => e.locale === "ko").length,
+      en: entries.filter((e) => e.locale === "en").length,
+      today: todayCount,
+    };
+  }, [entries]);
+
+  const pagedEntries = useMemo(() => {
+    const start = page * PAGE_SIZE;
+    return filtered.slice(start, start + PAGE_SIZE);
+  }, [filtered, page]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+
+  useEffect(() => {
+    if (page >= totalPages) setPage(0);
+  }, [page, totalPages]);
+
+  async function handleDelete(id: string, email: string) {
+    if (!confirm(`${email} 을(를) 명단에서 삭제할까요?`)) return;
+    setDeletingId(id);
+    const { error: deleteError } = await supabase
+      .from("waitlist")
+      .delete()
+      .eq("id", id);
+    setDeletingId(null);
+    if (deleteError) {
+      alert("삭제 실패: " + deleteError.message);
+      return;
+    }
+    setEntries((prev) => prev.filter((entry) => entry.id !== id));
+  }
+
+  function exportCsv() {
+    const header = ["email", "locale", "source", "created_at"];
+    const rows = filtered.map((e) =>
+      [e.email, e.locale, e.source ?? "", e.created_at].map(csvEscape).join(","),
+    );
+    const csv = [header.join(","), ...rows].join("\n");
+    const blob = new Blob([`\uFEFF${csv}`], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `waitlist-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function formatDate(dateStr: string) {
+    return new Date(dateStr).toLocaleString("ko-KR", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">출시 알림 명단</h1>
+          <p className="text-sm text-muted-foreground">
+            iOS 출시 알림 신청자 (BOK-371)
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={load} disabled={loading}>
+            {loading ? "불러오는 중..." : "새로고침"}
+          </Button>
+          <Button onClick={exportCsv} disabled={filtered.length === 0}>
+            CSV 내보내기 ({filtered.length})
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <StatCard label="총 신청자" value={stats.total} />
+        <StatCard label="오늘" value={stats.today} accent="primary" />
+        <StatCard label="한국어" value={stats.ko} />
+        <StatCard label="English" value={stats.en} />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>명단</CardTitle>
+          <CardDescription>
+            이메일 검색 + 언어 필터로 좁혀보세요. 최대 1,000건까지 조회합니다.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-col sm:flex-row gap-3">
+            <Input
+              placeholder="이메일 검색..."
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(0);
+              }}
+              className="sm:max-w-xs"
+            />
+            <Select
+              value={localeFilter}
+              onValueChange={(value) => {
+                setLocaleFilter(value as LocaleFilter);
+                setPage(0);
+              }}
+            >
+              <SelectTrigger className="sm:w-40">
+                <SelectValue placeholder="언어" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">전체</SelectItem>
+                <SelectItem value="ko">한국어</SelectItem>
+                <SelectItem value="en">English</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {error && (
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              조회 실패: {error}
+            </div>
+          )}
+
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>이메일</TableHead>
+                  <TableHead className="w-24">언어</TableHead>
+                  <TableHead className="w-28">출처</TableHead>
+                  <TableHead className="w-44">신청일</TableHead>
+                  <TableHead className="w-24 text-right">액션</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {loading ? (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
+                      불러오는 중...
+                    </TableCell>
+                  </TableRow>
+                ) : pagedEntries.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
+                      신청자가 없습니다.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  pagedEntries.map((entry) => (
+                    <TableRow key={entry.id}>
+                      <TableCell className="font-mono text-sm">{entry.email}</TableCell>
+                      <TableCell>
+                        <Badge variant={entry.locale === "ko" ? "default" : "secondary"}>
+                          {entry.locale.toUpperCase()}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {entry.source ?? "-"}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {formatDate(entry.created_at)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleDelete(entry.id, entry.email)}
+                          disabled={deletingId === entry.id}
+                        >
+                          {deletingId === entry.id ? "삭제 중..." : "삭제"}
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">
+                {page * PAGE_SIZE + 1}–
+                {Math.min((page + 1) * PAGE_SIZE, filtered.length)} / {filtered.length}
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                >
+                  이전
+                </Button>
+                <span className="px-2 py-1.5 text-muted-foreground">
+                  {page + 1} / {totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                  disabled={page >= totalPages - 1}
+                >
+                  다음
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: number;
+  accent?: "primary";
+}) {
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <div className="text-xs uppercase tracking-wide text-muted-foreground">
+          {label}
+        </div>
+        <div
+          className={
+            accent === "primary"
+              ? "mt-1 text-2xl font-bold text-primary"
+              : "mt-1 text-2xl font-bold"
+          }
+        >
+          {value.toLocaleString()}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function csvEscape(value: string): string {
+  if (/[",\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}

--- a/web/src/app/admin/waitlist/page.tsx
+++ b/web/src/app/admin/waitlist/page.tsx
@@ -126,14 +126,20 @@ export default function WaitlistAdminPage() {
     const rows = filtered.map((e) =>
       [e.email, e.locale, e.source ?? "", e.created_at].map(csvEscape).join(","),
     );
-    const csv = [header.join(","), ...rows].join("\n");
-    const blob = new Blob([`\uFEFF${csv}`], { type: "text/csv;charset=utf-8;" });
+    const csv = [header.join(","), ...rows].join("\r\n");
+    const blob = new Blob([`\uFEFF${csv}`], {
+      type: "application/octet-stream",
+    });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
     a.download = `waitlist-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.rel = "noopener";
+    a.style.display = "none";
+    document.body.appendChild(a);
     a.click();
-    URL.revokeObjectURL(url);
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 0);
   }
 
   function formatDate(dateStr: string) {
@@ -150,7 +156,7 @@ export default function WaitlistAdminPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold">출시 알림 명단</h1>
+          <h1 className="text-2xl font-bold text-foreground">출시 알림 명단</h1>
           <p className="text-sm text-muted-foreground">
             iOS 출시 알림 신청자 (BOK-371)
           </p>
@@ -324,7 +330,7 @@ function StatCard({
           className={
             accent === "primary"
               ? "mt-1 text-2xl font-bold text-primary"
-              : "mt-1 text-2xl font-bold"
+              : "mt-1 text-2xl font-bold text-foreground"
           }
         >
           {value.toLocaleString()}

--- a/web/src/components/waitlist-modal.tsx
+++ b/web/src/components/waitlist-modal.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState, useTransition, type FormEvent } from "react";
+import { useTranslations } from "next-intl";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { joinWaitlist } from "@/app/actions/waitlist";
+
+type Status =
+  | "idle"
+  | "submitting"
+  | "success"
+  | "duplicate"
+  | "invalid"
+  | "error";
+
+export function WaitlistModal({
+  open,
+  onOpenChange,
+  source = "landing",
+  locale,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  source?: string;
+  locale: string;
+}) {
+  const t = useTranslations("waitlist");
+  const [status, setStatus] = useState<Status>("idle");
+  const [, startTransition] = useTransition();
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    setStatus("submitting");
+    startTransition(async () => {
+      const result = await joinWaitlist(formData);
+      if (result.ok) {
+        setStatus("success");
+      } else if (result.code === "duplicate") {
+        setStatus("duplicate");
+      } else if (result.code === "invalid") {
+        setStatus("invalid");
+      } else {
+        setStatus("error");
+      }
+    });
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setTimeout(() => setStatus("idle"), 200);
+    }
+    onOpenChange(next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="border-white/10 sm:max-w-md"
+        style={{
+          background: "linear-gradient(180deg,#15172a 0%,#0d0f1a 100%)",
+          color: "white",
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle
+            className="text-white"
+            style={{ fontFamily: "var(--font-display)" }}
+          >
+            {t("title")}
+          </DialogTitle>
+          <DialogDescription style={{ color: "rgba(255,255,255,0.55)" }}>
+            {t("description")}
+          </DialogDescription>
+        </DialogHeader>
+
+        {status === "success" ? (
+          <div className="py-6 text-center">
+            <div className="mb-3 text-4xl">🎉</div>
+            <p
+              className="mb-1 font-semibold text-white"
+              style={{ fontFamily: "var(--font-display)" }}
+            >
+              {t("successTitle")}
+            </p>
+            <p
+              className="text-sm"
+              style={{ color: "rgba(255,255,255,0.55)" }}
+            >
+              {t("successDesc")}
+            </p>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div className="space-y-2">
+              <Label
+                htmlFor="waitlist-email"
+                className="text-white/80"
+              >
+                {t("emailLabel")}
+              </Label>
+              <Input
+                id="waitlist-email"
+                type="email"
+                name="email"
+                placeholder={t("emailPlaceholder")}
+                autoComplete="email"
+                required
+                disabled={status === "submitting"}
+                className="border-white/15 bg-white/5 text-white placeholder:text-white/30 focus-visible:border-[#5B7FFF] focus-visible:ring-[#5B7FFF]/30"
+              />
+            </div>
+            <input
+              type="text"
+              name="website"
+              tabIndex={-1}
+              autoComplete="off"
+              aria-hidden="true"
+              className="hidden"
+            />
+            <input type="hidden" name="locale" value={locale} />
+            <input type="hidden" name="source" value={source} />
+
+            {status === "duplicate" && (
+              <p className="text-sm text-amber-300">{t("duplicate")}</p>
+            )}
+            {status === "invalid" && (
+              <p className="text-sm text-rose-300">{t("invalid")}</p>
+            )}
+            {status === "error" && (
+              <p className="text-sm text-rose-300">{t("error")}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={status === "submitting"}
+              className="w-full rounded-xl py-2.5 font-semibold text-white transition disabled:opacity-60"
+              style={{
+                fontFamily: "var(--font-display)",
+                background: "linear-gradient(135deg,#5B7FFF,#6B8AFF)",
+                boxShadow: "0 8px 24px rgba(91,127,255,0.35)",
+              }}
+            >
+              {status === "submitting" ? t("submitting") : t("submit")}
+            </button>
+            <p
+              className="text-center text-xs"
+              style={{ color: "rgba(255,255,255,0.4)" }}
+            >
+              {t("privacy")}
+            </p>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/lib/email/client.ts
+++ b/web/src/lib/email/client.ts
@@ -1,0 +1,42 @@
+import { Resend } from "resend";
+import { waitlistWelcomeTemplate } from "./templates";
+
+let cached: Resend | null = null;
+
+function getClient(): Resend | null {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) return null;
+  if (!cached) cached = new Resend(apiKey);
+  return cached;
+}
+
+export async function sendWaitlistWelcome(
+  email: string,
+  locale: "ko" | "en",
+): Promise<{ ok: true; id?: string } | { ok: false; reason: string }> {
+  const client = getClient();
+  if (!client) {
+    return { ok: false, reason: "RESEND_API_KEY not configured" };
+  }
+
+  const from = process.env.RESEND_FROM_EMAIL ?? "Bookgolas <onboarding@resend.dev>";
+  const replyTo = process.env.RESEND_REPLY_TO;
+  const tpl = waitlistWelcomeTemplate(locale);
+
+  const { data, error } = await client.emails.send({
+    from,
+    to: email,
+    subject: tpl.subject,
+    html: tpl.html,
+    text: tpl.text,
+    ...(replyTo ? { replyTo } : {}),
+    headers: {
+      "X-Entity-Ref-ID": `waitlist-${Date.now()}`,
+    },
+  });
+
+  if (error) {
+    return { ok: false, reason: error.message };
+  }
+  return { ok: true, id: data?.id };
+}

--- a/web/src/lib/email/templates.ts
+++ b/web/src/lib/email/templates.ts
@@ -1,0 +1,129 @@
+type Locale = "ko" | "en";
+
+type Template = {
+  subject: string;
+  html: string;
+  text: string;
+};
+
+const SITE_URL = "https://book-golas.vercel.app";
+
+export function waitlistWelcomeTemplate(locale: Locale): Template {
+  return locale === "en" ? enTemplate() : koTemplate();
+}
+
+function koTemplate(): Template {
+  return {
+    subject: "북골라스 출시 알림 신청 완료 🎉",
+    text: [
+      "북골라스 출시 알림 신청이 완료되었습니다.",
+      "",
+      "iOS 앱이 App Store에 출시되는 즉시 이메일로 알려드릴게요.",
+      "조금만 기다려주세요!",
+      "",
+      `웹 미리보기: ${SITE_URL}`,
+      "",
+      "— byungsker (Bookgolas)",
+    ].join("\n"),
+    html: layout(
+      "신청 완료 🎉",
+      `
+        <p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:#1f2937;">
+          북골라스 <strong>출시 알림 신청</strong>이 완료되었습니다.
+        </p>
+        <p style="margin:0 0 16px;font-size:15px;line-height:1.7;color:#4b5563;">
+          iOS 앱이 App Store에 출시되는 즉시 이 이메일로 가장 먼저 알려드릴게요.
+          조금만 기다려주세요!
+        </p>
+        <div style="margin:24px 0;text-align:center;">
+          <a href="${SITE_URL}" style="display:inline-block;padding:12px 28px;background:linear-gradient(135deg,#5B7FFF,#6B8AFF);color:#fff;text-decoration:none;border-radius:12px;font-weight:600;font-size:14px;">
+            웹사이트 둘러보기 →
+          </a>
+        </div>
+        <p style="margin:24px 0 0;font-size:13px;color:#9ca3af;line-height:1.6;">
+          이 이메일에 답장하시면 직접 받아볼게요.<br/>
+          출시 알림 외 다른 용도로는 사용되지 않습니다.
+        </p>
+      `,
+    ),
+  };
+}
+
+function enTemplate(): Template {
+  return {
+    subject: "You're on the Bookgolas waitlist 🎉",
+    text: [
+      "You're on the Bookgolas launch waitlist.",
+      "",
+      "We'll email you the moment Bookgolas hits the App Store.",
+      "Stay tuned!",
+      "",
+      `Web preview: ${SITE_URL}`,
+      "",
+      "— byungsker (Bookgolas)",
+    ].join("\n"),
+    html: layout(
+      "You're on the list 🎉",
+      `
+        <p style="margin:0 0 16px;font-size:16px;line-height:1.6;color:#1f2937;">
+          You're confirmed on the <strong>Bookgolas launch waitlist</strong>.
+        </p>
+        <p style="margin:0 0 16px;font-size:15px;line-height:1.7;color:#4b5563;">
+          We'll email you the moment Bookgolas hits the App Store. Stay tuned!
+        </p>
+        <div style="margin:24px 0;text-align:center;">
+          <a href="${SITE_URL}" style="display:inline-block;padding:12px 28px;background:linear-gradient(135deg,#5B7FFF,#6B8AFF);color:#fff;text-decoration:none;border-radius:12px;font-weight:600;font-size:14px;">
+            Visit the site →
+          </a>
+        </div>
+        <p style="margin:24px 0 0;font-size:13px;color:#9ca3af;line-height:1.6;">
+          Reply to this email to reach me directly.<br/>
+          We'll only use your email for the launch announcement.
+        </p>
+      `,
+    ),
+  };
+}
+
+function layout(title: string, body: string): string {
+  return `<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>${title}</title>
+  </head>
+  <body style="margin:0;padding:0;background:#f3f4f6;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f3f4f6;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="max-width:560px;background:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 4px 24px rgba(0,0,0,0.06);">
+            <tr>
+              <td style="padding:32px 32px 0;">
+                <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:18px;font-weight:700;color:#5B7FFF;margin-bottom:8px;">
+                  Bookgolas
+                </div>
+                <h1 style="margin:0 0 24px;font-size:22px;line-height:1.3;color:#111827;font-weight:700;">
+                  ${title}
+                </h1>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0 32px 32px;">
+                ${body}
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:16px 32px 24px;border-top:1px solid #f3f4f6;">
+                <p style="margin:0;font-size:12px;color:#9ca3af;text-align:center;">
+                  © 2026 Bookgolas · Made by <a href="https://github.com/byungsker" style="color:#6B8AFF;text-decoration:none;">byungsker</a>
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+}


### PR DESCRIPTION
## 📌 Summary

2026-04-18 일일 작업 통합. BOK-371 (랜딩 WaitList + Resend 메일 + 어드민 명단) 단일 이슈를 dev에 반영합니다.

## 📋 Changes

머지된 이슈:
- **BOK-371 — 랜딩페이지 / WaitList 만들기** (PR #225, merge commit `18d61c4`)
  - `./supabase/migrations/20260418000000_create_waitlist.sql`: waitlist 테이블 + RLS (anon INSERT)
  - `./supabase/migrations/20260419000000_waitlist_admin_policies.sql`: admin SELECT/DELETE 정책
  - `./web/src/app/actions/waitlist.ts`: Server Action (검증, honeypot, after()로 메일 발송)
  - `./web/src/components/waitlist-modal.tsx`: shadcn Dialog 모달
  - `./web/src/app/[locale]/page.tsx`: nav/hero/cta 3곳 모달 트리거 + AppStoreWaitlistButton
  - `./web/messages/ko.json`, `./web/messages/en.json`: waitlist.* / hero.iosComingSoon / cta.* 갱신
  - `./web/src/lib/email/templates.ts`, `./web/src/lib/email/client.ts`: Resend ko/en HTML 메일 + fire-and-forget
  - `./web/src/app/admin/waitlist/page.tsx`: 어드민 명단 페이지 (검색/필터/CSV/삭제/페이지네이션)
  - `./web/src/app/admin/layout.tsx`: 사이드바 nav에 "출시 알림 명단" 추가
  - `./web/package.json`: resend 의존성 추가

## 🧠 Context & Background

- BOK-372에서 발견된 미작동 "앱 다운로드" 버튼을 출시 알림 신청 모달로 교체
- Resend로 신청 즉시 환영 메일 자동 발송 (서버 응답 지연 없음)
- 어드민에서 신청자 명단 확인 / CSV 내보내기 / 삭제 가능
- 로컬 npm run dev는 dev Supabase, Vercel Production은 prd Supabase로 환경 분리
- 어드민 라이트모드/반응형 전체 점검은 BOK-373으로 분리

## ✅ How to Test

각 이슈 PR에서 개별 테스트 완료. dev 머지 후:
1. Vercel이 dev 브랜치 push로 Preview 자동 빌드
2. Preview URL에서 모달/메일 동작 재확인
3. 이상 없으면 Vercel 대시보드에서 Production으로 promote

## 🔗 Related Issues

- Closes: BOK-371
- Spawned: BOK-373 (어드민 라이트모드 + 반응형 개선)
- Related: BOK-372 (Vercel Production deployment 부재 발견)

## 🙌 Additional Notes

- Supabase **dev/prd 양쪽 환경에 마이그레이션 적용 완료** (MCP `apply_migration` 사용)
- Vercel Production 환경변수 `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `RESEND_REPLY_TO` 등록 완료
- 머지 후 Vercel Production promote 별도 진행 (BOK-372 학습 적용)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added iOS launch waitlist signup functionality allowing users to register via email for release notifications
  * Introduced waitlist management admin panel with filtering, search, export, and deletion capabilities
  * Added automated welcome email delivery upon waitlist signup
  * Updated navigation and hero section messaging to promote iOS launch notification signup
  * Added form validation with honeypot spam protection and localized error messages
  * Full multi-language support (English and Korean) for waitlist UI and communications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->