### PR TITLE
feature/BOK-373-admin-light-mode-responsive

### DIFF
--- a/web/src/app/admin/announcements/page.tsx
+++ b/web/src/app/admin/announcements/page.tsx
@@ -105,11 +105,11 @@ export default function AnnouncementsPage() {
   function getStatusBadge(status: string) {
     switch (status) {
       case "sending":
-        return <Badge variant="outline" className="text-blue-500 border-blue-500/30 bg-blue-500/10">발송 중</Badge>;
+        return <Badge variant="outline" className="text-blue-700 dark:text-blue-400 border-blue-500/40 bg-blue-500/10">발송 중</Badge>;
       case "sent":
-        return <Badge variant="outline" className="text-green-500 border-green-500/30 bg-green-500/10">완료</Badge>;
+        return <Badge variant="outline" className="text-green-700 dark:text-green-400 border-green-500/40 bg-green-500/10">완료</Badge>;
       case "failed":
-        return <Badge variant="outline" className="text-red-500 border-red-500/30 bg-red-500/10">실패</Badge>;
+        return <Badge variant="outline" className="text-red-700 dark:text-red-400 border-red-500/40 bg-red-500/10">실패</Badge>;
       default:
         return <Badge variant="outline">대기</Badge>;
     }
@@ -175,8 +175,8 @@ export default function AnnouncementsPage() {
               <div
                 className={`p-3 rounded-md text-sm ${
                   result.type === "success"
-                    ? "bg-green-50 text-green-800 dark:bg-green-500/10 dark:text-green-400"
-                    : "bg-red-50 text-red-800 dark:bg-red-500/10 dark:text-red-400"
+                    ? "bg-green-100 text-green-800 dark:bg-green-500/10 dark:text-green-400"
+                    : "bg-red-100 text-red-800 dark:bg-red-500/10 dark:text-red-400"
                 }`}
               >
                 {result.message}
@@ -258,13 +258,13 @@ export default function AnnouncementsPage() {
                     <TableCell className="text-center">
                       {a.total_count}
                     </TableCell>
-                    <TableCell className="text-center text-green-500">
+                    <TableCell className="text-center text-green-700 dark:text-green-500">
                       {a.sent_count}
                     </TableCell>
                     <TableCell
                       className={`text-center ${
                         a.failed_count > 0
-                          ? "text-red-500"
+                          ? "text-red-700 dark:text-red-500"
                           : "text-muted-foreground"
                       }`}
                     >

--- a/web/src/app/admin/layout.tsx
+++ b/web/src/app/admin/layout.tsx
@@ -58,8 +58,8 @@ export default function AdminLayout({
   return (
     <div className="min-h-screen bg-background">
       <nav className="bg-card border-b border-border">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between h-16">
+        <div className="w-full mx-auto px-4 sm:px-6 lg:px-8 2xl:max-w-screen-2xl">
+          <div className="flex justify-between h-16 gap-4">
             <div className="flex items-center min-w-0">
               <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
                 <SheetTrigger asChild>
@@ -140,9 +140,9 @@ export default function AdminLayout({
                 ))}
               </div>
             </div>
-            <div className="flex items-center gap-2 sm:gap-3">
+            <div className="flex items-center gap-2 sm:gap-3 shrink-0">
               {userEmail && (
-                <span className="hidden xl:inline text-sm text-muted-foreground truncate max-w-[180px]">
+                <span className="hidden 2xl:inline text-sm text-muted-foreground truncate max-w-[180px]">
                   {userEmail}
                 </span>
               )}

--- a/web/src/app/admin/layout.tsx
+++ b/web/src/app/admin/layout.tsx
@@ -15,6 +15,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
+import { ThemeToggle } from "@/components/admin/theme-toggle";
 
 const navItems = [
   { href: "/admin", label: "대시보드", icon: "📊" },
@@ -65,7 +66,7 @@ export default function AdminLayout({
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="lg:hidden mr-2 text-foreground"
+                    className="xl:hidden mr-2 text-foreground"
                     aria-label="메뉴 열기"
                   >
                     <Menu className="size-5" />
@@ -121,7 +122,7 @@ export default function AdminLayout({
                   Admin
                 </span>
               </Link>
-              <div className="hidden lg:ml-8 lg:flex lg:items-center lg:gap-1">
+              <div className="hidden xl:ml-8 xl:flex xl:items-center xl:gap-1">
                 {navItems.map((item) => (
                   <Link
                     key={item.href}
@@ -139,12 +140,13 @@ export default function AdminLayout({
                 ))}
               </div>
             </div>
-            <div className="flex items-center gap-2 sm:gap-4">
+            <div className="flex items-center gap-2 sm:gap-3">
               {userEmail && (
-                <span className="hidden sm:inline text-sm text-muted-foreground truncate max-w-[200px]">
+                <span className="hidden xl:inline text-sm text-muted-foreground truncate max-w-[180px]">
                   {userEmail}
                 </span>
               )}
+              <ThemeToggle />
               <Button variant="outline" size="sm" onClick={handleLogout}>
                 로그아웃
               </Button>

--- a/web/src/app/admin/layout.tsx
+++ b/web/src/app/admin/layout.tsx
@@ -6,7 +6,15 @@ import { usePathname, useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
 import { useEffect, useState } from "react";
+import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 
 const navItems = [
   { href: "/admin", label: "대시보드", icon: "📊" },
@@ -26,6 +34,7 @@ export default function AdminLayout({
   const pathname = usePathname();
   const router = useRouter();
   const [userEmail, setUserEmail] = useState<string | null>(null);
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
   useEffect(() => {
     async function getUser() {
@@ -50,7 +59,55 @@ export default function AdminLayout({
       <nav className="bg-card border-b border-border">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between h-16">
-            <div className="flex">
+            <div className="flex items-center min-w-0">
+              <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
+                <SheetTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="lg:hidden mr-2 text-foreground"
+                    aria-label="메뉴 열기"
+                  >
+                    <Menu className="size-5" />
+                  </Button>
+                </SheetTrigger>
+                <SheetContent side="left" className="w-72 p-0">
+                  <SheetHeader className="border-b border-border">
+                    <SheetTitle className="flex items-center gap-2">
+                      <Image
+                        src="/logo-bookgolas.png"
+                        alt="북골라스"
+                        width={28}
+                        height={28}
+                        className="rounded-md"
+                      />
+                      <span className="text-base font-bold text-foreground">북골라스</span>
+                      <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-primary/10 text-primary">
+                        Admin
+                      </span>
+                    </SheetTitle>
+                  </SheetHeader>
+                  <div className="flex flex-col gap-1 p-3">
+                    {navItems.map((item) => (
+                      <Link
+                        key={item.href}
+                        href={item.href}
+                        onClick={() => setMobileNavOpen(false)}
+                        className={cn(
+                          "flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                          pathname === item.href
+                            ? "bg-accent text-accent-foreground"
+                            : "text-foreground hover:bg-accent/60"
+                        )}
+                      >
+                        <span className="text-base">{item.icon}</span>
+                        <span>{item.label}</span>
+                      </Link>
+                    ))}
+                  </div>
+                </SheetContent>
+              </Sheet>
+
               <Link href="/admin" className="flex-shrink-0 flex items-center gap-2">
                 <Image
                   src="/logo-bookgolas.png"
@@ -60,15 +117,17 @@ export default function AdminLayout({
                   className="rounded-md"
                 />
                 <span className="text-xl font-bold text-foreground">북골라스</span>
-                <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-primary/10 text-primary">Admin</span>
+                <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-primary/10 text-primary">
+                  Admin
+                </span>
               </Link>
-              <div className="hidden sm:ml-8 sm:flex sm:space-x-4">
+              <div className="hidden lg:ml-8 lg:flex lg:items-center lg:gap-1">
                 {navItems.map((item) => (
                   <Link
                     key={item.href}
                     href={item.href}
                     className={cn(
-                      "inline-flex items-center px-3 py-2 text-sm font-medium rounded-md transition-colors",
+                      "inline-flex items-center whitespace-nowrap px-3 py-2 text-sm font-medium rounded-md transition-colors",
                       pathname === item.href
                         ? "bg-accent text-accent-foreground"
                         : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
@@ -80,9 +139,11 @@ export default function AdminLayout({
                 ))}
               </div>
             </div>
-            <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2 sm:gap-4">
               {userEmail && (
-                <span className="text-sm text-muted-foreground">{userEmail}</span>
+                <span className="hidden sm:inline text-sm text-muted-foreground truncate max-w-[200px]">
+                  {userEmail}
+                </span>
               )}
               <Button variant="outline" size="sm" onClick={handleLogout}>
                 로그아웃

--- a/web/src/app/admin/login/page.tsx
+++ b/web/src/app/admin/login/page.tsx
@@ -47,12 +47,12 @@ function LoginForm() {
         </CardHeader>
         <CardContent>
           {unauthorizedError && (
-            <div className="mb-4 p-3 bg-red-50 text-red-800 rounded-md text-sm">
+            <div className="mb-4 p-3 bg-red-100 text-red-800 dark:bg-red-500/10 dark:text-red-400 rounded-md text-sm">
               관리자 권한이 없습니다.
             </div>
           )}
           {error && (
-            <div className="mb-4 p-3 bg-red-50 text-red-800 rounded-md text-sm">
+            <div className="mb-4 p-3 bg-red-100 text-red-800 dark:bg-red-500/10 dark:text-red-400 rounded-md text-sm">
               {error}
             </div>
           )}
@@ -93,7 +93,7 @@ export default function AdminLoginPage() {
   return (
     <Suspense fallback={
       <div className="min-h-screen flex items-center justify-center bg-background">
-        <div className="text-gray-500">로딩 중...</div>
+        <div className="text-muted-foreground">로딩 중...</div>
       </div>
     }>
       <LoginForm />

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -146,7 +146,7 @@ export default function AdminDashboard() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-orange-400">
+            <div className="text-3xl font-bold text-orange-600 dark:text-orange-400">
               {stats.fatigueUsers}
             </div>
           </CardContent>
@@ -191,7 +191,7 @@ export default function AdminDashboard() {
             <CardTitle className="text-foreground">최근 발송 로그</CardTitle>
             <a
               href="/admin/push-logs"
-              className="text-sm text-blue-400 hover:underline"
+              className="text-sm text-primary hover:underline"
             >
               더보기 →
             </a>
@@ -219,7 +219,7 @@ export default function AdminDashboard() {
                     </div>
                     <div>
                       {log.is_clicked ? (
-                        <span className="text-green-400">✅ clicked</span>
+                        <span className="text-green-600 dark:text-green-400">✅ clicked</span>
                       ) : (
                         <span className="text-muted-foreground">⏳ pending</span>
                       )}

--- a/web/src/app/admin/push-logs/page.tsx
+++ b/web/src/app/admin/push-logs/page.tsx
@@ -174,7 +174,7 @@ export default function PushLogsPage() {
                       </TableCell>
                       <TableCell className="text-center">
                         {log.is_clicked ? (
-                          <span className="text-green-400 font-medium">
+                          <span className="text-green-600 dark:text-green-400 font-medium">
                             ✅ Clicked
                           </span>
                         ) : (

--- a/web/src/app/admin/test-push/page.tsx
+++ b/web/src/app/admin/test-push/page.tsx
@@ -280,8 +280,10 @@ export default function TestPushPage() {
             {/* 결과 메시지 */}
             {result && (
               <div
-                className={`p-3 rounded-md ${
-                  result.success ? "bg-green-50 text-green-800" : "bg-red-50 text-red-800"
+                className={`p-3 rounded-md text-sm ${
+                  result.success
+                    ? "bg-green-100 text-green-800 dark:bg-green-500/10 dark:text-green-400"
+                    : "bg-red-100 text-red-800 dark:bg-red-500/10 dark:text-red-400"
                 }`}
               >
                 {result.message}

--- a/web/src/app/admin/users/page.tsx
+++ b/web/src/app/admin/users/page.tsx
@@ -131,7 +131,7 @@ export default function UsersPage() {
             <CardTitle className="text-sm font-medium text-muted-foreground">전체 유저</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{users.length}</div>
+            <div className="text-2xl font-bold text-foreground">{users.length}</div>
           </CardContent>
         </Card>
         <Card>
@@ -139,7 +139,7 @@ export default function UsersPage() {
             <CardTitle className="text-sm font-medium text-muted-foreground">관리자</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-red-500">{adminCount}</div>
+            <div className="text-2xl font-bold text-red-600 dark:text-red-500">{adminCount}</div>
           </CardContent>
         </Card>
         <Card>
@@ -147,7 +147,7 @@ export default function UsersPage() {
             <CardTitle className="text-sm font-medium text-muted-foreground">Pro 구독자</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-yellow-500">{proCount}</div>
+            <div className="text-2xl font-bold text-amber-600 dark:text-yellow-500">{proCount}</div>
           </CardContent>
         </Card>
       </div>
@@ -193,7 +193,7 @@ export default function UsersPage() {
               ) : (
                 filteredUsers.map((user) => (
                   <TableRow key={user.id}>
-                    <TableCell className="font-medium">
+                    <TableCell className="font-medium text-foreground">
                       <div className="flex items-center gap-2">
                         {user.email}
                         {user.id === currentUserId && (

--- a/web/src/components/admin/theme-toggle.tsx
+++ b/web/src/components/admin/theme-toggle.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+const STORAGE_KEY = "admin-theme";
+
+function readInitialTheme(): "dark" | "light" {
+  if (typeof window === "undefined") return "dark";
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === "dark" || stored === "light") return stored;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<"dark" | "light">(() => readInitialTheme());
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    return () => {
+      document.documentElement.classList.add("dark");
+    };
+  }, [theme]);
+
+  function toggle() {
+    setTheme((prev) => {
+      const next = prev === "dark" ? "light" : "dark";
+      window.localStorage.setItem(STORAGE_KEY, next);
+      return next;
+    });
+  }
+
+  const isDark = theme === "dark";
+  const label = isDark ? "라이트 모드로 전환" : "다크 모드로 전환";
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggle}
+      aria-label={label}
+      title={label}
+      className="text-foreground"
+      suppressHydrationWarning
+    >
+      <span suppressHydrationWarning>
+        {isDark ? <Sun className="size-4" /> : <Moon className="size-4" />}
+      </span>
+    </Button>
+  );
+}

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border border-neutral-300 bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+type SheetSide = "top" | "bottom" | "left" | "right"
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  side?: SheetSide
+  showCloseButton?: boolean
+}) {
+  const sideClasses: Record<SheetSide, string> = {
+    right:
+      "inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+    left:
+      "inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
+    top:
+      "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+    bottom:
+      "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+  }
+
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <DialogPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg duration-300 ease-in-out outline-none",
+          sideClasses[side],
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="sheet-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none"
+          >
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground text-base font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}


### PR DESCRIPTION
## 📌 Summary

`/admin/*` 어드민 페이지의 라이트 모드 가시성과 좁은/중간 화면 반응형 레이아웃 깨짐을 개선했습니다.

## 📋 Changes

- `./web/src/app/admin/layout.tsx`: 반응형 sidebar 개편. `<xl`에서 햄버거 + 왼쪽 Sheet, `xl+`에서 전체 nav. 헤더 컨테이너 폭 `max-w-7xl`→`w-full + 2xl:max-w-screen-2xl`. 이메일은 `2xl:inline`, 우측 그룹 `shrink-0`. ThemeToggle 장착
- `./web/src/components/ui/sheet.tsx`: shadcn Sheet 컴포넌트 신규 추가 (Radix Dialog 기반, 4방향 지원)
- `./web/src/components/admin/theme-toggle.tsx`: 라이트/다크 토글 버튼. localStorage(`admin-theme`) + `prefers-color-scheme` fallback, admin 페이지 이탈 시 `.dark` 복원으로 랜딩 보호
- `./web/src/components/ui/button.tsx`: outline variant 라이트 모드 가시성 개선 — `border-neutral-300` + `text-foreground` 명시 (기존 `border-input`이 흰 배경과 구분되지 않던 문제)
- `./web/src/app/admin/page.tsx`: `text-orange-400`→`text-orange-600 dark:text-orange-400`, 더보기 링크 `text-blue-400`→`text-primary`, clicked 상태 색상 dark variant
- `./web/src/app/admin/users/page.tsx`: StatCard 숫자/이메일에 `text-foreground`, `text-yellow-500`→`text-amber-600 dark:text-yellow-500`, `text-red-500`→`text-red-600 dark:text-red-500`
- `./web/src/app/admin/push-logs/page.tsx`: clicked 상태 `text-green-400`→`text-green-600 dark:text-green-400`
- `./web/src/app/admin/announcements/page.tsx`: 상태 배지 라이트 모드 대응, 성공/실패 테이블 숫자 색상 dark variant, 결과 메시지 배경 `bg-red-50`→`bg-red-100`
- `./web/src/app/admin/test-push/page.tsx`: 결과 메시지에 dark variant 추가
- `./web/src/app/admin/login/page.tsx`: 에러 박스 라이트 대비 개선, `text-gray-500`→`text-muted-foreground`

## 🧠 Context & Background

BOK-371 `/admin/waitlist` 작업 중 발견된 이슈.

- 흰 배경에 `text-*-400` 같은 연한 색이 겹쳐 가독성이 심각하게 낮았음 (StatCard 숫자, outline 버튼 텍스트 등)
- `sm:flex` 기준 수평 nav가 768–1535px 구간에서 라벨 줄바꿈 또는 우측 영역(이메일/로그아웃)과 겹침
- 다크/라이트 전환 수단이 전혀 없어 라이트 모드 사용자가 강제로 다크 모드를 보게 되는 케이스 있음

## ✅ How to Test

1. `/admin/login` 접속 → 로그인
2. 우측 상단 Sun/Moon 아이콘 클릭 → 라이트/다크 전환 확인 (새로고침 후에도 선택 유지)
3. 뷰포트 너비 조정:
   - < 1280px: 좌측 햄버거 메뉴 등장, 클릭 시 좌측 Sheet로 nav 펼쳐짐
   - 1280–1535px: 우측 이메일 숨김, nav 겹침 없음
   - 1536px+: 이메일까지 표시
4. 라이트 모드에서 각 페이지 확인:
   - `/admin`: "더보기 →", StatCard "미클릭 3+" 숫자 가독성
   - `/admin/users`: 관리자/Pro 카운터, 테이블 이메일 가독성
   - `/admin/push-logs`: "✅ Clicked" 가독성
   - `/admin/announcements`: 상태 배지, 성공/실패 숫자, 결과 메시지
   - `/admin/waitlist`: "새로고침" outline 버튼이 선명하게 보이는지
5. 랜딩(`/`) 재방문 시 다크 모드가 자동 복원되는지

## 🔗 Related Issues

- Closes: BOK-373
- Follow-up: 어드민 발송 로그 데이터 조회 누락(별도 이슈 예정)

## 🙌 Additional Notes

- 어드민 강제 다크 모드 적용은 본 PR에서 채택하지 않음(토글 지원으로 대체)
- Button outline variant 변경은 전역 영향 — admin 외 페이지(랜딩은 다크 전용)에도 라이트 모드 outline 대비가 자연스럽게 개선됨