### PR TITLE
feat: prepare subscription launch readiness

### DIFF
--- a/app/lib/data/services/auth_service.dart
+++ b/app/lib/data/services/auth_service.dart
@@ -51,6 +51,7 @@ class AuthService {
           'id': userId,
           'email': email,
           'nickname': name,
+          'revenuecat_user_id': userId,
           'created_at': DateTime.now().toUtc().toIso8601String(),
         });
       }
@@ -309,6 +310,7 @@ class AuthService {
         'id': userId,
         'email': email,
         'nickname': nickname,
+        'revenuecat_user_id': userId,
       });
 
       final newData =

--- a/app/lib/data/services/subscription_service.dart
+++ b/app/lib/data/services/subscription_service.dart
@@ -8,7 +8,7 @@ import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
 /// Provides methods for checking subscription status, presenting paywall,
 /// and managing customer center interactions.
 class SubscriptionService {
-  static const String _proEntitlementId = "byungsker's lab Pro";
+  static const String _proEntitlementId = 'byungskerslab/북골라스 Pro';
 
   /// Gets the current customer info from RevenueCat.
   ///
@@ -91,12 +91,14 @@ class SubscriptionService {
   /// Restores previous purchases for the current user.
   ///
   /// Useful when user reinstalls app or switches devices.
-  Future<void> restorePurchases() async {
+  Future<bool> restorePurchases() async {
     try {
-      await Purchases.restorePurchases();
+      final customerInfo = await Purchases.restorePurchases();
       debugPrint('Purchases restored successfully');
+      return _hasProEntitlement(customerInfo);
     } catch (e) {
       debugPrint('Failed to restore purchases: $e');
+      return false;
     }
   }
 
@@ -125,7 +127,7 @@ class SubscriptionService {
         orElse: () => offerings.current!.monthly!,
       );
       if (monthlyPackage == null) return false;
-      await Purchases.purchasePackage(monthlyPackage);
+      await Purchases.purchase(PurchaseParams.package(monthlyPackage));
       return true;
     } catch (e) {
       debugPrint('Failed to purchase monthly: $e');
@@ -142,7 +144,7 @@ class SubscriptionService {
         orElse: () => offerings.current!.annual!,
       );
       if (yearlyPackage == null) return false;
-      await Purchases.purchasePackage(yearlyPackage);
+      await Purchases.purchase(PurchaseParams.package(yearlyPackage));
       return true;
     } catch (e) {
       debugPrint('Failed to purchase yearly: $e');

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -893,7 +893,7 @@
            "paywallBenefit1": "Unlimited concurrent reading",
            "@paywallBenefit1": {"description": "Unlimited concurrent reading"},
 
-           "paywallBenefit2": "AI Recall 30 times per month",
+           "paywallBenefit2": "Unlimited AI Recall",
            "@paywallBenefit2": {"description": "AI Recall monthly usage"},
 
            "paywallBenefit3": "Reading insights & statistics",
@@ -902,7 +902,7 @@
            "paywallMonthly": "Monthly",
            "@paywallMonthly": {"description": "Monthly subscription"},
 
-           "paywallMonthlyPrice": "$3.90",
+           "paywallMonthlyPrice": "US$2.99",
            "@paywallMonthlyPrice": {"description": "Monthly price"},
 
            "paywallPerMonth": "/mo",
@@ -911,13 +911,13 @@
            "paywallYearly": "Yearly",
            "@paywallYearly": {"description": "Yearly subscription"},
 
-           "paywallYearlyPrice": "$29.90",
+           "paywallYearlyPrice": "US$19.99",
            "@paywallYearlyPrice": {"description": "Yearly price"},
 
            "paywallPerYear": "/yr",
            "@paywallPerYear": {"description": "Per year label"},
 
-           "paywallYearlySavings": "Save 36% with yearly",
+           "paywallYearlySavings": "Save 44% with yearly",
            "@paywallYearlySavings": {"description": "Yearly savings message"},
 
            "paywallRestore": "Restore purchases",
@@ -965,7 +965,7 @@
            "subscriptionMonthly": "Monthly",
            "@subscriptionMonthly": {"description": "Monthly subscription"},
 
-           "subscriptionMonthlyPrice": "$3.90",
+           "subscriptionMonthlyPrice": "US$2.99",
            "@subscriptionMonthlyPrice": {"description": "Monthly price"},
 
            "subscriptionPerMonth": "/mo",
@@ -974,13 +974,13 @@
            "subscriptionYearly": "Yearly",
            "@subscriptionYearly": {"description": "Yearly subscription"},
 
-           "subscriptionYearlyPrice": "$29.90",
+           "subscriptionYearlyPrice": "US$19.99",
            "@subscriptionYearlyPrice": {"description": "Yearly price"},
 
            "subscriptionPerYear": "/yr",
            "@subscriptionPerYear": {"description": "Per year label"},
 
-           "subscriptionYearlySavings": "Save 36%",
+           "subscriptionYearlySavings": "Save 44%",
            "@subscriptionYearlySavings": {"description": "Yearly savings"},
 
            "subscriptionBenefitsTitle": "Pro Benefits",
@@ -989,7 +989,7 @@
            "subscriptionBenefit1": "Unlimited concurrent reading",
            "@subscriptionBenefit1": {"description": "Unlimited concurrent reading"},
 
-           "subscriptionBenefit2": "AI Recall 30 times per month",
+           "subscriptionBenefit2": "Unlimited AI Recall",
            "@subscriptionBenefit2": {"description": "AI Recall monthly usage"},
 
            "subscriptionBenefit3": "Reading insights & statistics",

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2424,7 +2424,7 @@
         "paywallBenefit1": "동시 읽기 무제한",
         "@paywallBenefit1": {"description": "Unlimited concurrent reading"},
 
-        "paywallBenefit2": "AI Recall 월 30회 사용",
+        "paywallBenefit2": "AI Recall 무제한",
         "@paywallBenefit2": {"description": "AI Recall monthly usage"},
 
         "paywallBenefit3": "독서 인사이트 및 통계",
@@ -2433,7 +2433,7 @@
         "paywallMonthly": "월간 구독",
         "@paywallMonthly": {"description": "Monthly subscription"},
 
-        "paywallMonthlyPrice": "₩3,900",
+        "paywallMonthlyPrice": "US$2.99",
         "@paywallMonthlyPrice": {"description": "Monthly price"},
 
         "paywallPerMonth": "/월",
@@ -2442,13 +2442,13 @@
         "paywallYearly": "연간 구독",
         "@paywallYearly": {"description": "Yearly subscription"},
 
-        "paywallYearlyPrice": "₩29,900",
+        "paywallYearlyPrice": "US$19.99",
         "@paywallYearlyPrice": {"description": "Yearly price"},
 
         "paywallPerYear": "/년",
         "@paywallPerYear": {"description": "Per year label"},
 
-        "paywallYearlySavings": "연간 구독 시 36% 절약",
+        "paywallYearlySavings": "연간 구독 시 44% 절약",
         "@paywallYearlySavings": {"description": "Yearly savings message"},
 
         "paywallRestore": "이전 구매 복원",
@@ -2496,7 +2496,7 @@
         "subscriptionMonthly": "월간 구독",
         "@subscriptionMonthly": {"description": "Monthly subscription"},
 
-        "subscriptionMonthlyPrice": "₩3,900",
+        "subscriptionMonthlyPrice": "US$2.99",
         "@subscriptionMonthlyPrice": {"description": "Monthly price"},
 
         "subscriptionPerMonth": "/월",
@@ -2505,13 +2505,13 @@
         "subscriptionYearly": "연간 구독",
         "@subscriptionYearly": {"description": "Yearly subscription"},
 
-        "subscriptionYearlyPrice": "₩29,900",
+        "subscriptionYearlyPrice": "US$19.99",
         "@subscriptionYearlyPrice": {"description": "Yearly price"},
 
         "subscriptionPerYear": "/년",
         "@subscriptionPerYear": {"description": "Per year label"},
 
-        "subscriptionYearlySavings": "36% 절약",
+        "subscriptionYearlySavings": "44% 절약",
         "@subscriptionYearlySavings": {"description": "Yearly savings"},
 
         "subscriptionBenefitsTitle": "Pro 혜택",
@@ -2520,7 +2520,7 @@
         "subscriptionBenefit1": "동시 읽기 무제한",
         "@subscriptionBenefit1": {"description": "Unlimited concurrent reading"},
 
-        "subscriptionBenefit2": "AI Recall 월 30회 사용",
+        "subscriptionBenefit2": "AI Recall 무제한",
         "@subscriptionBenefit2": {"description": "AI Recall monthly usage"},
 
         "subscriptionBenefit3": "독서 인사이트 및 통계",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -4015,7 +4015,7 @@ abstract class AppLocalizations {
   /// AI Recall monthly usage
   ///
   /// In ko, this message translates to:
-  /// **'AI Recall 월 30회 사용'**
+  /// **'AI Recall 무제한'**
   String get paywallBenefit2;
 
   /// Reading insights and statistics
@@ -4033,7 +4033,7 @@ abstract class AppLocalizations {
   /// Monthly price
   ///
   /// In ko, this message translates to:
-  /// **'₩3,900'**
+  /// **'US\$2.99'**
   String get paywallMonthlyPrice;
 
   /// Per month label
@@ -4051,7 +4051,7 @@ abstract class AppLocalizations {
   /// Yearly price
   ///
   /// In ko, this message translates to:
-  /// **'₩29,900'**
+  /// **'US\$19.99'**
   String get paywallYearlyPrice;
 
   /// Per year label
@@ -4063,7 +4063,7 @@ abstract class AppLocalizations {
   /// Yearly savings message
   ///
   /// In ko, this message translates to:
-  /// **'연간 구독 시 36% 절약'**
+  /// **'연간 구독 시 44% 절약'**
   String get paywallYearlySavings;
 
   /// Restore purchases button
@@ -4153,7 +4153,7 @@ abstract class AppLocalizations {
   /// Monthly price
   ///
   /// In ko, this message translates to:
-  /// **'₩3,900'**
+  /// **'US\$2.99'**
   String get subscriptionMonthlyPrice;
 
   /// Per month label
@@ -4171,7 +4171,7 @@ abstract class AppLocalizations {
   /// Yearly price
   ///
   /// In ko, this message translates to:
-  /// **'₩29,900'**
+  /// **'US\$19.99'**
   String get subscriptionYearlyPrice;
 
   /// Per year label
@@ -4183,7 +4183,7 @@ abstract class AppLocalizations {
   /// Yearly savings
   ///
   /// In ko, this message translates to:
-  /// **'36% 절약'**
+  /// **'44% 절약'**
   String get subscriptionYearlySavings;
 
   /// Pro benefits title
@@ -4201,7 +4201,7 @@ abstract class AppLocalizations {
   /// AI Recall monthly usage
   ///
   /// In ko, this message translates to:
-  /// **'AI Recall 월 30회 사용'**
+  /// **'AI Recall 무제한'**
   String get subscriptionBenefit2;
 
   /// Reading insights

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -2198,7 +2198,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get paywallBenefit1 => 'Unlimited concurrent reading';
 
   @override
-  String get paywallBenefit2 => 'AI Recall 30 times per month';
+  String get paywallBenefit2 => 'Unlimited AI Recall';
 
   @override
   String get paywallBenefit3 => 'Reading insights & statistics';
@@ -2207,7 +2207,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get paywallMonthly => 'Monthly';
 
   @override
-  String get paywallMonthlyPrice => '\$3.90';
+  String get paywallMonthlyPrice => 'US\$2.99';
 
   @override
   String get paywallPerMonth => '/mo';
@@ -2216,13 +2216,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get paywallYearly => 'Yearly';
 
   @override
-  String get paywallYearlyPrice => '\$29.90';
+  String get paywallYearlyPrice => 'US\$19.99';
 
   @override
   String get paywallPerYear => '/yr';
 
   @override
-  String get paywallYearlySavings => 'Save 36% with yearly';
+  String get paywallYearlySavings => 'Save 44% with yearly';
 
   @override
   String get paywallRestore => 'Restore purchases';
@@ -2271,7 +2271,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get subscriptionMonthly => 'Monthly';
 
   @override
-  String get subscriptionMonthlyPrice => '\$3.90';
+  String get subscriptionMonthlyPrice => 'US\$2.99';
 
   @override
   String get subscriptionPerMonth => '/mo';
@@ -2280,13 +2280,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get subscriptionYearly => 'Yearly';
 
   @override
-  String get subscriptionYearlyPrice => '\$29.90';
+  String get subscriptionYearlyPrice => 'US\$19.99';
 
   @override
   String get subscriptionPerYear => '/yr';
 
   @override
-  String get subscriptionYearlySavings => 'Save 36%';
+  String get subscriptionYearlySavings => 'Save 44%';
 
   @override
   String get subscriptionBenefitsTitle => 'Pro Benefits';
@@ -2295,7 +2295,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get subscriptionBenefit1 => 'Unlimited concurrent reading';
 
   @override
-  String get subscriptionBenefit2 => 'AI Recall 30 times per month';
+  String get subscriptionBenefit2 => 'Unlimited AI Recall';
 
   @override
   String get subscriptionBenefit3 => 'Reading insights & statistics';

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -2132,7 +2132,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get paywallBenefit1 => '동시 읽기 무제한';
 
   @override
-  String get paywallBenefit2 => 'AI Recall 월 30회 사용';
+  String get paywallBenefit2 => 'AI Recall 무제한';
 
   @override
   String get paywallBenefit3 => '독서 인사이트 및 통계';
@@ -2141,7 +2141,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get paywallMonthly => '월간 구독';
 
   @override
-  String get paywallMonthlyPrice => '₩3,900';
+  String get paywallMonthlyPrice => 'US\$2.99';
 
   @override
   String get paywallPerMonth => '/월';
@@ -2150,13 +2150,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get paywallYearly => '연간 구독';
 
   @override
-  String get paywallYearlyPrice => '₩29,900';
+  String get paywallYearlyPrice => 'US\$19.99';
 
   @override
   String get paywallPerYear => '/년';
 
   @override
-  String get paywallYearlySavings => '연간 구독 시 36% 절약';
+  String get paywallYearlySavings => '연간 구독 시 44% 절약';
 
   @override
   String get paywallRestore => '이전 구매 복원';
@@ -2204,7 +2204,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get subscriptionMonthly => '월간 구독';
 
   @override
-  String get subscriptionMonthlyPrice => '₩3,900';
+  String get subscriptionMonthlyPrice => 'US\$2.99';
 
   @override
   String get subscriptionPerMonth => '/월';
@@ -2213,13 +2213,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get subscriptionYearly => '연간 구독';
 
   @override
-  String get subscriptionYearlyPrice => '₩29,900';
+  String get subscriptionYearlyPrice => 'US\$19.99';
 
   @override
   String get subscriptionPerYear => '/년';
 
   @override
-  String get subscriptionYearlySavings => '36% 절약';
+  String get subscriptionYearlySavings => '44% 절약';
 
   @override
   String get subscriptionBenefitsTitle => 'Pro 혜택';
@@ -2228,7 +2228,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get subscriptionBenefit1 => '동시 읽기 무제한';
 
   @override
-  String get subscriptionBenefit2 => 'AI Recall 월 30회 사용';
+  String get subscriptionBenefit2 => 'AI Recall 무제한';
 
   @override
   String get subscriptionBenefit3 => '독서 인사이트 및 통계';

--- a/app/lib/ui/subscription/view_model/subscription_view_model.dart
+++ b/app/lib/ui/subscription/view_model/subscription_view_model.dart
@@ -79,9 +79,9 @@ class SubscriptionViewModel extends BaseViewModel {
     setLoading(true);
     clearError();
     try {
-      await _subscriptionService.restorePurchases();
+      final restored = await _subscriptionService.restorePurchases();
       await loadSubscriptionStatus();
-      return true;
+      return restored;
     } catch (e) {
       setError('복원에 실패했습니다: $e');
       return false;

--- a/app/lib/utils/subscription_utils.dart
+++ b/app/lib/utils/subscription_utils.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 /// Constants for subscription tiers and limits
@@ -19,6 +20,7 @@ class SubscriptionConstants {
 /// Utility class for checking subscription status and limits
 class SubscriptionUtils {
   static final SupabaseClient _supabase = Supabase.instance.client;
+  static const String _proEntitlementId = 'byungskerslab/북골라스 Pro';
 
   /// Checks if the current user is a super admin
   ///
@@ -40,6 +42,8 @@ class SubscriptionUtils {
       final userId = _supabase.auth.currentUser?.id;
       if (userId == null) return false;
 
+      if (await _hasRevenueCatProEntitlement()) return true;
+
       final response = await _supabase
           .from('users')
           .select('subscription_status')
@@ -47,9 +51,7 @@ class SubscriptionUtils {
           .single();
 
       final status = response['subscription_status'] as String?;
-      return status == 'pro_monthly' ||
-          status == 'pro_yearly' ||
-          status == 'pro_lifetime';
+      return status == 'pro_monthly' || status == 'pro_yearly';
     } catch (e) {
       return false;
     }
@@ -57,9 +59,9 @@ class SubscriptionUtils {
 
   /// Gets the current subscription status
   ///
-  /// Returns: 'free', 'pro_monthly', 'pro_yearly', 'pro_lifetime', or null if not found
+  /// Returns: 'free', 'pro_monthly', 'pro_yearly', or null if not found
   static Future<String?> getSubscriptionStatus() async {
-    if (isSuperAdmin()) return 'pro_lifetime';
+    if (isSuperAdmin()) return 'pro_yearly';
 
     try {
       final userId = _supabase.auth.currentUser?.id;
@@ -114,11 +116,13 @@ class SubscriptionUtils {
 
       final response = await _supabase
           .from('users')
-          .select('ai_recall_usage_count')
+          .select('ai_recall_usage_count, ai_recall_reset_at')
           .eq('id', userId)
           .single();
 
       final usageCount = response['ai_recall_usage_count'] as int? ?? 0;
+      final resetAt = _parseResetAt(response['ai_recall_reset_at']);
+      if (_isResetDue(resetAt)) return true;
       return usageCount < SubscriptionConstants.maxAiRecallPerMonthFree;
     } catch (e) {
       return true; // If error, allow (fail open for better UX)
@@ -135,12 +139,19 @@ class SubscriptionUtils {
 
       final response = await _supabase
           .from('users')
-          .select('ai_recall_usage_count')
+          .select('ai_recall_usage_count, ai_recall_reset_at')
           .eq('id', userId)
           .single();
 
       final usageCount = response['ai_recall_usage_count'] as int? ?? 0;
-      return SubscriptionConstants.maxAiRecallPerMonthFree - usageCount;
+      final resetAt = _parseResetAt(response['ai_recall_reset_at']);
+      if (_isResetDue(resetAt)) {
+        return SubscriptionConstants.maxAiRecallPerMonthFree;
+      }
+      return (SubscriptionConstants.maxAiRecallPerMonthFree - usageCount).clamp(
+        0,
+        SubscriptionConstants.maxAiRecallPerMonthFree,
+      );
     } catch (e) {
       return SubscriptionConstants.maxAiRecallPerMonthFree;
     }
@@ -210,6 +221,24 @@ class SubscriptionUtils {
           .rpc('increment_ocr_daily_usage', params: {'p_user_id': userId});
     } catch (e) {
       debugPrint('Failed to increment OCR usage: $e');
+    }
+  }
+
+  static DateTime? _parseResetAt(Object? value) {
+    if (value is! String || value.isEmpty) return null;
+    return DateTime.tryParse(value);
+  }
+
+  static bool _isResetDue(DateTime? resetAt) {
+    return resetAt == null || !resetAt.isAfter(DateTime.now().toUtc());
+  }
+
+  static Future<bool> _hasRevenueCatProEntitlement() async {
+    try {
+      final customerInfo = await Purchases.getCustomerInfo();
+      return customerInfo.entitlements.active.containsKey(_proEntitlementId);
+    } catch (e) {
+      return false;
     }
   }
 }

--- a/app/metadata/review-notes.md
+++ b/app/metadata/review-notes.md
@@ -58,4 +58,4 @@ AI Recall and book search require an internet connection. Reading logs and notes
 - Pro Monthly: US$2.99/month
 - Pro Annual: US$19.99/year (44% savings)
 
-Subscriptions are managed through StoreKit 2. Auto-renewable subscription with standard Apple billing.
+Subscriptions are managed through Apple in-app purchase. Auto-renewable subscription with standard Apple billing.

--- a/app/privacy-policy.md
+++ b/app/privacy-policy.md
@@ -70,7 +70,7 @@ Bookgolas은 서비스 제공을 위해 다음과 같은 업체에 개인정보 
 ### 권리 행사 방법
 
 - 앱 내 설정 → 계정 삭제
-- 이메일: support@bookgolas.com
+- 이메일: support@bookgolas.app
 
 ## 7. 개인정보의 안전성 확보 조치
 
@@ -86,7 +86,7 @@ Bookgolas은 개인정보의 안전성 확보를 위해 다음과 같은 조치�
 ### 개인정보 보호책임자
 
 - **이름**: 이병우
-- **이메일**: support@bookgolas.com
+- **이메일**: support@bookgolas.app
 
 ### 개인정보 분쟁조정위원회
 
@@ -101,7 +101,7 @@ Bookgolas은 개인정보의 안전성 확보를 위해 다음과 같은 조치�
 
 개인정보 처리방침과 관련된 문의사항이 있으시면 언제든지 연락주시기 바랍니다.
 
-- **이메일**: support@bookgolas.com
+- **이메일**: support@bookgolas.app
 - **개발자**: 이병우
 
 ---

--- a/app/terms-of-service.md
+++ b/app/terms-of-service.md
@@ -92,7 +92,7 @@
 
 **운영자 정보**
 - **이름**: 이병우
-- **이메일**: support@bookgolas.com
+- **이메일**: support@bookgolas.app
 - **서비스명**: Bookgolas
 
 ---

--- a/supabase/functions/revenuecat-webhook/index.ts
+++ b/supabase/functions/revenuecat-webhook/index.ts
@@ -18,17 +18,34 @@ interface RevenueCatWebhookPayload {
   event: RevenueCatEvent;
 }
 
-type SubscriptionStatus = "free" | "pro_monthly" | "pro_yearly" | "pro_lifetime";
+type SubscriptionStatus =
+  | "free"
+  | "pro_monthly"
+  | "pro_yearly";
+
+const PRODUCT_STATUS_BY_ID: Record<string, SubscriptionStatus> = {
+  "monthly": "pro_monthly",
+  "yearly": "pro_yearly",
+  "bookgolas_pro_monthly": "pro_monthly",
+  "bookgolas_pro_yearly": "pro_yearly",
+  "com.bookgolas.app.pro.monthly": "pro_monthly",
+  "com.bookgolas.app.pro.yearly": "pro_yearly",
+};
 
 function mapProductIdToStatus(productId: string): SubscriptionStatus {
-  if (productId.includes("lifetime")) {
-    return "pro_lifetime";
-  } else if (productId.includes("yearly") || productId.includes("annual")) {
+  const normalizedProductId = productId.toLowerCase();
+  const status = PRODUCT_STATUS_BY_ID[normalizedProductId];
+  if (status) return status;
+
+  if (
+    normalizedProductId.includes("yearly") ||
+    normalizedProductId.includes("annual")
+  ) {
     return "pro_yearly";
-  } else if (productId.includes("monthly")) {
+  } else if (normalizedProductId.includes("monthly")) {
     return "pro_monthly";
   }
-  return "pro_monthly";
+  throw new Error(`Unsupported subscription product_id: ${productId}`);
 }
 
 function mapEventTypeToDbEventType(eventType: string): string {
@@ -44,11 +61,16 @@ function mapEventTypeToDbEventType(eventType: string): string {
 }
 
 function shouldUpdateToFreeStatus(eventType: string): boolean {
-  return ["CANCELLATION", "EXPIRATION", "REFUND"].includes(eventType);
+  return ["EXPIRATION", "REFUND"].includes(eventType);
 }
 
 function shouldUpdateToPaidStatus(eventType: string): boolean {
-  return ["INITIAL_PURCHASE", "RENEWAL"].includes(eventType);
+  return ["INITIAL_PURCHASE", "RENEWAL", "UNCANCELLATION", "PRODUCT_CHANGE"]
+    .includes(eventType);
+}
+
+function shouldUpdateExpirationOnly(eventType: string): boolean {
+  return ["CANCELLATION", "BILLING_ISSUE"].includes(eventType);
 }
 
 serve(async (req: Request) => {
@@ -66,23 +88,28 @@ serve(async (req: Request) => {
 
   try {
     const authHeader = req.headers.get("authorization");
-    if (REVENUECAT_WEBHOOK_AUTH_KEY && authHeader !== `Bearer ${REVENUECAT_WEBHOOK_AUTH_KEY}`) {
+    if (
+      REVENUECAT_WEBHOOK_AUTH_KEY &&
+      authHeader !== `Bearer ${REVENUECAT_WEBHOOK_AUTH_KEY}`
+    ) {
       console.error("Unauthorized webhook request");
       return new Response(
         JSON.stringify({ error: "Unauthorized" }),
-        { status: 401, headers: { "Content-Type": "application/json" } }
+        { status: 401, headers: { "Content-Type": "application/json" } },
       );
     }
 
     const payload: RevenueCatWebhookPayload = await req.json();
     const event = payload.event;
 
-    console.log(`Processing RevenueCat event: ${event.type} for user: ${event.app_user_id}`);
+    console.log(
+      `Processing RevenueCat event: ${event.type} for user: ${event.app_user_id}`,
+    );
 
     if (!event.type || !event.app_user_id) {
       return new Response(
         JSON.stringify({ error: "Missing required event fields" }),
-        { status: 400, headers: { "Content-Type": "application/json" } }
+        { status: 400, headers: { "Content-Type": "application/json" } },
       );
     }
 
@@ -94,36 +121,46 @@ serve(async (req: Request) => {
           autoRefreshToken: false,
           persistSession: false,
         },
-      }
+      },
     );
 
     const { data: user, error: userError } = await supabaseClient
       .from("users")
       .select("id")
-      .eq("revenuecat_user_id", event.app_user_id)
+      .or(
+        `id.eq.${event.app_user_id},revenuecat_user_id.eq.${event.app_user_id}`,
+      )
       .single();
 
     if (userError || !user) {
-      console.error(`User not found for RevenueCat ID: ${event.app_user_id}`, userError);
+      console.error(
+        `User not found for RevenueCat ID: ${event.app_user_id}`,
+        userError,
+      );
       return new Response(
-        JSON.stringify({ error: "User not found", revenuecat_user_id: event.app_user_id }),
-        { status: 404, headers: { "Content-Type": "application/json" } }
+        JSON.stringify({
+          error: "User not found",
+          revenuecat_user_id: event.app_user_id,
+        }),
+        { status: 404, headers: { "Content-Type": "application/json" } },
       );
     }
 
     console.log(`Found user: ${user.id}`);
 
+    const expiresAt = event.expiration_at_ms
+      ? new Date(event.expiration_at_ms).toISOString()
+      : null;
+
     if (shouldUpdateToPaidStatus(event.type)) {
       const subscriptionStatus = mapProductIdToStatus(event.product_id);
-      const expiresAt = event.expiration_at_ms
-        ? new Date(event.expiration_at_ms).toISOString()
-        : null;
 
       const { error: updateError } = await supabaseClient
         .from("users")
         .update({
           subscription_status: subscriptionStatus,
-          subscription_expires_at: subscriptionStatus === "pro_lifetime" ? null : expiresAt,
+          subscription_expires_at: expiresAt,
+          revenuecat_user_id: event.app_user_id,
         })
         .eq("id", user.id);
 
@@ -132,7 +169,27 @@ serve(async (req: Request) => {
         throw updateError;
       }
 
-      console.log(`Updated user ${user.id} to ${subscriptionStatus}, expires: ${expiresAt}`);
+      console.log(
+        `Updated user ${user.id} to ${subscriptionStatus}, expires: ${expiresAt}`,
+      );
+    } else if (shouldUpdateExpirationOnly(event.type)) {
+      const { error: updateError } = await supabaseClient
+        .from("users")
+        .update({
+          subscription_expires_at: expiresAt,
+          revenuecat_user_id: event.app_user_id,
+        })
+        .eq("id", user.id);
+
+      if (updateError) {
+        console.error(
+          "Failed to update user subscription expiration:",
+          updateError,
+        );
+        throw updateError;
+      }
+
+      console.log(`Updated user ${user.id} expiration only: ${expiresAt}`);
     } else if (shouldUpdateToFreeStatus(event.type)) {
       const { error: updateError } = await supabaseClient
         .from("users")
@@ -143,7 +200,10 @@ serve(async (req: Request) => {
         .eq("id", user.id);
 
       if (updateError) {
-        console.error("Failed to update user subscription to free:", updateError);
+        console.error(
+          "Failed to update user subscription to free:",
+          updateError,
+        );
         throw updateError;
       }
 
@@ -174,11 +234,13 @@ serve(async (req: Request) => {
           "Content-Type": "application/json",
           "Access-Control-Allow-Origin": "*",
         },
-      }
+      },
     );
   } catch (error: unknown) {
     console.error("Error processing webhook:", error);
-    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    const errorMessage = error instanceof Error
+      ? error.message
+      : "Unknown error";
     return new Response(
       JSON.stringify({ error: errorMessage }),
       {
@@ -187,7 +249,7 @@ serve(async (req: Request) => {
           "Content-Type": "application/json",
           "Access-Control-Allow-Origin": "*",
         },
-      }
+      },
     );
   }
 });

--- a/supabase/migrations/20260531163408_fix_subscription_launch_readiness.sql
+++ b/supabase/migrations/20260531163408_fix_subscription_launch_readiness.sql
@@ -1,0 +1,42 @@
+CREATE OR REPLACE FUNCTION increment_ai_recall_usage(user_id UUID)
+RETURNS void AS $$
+BEGIN
+  UPDATE public.users
+  SET
+    ai_recall_usage_count = CASE
+      WHEN ai_recall_reset_at IS NULL OR ai_recall_reset_at <= now() THEN 1
+      ELSE COALESCE(ai_recall_usage_count, 0) + 1
+    END,
+    ai_recall_reset_at = CASE
+      WHEN ai_recall_reset_at IS NULL OR ai_recall_reset_at <= now() THEN date_trunc('month', now()) + interval '1 month'
+      ELSE ai_recall_reset_at
+    END
+  WHERE id = user_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+UPDATE public.users
+SET revenuecat_user_id = id::text
+WHERE revenuecat_user_id IS NULL;
+
+UPDATE public.users
+SET subscription_status = 'free',
+    subscription_expires_at = NULL
+WHERE subscription_status = 'pro_lifetime';
+
+ALTER TABLE public.users
+  DROP CONSTRAINT IF EXISTS users_subscription_status_check;
+
+ALTER TABLE public.users
+  ADD CONSTRAINT users_subscription_status_check
+  CHECK (subscription_status IN ('free', 'pro_monthly', 'pro_yearly'));
+
+COMMENT ON COLUMN public.users.subscription_status IS 'User subscription tier: free, pro_monthly, pro_yearly';
+COMMENT ON COLUMN public.users.subscription_expires_at IS 'Subscription expiration date (NULL for free tier)';
+
+ALTER TABLE public.subscription_events
+  DROP CONSTRAINT IF EXISTS subscription_events_event_type_check;
+
+ALTER TABLE public.subscription_events
+  ADD CONSTRAINT subscription_events_event_type_check
+  CHECK (event_type IN ('initial_purchase', 'renewal', 'cancellation', 'expiration', 'refund', 'billing_issue', 'uncancellation', 'product_change'));

--- a/web/src/app/admin/users/page.tsx
+++ b/web/src/app/admin/users/page.tsx
@@ -35,7 +35,6 @@ const SUBSCRIPTION_LABELS: Record<string, { label: string; variant: "default" | 
   free: { label: "Free", variant: "outline" },
   pro_monthly: { label: "Pro (Monthly)", variant: "default" },
   pro_yearly: { label: "Pro (Yearly)", variant: "default" },
-  pro_lifetime: { label: "Pro (Lifetime)", variant: "default" },
 };
 
 export default function UsersPage() {

--- a/web/src/app/privacy/page.tsx
+++ b/web/src/app/privacy/page.tsx
@@ -95,7 +95,7 @@ export default function PrivacyPage() {
             </li>
             <li>
               <strong className="text-gray-200">이메일</strong>:
-              support@bookgolas.com
+              support@bookgolas.app
             </li>
           </ul>
 
@@ -109,7 +109,7 @@ export default function PrivacyPage() {
           <ul className="list-disc pl-6 mb-4 text-gray-300">
             <li>
               <strong className="text-gray-200">이메일</strong>:
-              support@bookgolas.com
+              support@bookgolas.app
             </li>
           </ul>
         </div>

--- a/web/src/app/terms/page.tsx
+++ b/web/src/app/terms/page.tsx
@@ -145,7 +145,7 @@ export default function TermsPage() {
             </li>
             <li>
               <strong className="text-gray-200">이메일</strong>:
-              support@bookgolas.com
+              support@bookgolas.app
             </li>
           </ul>
         </div>


### PR DESCRIPTION
이번 PR은 RevenueCat 기반 구독 출시 준비를 위해 앱, webhook, DB migration, 법무/리뷰 문구를 정리합니다.

## 📋 Changes

- RevenueCat Pro entitlement 확인과 구매 복원 로직 개선
- App Store 월간/연간 구독만 사용하도록 Lifetime 경로 제거
- RevenueCat webhook의 구독 이벤트 처리와 product mapping 정리
- AI Recall 월간 사용량 reset 로직 보정 migration 추가
- 앱/웹 법무 문서, 리뷰 노트, 구독 가격/혜택 문구 정리
- 관리자 사용자 화면에서 Lifetime 구독 라벨 제거

## 🧠 Context & Background

- App Store 유료 구독 출시 전 월간/연간 구독만 운영하기 위한 정리입니다.
- RevenueCat App Store 앱, 제품, entitlement, offering 설정과 맞춰 코드 경로를 정리했습니다.

## ✅ How to Test

1. 앱에서 무료 사용자 상태로 paywall가 열리는지 확인
2. 월간/연간 구독 상품이 표시되는지 확인
3. 구독 후 Pro entitlement가 반영되는지 확인
4. 구매 복원과 Customer Center 진입을 확인
5. AI Recall 제한이 Pro 사용자에게 적용되지 않는지 확인

검증 완료:
- flutter test test/widget_test.dart
- deno check supabase/functions/revenuecat-webhook/index.ts
- git diff --check

## 🧾 Screenshots or Videos (Optional)

- UI 스크린샷은 별도 구독 심사용 이미지 작업 후 첨부 예정입니다.

## 🔗 Related Issues

- Related: BYU-000

## 🙌 Additional Notes (Optional)

- Production Supabase 배포는 main 브랜치 CI에서만 수행되어야 합니다.
- RevenueCat App Store Connect API 키 업로드는 수동 확인이 남아 있지만, 제품 ID는 수동 생성 및 offering 연결이 완료된 상태입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Integrated RevenueCat subscription management system

* **Updates**
  - Pro subscription pricing: $2.99/month, $19.99/year
  - AI Recall feature now provides unlimited usage
  - Yearly subscription savings increased to 44%
  - Support email address updated to support@bookgolas.app

<!-- end of auto-generated comment: release notes by coderabbit.ai -->