### PR TITLE
fix: recalculate daily reading target

### DIFF
--- a/app/lib/ui/book_detail/view_model/book_detail_view_model.dart
+++ b/app/lib/ui/book_detail/view_model/book_detail_view_model.dart
@@ -16,7 +16,6 @@ class BookDetailViewModel extends BaseViewModel {
   int _todayPagesRead = 0;
   bool _isTodayGoalAchievedLocked = false;
   int? _lockedTodayGoalPage;
-  int? _effectiveDailyTarget;
   bool _shouldShowPaywall = false;
 
   Book get currentBook => _currentBook;
@@ -53,30 +52,38 @@ class BookDetailViewModel extends BaseViewModel {
     return _currentBook.currentPage >= todayGoalPage;
   }
 
-  /// 실효 일일 목표: stored > 0이면 stored, 아니면 fallback 계산
-  /// 한 번 고정되면 페이지 업데이트 시 재계산되지 않음
-  int get _resolvedDailyTarget {
-    if (_effectiveDailyTarget != null) return _effectiveDailyTarget!;
-    final stored = _currentBook.dailyTargetPages ?? 0;
-    if (stored > 0) {
-      _effectiveDailyTarget = stored;
-      return _effectiveDailyTarget!;
-    }
-    final days = daysLeft;
-    final pages = pagesLeft;
-    if (days > 0) {
-      _effectiveDailyTarget = (pages / days).ceil();
-    } else {
-      _effectiveDailyTarget = pages > 0 ? pages : 0;
-    }
-    return _effectiveDailyTarget!;
-  }
+  int get _resolvedDailyTarget => _calculateCatchUpDailyTarget(
+        currentPage: _todayStartPage,
+        totalPages: _currentBook.totalPages,
+        targetDate: _currentBook.targetDate,
+      );
 
   int get daysLeft {
-    final now = DateTime.now();
-    final target = _currentBook.targetDate;
-    final days = target.difference(now).inDays;
+    final today = _dateOnly(DateTime.now());
+    final target = _dateOnly(_currentBook.targetDate);
+    final days = target.difference(today).inDays;
     return days >= 0 ? days + 1 : days;
+  }
+
+  int get _storedDailyTarget => _currentBook.dailyTargetPages ?? 0;
+
+  static DateTime _dateOnly(DateTime date) =>
+      DateTime(date.year, date.month, date.day);
+
+  static int _calculateCatchUpDailyTarget({
+    required int currentPage,
+    required int totalPages,
+    required DateTime targetDate,
+  }) {
+    final pagesRemaining = totalPages - currentPage;
+    if (pagesRemaining <= 0) return 0;
+
+    final today = _dateOnly(DateTime.now());
+    final target = _dateOnly(targetDate);
+    final daysRemaining = target.difference(today).inDays + 1;
+    if (daysRemaining <= 0) return pagesRemaining;
+
+    return (pagesRemaining / daysRemaining).ceil();
   }
 
   double get progressPercentage {
@@ -114,8 +121,7 @@ class BookDetailViewModel extends BaseViewModel {
   Future<void> loadDailyAchievements() async {
     try {
       final achievements = <String, bool>{};
-      _effectiveDailyTarget ??= _resolvedDailyTarget;
-      final dailyTarget = _effectiveDailyTarget!;
+      final historyDailyTarget = _storedDailyTarget;
 
       final userId = Supabase.instance.client.auth.currentUser?.id;
       if (userId == null) {
@@ -123,8 +129,7 @@ class BookDetailViewModel extends BaseViewModel {
         return;
       }
 
-      debugPrint(
-          '📊 [loadDailyAchievements] bookId=${_currentBook.id}, dailyTarget=$dailyTarget');
+      debugPrint('📊 [loadDailyAchievements] bookId=${_currentBook.id}');
 
       final response = await Supabase.instance.client
           .from('reading_progress_history')
@@ -149,13 +154,6 @@ class BookDetailViewModel extends BaseViewModel {
 
       debugPrint('📊 [loadDailyAchievements] 날짜별 페이지: $dailyPages');
 
-      // dailyTarget이 0이면 (설정 없음 + fallback도  0) 달성 불가로 처리
-      if (dailyTarget > 0) {
-        for (final entry in dailyPages.entries) {
-          achievements[entry.key] = entry.value >= dailyTarget;
-        }
-      }
-
       final now = DateTime.now();
       final todayKey =
           '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
@@ -163,11 +161,21 @@ class BookDetailViewModel extends BaseViewModel {
 
       // 오늘 시작 페이지 계산 (현재 페이지 - 오늘 읽은 페이지)
       _todayStartPage = _currentBook.currentPage - _todayPagesRead;
+      final todayDailyTarget = _resolvedDailyTarget;
+
+      final historicalTarget =
+          historyDailyTarget > 0 ? historyDailyTarget : todayDailyTarget;
+      if (historicalTarget > 0) {
+        for (final entry in dailyPages.entries) {
+          achievements[entry.key] = entry.value >= historicalTarget;
+        }
+      }
 
       // 이미 locked 상태이면 오늘 달성 보장 (재호출 시에도 유지)
       if (_isTodayGoalAchievedLocked) {
         achievements[todayKey] = true;
-      } else if (dailyTarget > 0 && _currentBook.currentPage >= todayGoalPage) {
+      } else if (todayDailyTarget > 0 &&
+          _currentBook.currentPage >= todayGoalPage) {
         _isTodayGoalAchievedLocked = true;
         _lockedTodayGoalPage = todayGoalPage;
         achievements[todayKey] = true;
@@ -215,7 +223,7 @@ class BookDetailViewModel extends BaseViewModel {
           _todayPagesRead += pagesRead;
 
           // 오늘 달성 여부 로컬 업데이트 (DB 쿼리 대신 즉시 반영)
-          final dailyTarget = _effectiveDailyTarget ?? _resolvedDailyTarget;
+          final dailyTarget = _resolvedDailyTarget;
           if (dailyTarget > 0) {
             final now = DateTime.now();
             final todayKey =

--- a/app/test/ui/book_detail/view_model/book_detail_view_model_test.dart
+++ b/app/test/ui/book_detail/view_model/book_detail_view_model_test.dart
@@ -54,6 +54,7 @@ void main() {
       expect(viewModel.effectiveDailyTarget, 324);
       expect(viewModel.todayGoalPage, 404);
       expect(viewModel.pagesToGoal, 324);
+      expect(viewModel.isTodayGoalAchieved, isFalse);
     });
   });
 }

--- a/app/test/ui/book_detail/view_model/book_detail_view_model_test.dart
+++ b/app/test/ui/book_detail/view_model/book_detail_view_model_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:book_golas/data/services/book_service.dart';
+import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/ui/book_detail/view_model/book_detail_view_model.dart';
+
+class MockBookService extends Mock implements BookService {}
+
+void main() {
+  group('BookDetailViewModel daily target', () {
+    test(
+        'recalculates catch-up target from remaining pages instead of stale stored target',
+        () {
+      final now = DateTime.now();
+      final book = Book(
+        id: 'book-1',
+        title: 'Moral Ambition',
+        startDate: now.subtract(const Duration(days: 15)),
+        targetDate: now.add(const Duration(days: 1)),
+        currentPage: 80,
+        totalPages: 404,
+        dailyTargetPages: 22,
+      );
+
+      final viewModel = BookDetailViewModel(
+        bookService: MockBookService(),
+        initialBook: book,
+      );
+
+      expect(viewModel.effectiveDailyTarget, 162);
+      expect(viewModel.todayGoalPage, 242);
+      expect(viewModel.pagesToGoal, 162);
+      expect(viewModel.isTodayGoalAchieved, isFalse);
+    });
+
+    test('uses all remaining pages as target after deadline has passed', () {
+      final now = DateTime.now();
+      final book = Book(
+        id: 'book-1',
+        title: 'Overdue Book',
+        startDate: now.subtract(const Duration(days: 20)),
+        targetDate: now.subtract(const Duration(days: 1)),
+        currentPage: 80,
+        totalPages: 404,
+        dailyTargetPages: 22,
+      );
+
+      final viewModel = BookDetailViewModel(
+        bookService: MockBookService(),
+        initialBook: book,
+      );
+
+      expect(viewModel.effectiveDailyTarget, 324);
+      expect(viewModel.todayGoalPage, 404);
+      expect(viewModel.pagesToGoal, 324);
+    });
+  });
+}


### PR DESCRIPTION
## 📌 Summary
> 독서 상세 화면의 오늘 목표를 저장된 오래된 daily target이 아니라, 현재 남은 페이지와 목표일까지 남은 일수 기준으로 재계산합니다.

## 📋 Changes
> - `app/lib/ui/book_detail/view_model/book_detail_view_model.dart`: 오늘 목표/오늘 달성 판단을 catch-up 기준으로 분리했습니다.
> - `app/test/ui/book_detail/view_model/book_detail_view_model_test.dart`: 마감 임박/마감 초과 상황 회귀 테스트를 추가했습니다.

## 🧠 Context & Background
> 마감이 가까운데도 최초 계획의 `dailyTargetPages`가 남아 `오늘 목표: 22p` 및 `목표 달성`으로 보이는 문제가 있었습니다. 이제 오늘 화면은 실제 마감 성공에 필요한 페이지 수를 보여줍니다.

## ✅ How to Test
> 1. `cd app && flutter test test/ui/book_detail/view_model/book_detail_view_model_test.dart`
> 2. `cd app && flutter analyze lib/ui/book_detail/view_model/book_detail_view_model.dart test/ui/book_detail/view_model/book_detail_view_model_test.dart`

## 🔗 Related Issues
> - Related: BYU-ux-catch-up-daily-target


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced daily reading goal calculations to dynamically adjust targets based on remaining pages and days until deadline, replacing cached values with real-time computations. Improved achievement evaluation to use recalculated targets, ensuring accurate catch-up goals when approaching book completion dates. Updated progress tracking to consistently reference current target calculations

* **Tests**
  * Added comprehensive unit tests to validate daily reading goal computation accuracy, including catch-up scenarios and deadline handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->