### PR TITLE
fix: show true today goal progress

### DIFF
--- a/app/lib/data/repositories/reading_progress_repository.dart
+++ b/app/lib/data/repositories/reading_progress_repository.dart
@@ -1,0 +1,16 @@
+import 'package:book_golas/data/services/reading_progress_service.dart';
+
+abstract class ReadingProgressRepository {
+  Future<Map<String, int>> getTodayPagesReadByBook();
+}
+
+class ReadingProgressRepositoryImpl implements ReadingProgressRepository {
+  final ReadingProgressService _readingProgressService;
+
+  ReadingProgressRepositoryImpl(this._readingProgressService);
+
+  @override
+  Future<Map<String, int>> getTodayPagesReadByBook() {
+    return _readingProgressService.fetchTodayPagesReadByBook();
+  }
+}

--- a/app/lib/data/services/reading_progress_service.dart
+++ b/app/lib/data/services/reading_progress_service.dart
@@ -134,6 +134,43 @@ class ReadingProgressService {
     }
   }
 
+  /// 오늘 책별로 읽은 페이지 수 조회
+  Future<Map<String, int>> fetchTodayPagesReadByBook() async {
+    try {
+      final userId = _supabase.auth.currentUser?.id;
+      if (userId == null) return {};
+
+      final now = DateTime.now();
+      final startOfToday = DateTime(now.year, now.month, now.day);
+      final startOfTomorrow = startOfToday.add(const Duration(days: 1));
+
+      final response = await _supabase
+          .from(_tableName)
+          .select('book_id, page, previous_page')
+          .eq('user_id', userId)
+          .gte('created_at', startOfToday.toIso8601String())
+          .lt('created_at', startOfTomorrow.toIso8601String());
+
+      final pagesReadByBook = <String, int>{};
+      for (final record in response as List) {
+        final bookId = record['book_id'] as String?;
+        if (bookId == null) continue;
+
+        final page = record['page'] as int? ?? 0;
+        final previousPage = record['previous_page'] as int? ?? 0;
+        final pagesRead = page - previousPage;
+        if (pagesRead <= 0) continue;
+
+        pagesReadByBook[bookId] = (pagesReadByBook[bookId] ?? 0) + pagesRead;
+      }
+
+      return pagesReadByBook;
+    } catch (e) {
+      debugPrint('오늘 책별 진행 기록 조회 실패: $e');
+      return {};
+    }
+  }
+
   /// 목표 달성률 계산 (일별 목표 대비 실제 읽은 페이지)
   Future<double> calculateGoalAchievementRate() async {
     try {

--- a/app/lib/ui/book_list/view_model/book_list_view_model.dart
+++ b/app/lib/ui/book_list/view_model/book_list_view_model.dart
@@ -5,15 +5,18 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:book_golas/ui/core/view_model/base_view_model.dart';
 import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/data/services/reading_progress_service.dart';
 import 'package:book_golas/data/services/widget_data_service.dart';
 
 enum AllTabFilter { all, reading, planned, completed, paused }
 
 class BookListViewModel extends BaseViewModel {
+  final ReadingProgressService _readingProgressService;
   StreamSubscription<List<Map<String, dynamic>>>? _booksSubscription;
   StreamSubscription<AuthState>? _authSubscription;
 
   List<Book> _books = [];
+  Map<String, int> _todayPagesReadByBook = {};
   int _selectedTabIndex = 0;
   bool _showAllCurrentBooks = false;
   bool _isInitialized = false;
@@ -23,6 +26,12 @@ class BookListViewModel extends BaseViewModel {
   int get selectedTabIndex => _selectedTabIndex;
   bool get showAllCurrentBooks => _showAllCurrentBooks;
   AllTabFilter get allTabFilter => _allTabFilter;
+
+  int todayPagesReadFor(Book book) {
+    final id = book.id;
+    if (id == null) return 0;
+    return _todayPagesReadByBook[id] ?? 0;
+  }
 
   @override
   bool get isLoading => !_isInitialized || super.isLoading;
@@ -39,7 +48,9 @@ class BookListViewModel extends BaseViewModel {
           (book.currentPage >= book.totalPages && book.totalPages > 0))
       .toList();
 
-  BookListViewModel();
+  BookListViewModel({ReadingProgressService? readingProgressService})
+      : _readingProgressService =
+            readingProgressService ?? ReadingProgressService();
 
   void initialize() {
     if (_isInitialized) return;
@@ -117,6 +128,8 @@ class BookListViewModel extends BaseViewModel {
           .order('created_at', ascending: false);
 
       _books = (response as List).map((e) => Book.fromJson(e)).toList();
+      _todayPagesReadByBook =
+          await _readingProgressService.fetchTodayPagesReadByBook();
       _syncWidgetData();
       setLoading(false);
       notifyListeners();
@@ -133,11 +146,13 @@ class BookListViewModel extends BaseViewModel {
         .eq('user_id', userId)
         .order('created_at', ascending: false)
         .listen(
-          (rows) {
+          (rows) async {
             _books = rows
                 .where((e) => e['deleted_at'] == null)
                 .map((e) => Book.fromJson(e))
                 .toList();
+            _todayPagesReadByBook =
+                await _readingProgressService.fetchTodayPagesReadByBook();
             _syncWidgetData();
             notifyListeners();
           },
@@ -179,6 +194,8 @@ class BookListViewModel extends BaseViewModel {
           .order('created_at', ascending: false);
 
       _books = (response as List).map((e) => Book.fromJson(e)).toList();
+      _todayPagesReadByBook =
+          await _readingProgressService.fetchTodayPagesReadByBook();
       _syncWidgetData();
       debugPrint('[BookListViewModel] refresh done: ${_books.length} books');
       notifyListeners();

--- a/app/lib/ui/book_list/view_model/book_list_view_model.dart
+++ b/app/lib/ui/book_list/view_model/book_list_view_model.dart
@@ -5,13 +5,14 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:book_golas/ui/core/view_model/base_view_model.dart';
 import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/data/repositories/reading_progress_repository.dart';
 import 'package:book_golas/data/services/reading_progress_service.dart';
 import 'package:book_golas/data/services/widget_data_service.dart';
 
 enum AllTabFilter { all, reading, planned, completed, paused }
 
 class BookListViewModel extends BaseViewModel {
-  final ReadingProgressService _readingProgressService;
+  final ReadingProgressRepository _readingProgressRepository;
   StreamSubscription<List<Map<String, dynamic>>>? _booksSubscription;
   StreamSubscription<AuthState>? _authSubscription;
 
@@ -48,9 +49,9 @@ class BookListViewModel extends BaseViewModel {
           (book.currentPage >= book.totalPages && book.totalPages > 0))
       .toList();
 
-  BookListViewModel({ReadingProgressService? readingProgressService})
-      : _readingProgressService =
-            readingProgressService ?? ReadingProgressService();
+  BookListViewModel({ReadingProgressRepository? readingProgressRepository})
+      : _readingProgressRepository = readingProgressRepository ??
+            ReadingProgressRepositoryImpl(ReadingProgressService());
 
   void initialize() {
     if (_isInitialized) return;
@@ -129,7 +130,7 @@ class BookListViewModel extends BaseViewModel {
 
       _books = (response as List).map((e) => Book.fromJson(e)).toList();
       _todayPagesReadByBook =
-          await _readingProgressService.fetchTodayPagesReadByBook();
+          await _readingProgressRepository.getTodayPagesReadByBook();
       _syncWidgetData();
       setLoading(false);
       notifyListeners();
@@ -152,7 +153,7 @@ class BookListViewModel extends BaseViewModel {
                 .map((e) => Book.fromJson(e))
                 .toList();
             _todayPagesReadByBook =
-                await _readingProgressService.fetchTodayPagesReadByBook();
+                await _readingProgressRepository.getTodayPagesReadByBook();
             _syncWidgetData();
             notifyListeners();
           },
@@ -195,7 +196,7 @@ class BookListViewModel extends BaseViewModel {
 
       _books = (response as List).map((e) => Book.fromJson(e)).toList();
       _todayPagesReadByBook =
-          await _readingProgressService.fetchTodayPagesReadByBook();
+          await _readingProgressRepository.getTodayPagesReadByBook();
       _syncWidgetData();
       debugPrint('[BookListViewModel] refresh done: ${_books.length} books');
       notifyListeners();

--- a/app/lib/ui/book_list/widgets/book_list_card.dart
+++ b/app/lib/ui/book_list/widgets/book_list_card.dart
@@ -151,7 +151,7 @@ class BookListCard extends StatelessWidget {
       children: [
         _buildLabeledProgressRow(
           label: l10n.chartTodayGoal,
-          percent: '$schedulePercent%',
+          percent: schedulePercent,
           progress: scheduleProgress,
           color: BLabColors.success,
           isDark: isDark,

--- a/app/lib/ui/book_list/widgets/book_list_card.dart
+++ b/app/lib/ui/book_list/widgets/book_list_card.dart
@@ -5,12 +5,19 @@ import 'package:book_golas/l10n/app_localizations.dart';
 import 'package:book_golas/ui/core/widgets/book_image_widget.dart';
 import 'package:book_golas/ui/core/widgets/pressable_wrapper.dart';
 import 'package:book_golas/ui/core/theme/design_system.dart';
+import 'package:book_golas/ui/book_list/widgets/book_list_progress_calculator.dart';
 
 class BookListCard extends StatelessWidget {
   final Book book;
   final VoidCallback onTap;
+  final int todayPagesRead;
 
-  const BookListCard({super.key, required this.book, required this.onTap});
+  const BookListCard({
+    super.key,
+    required this.book,
+    required this.onTap,
+    this.todayPagesRead = 0,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -120,7 +127,7 @@ class BookListCard extends StatelessWidget {
         _buildDdayAndPages(isDark, daysLeft, isCompleted, l10n),
         const SizedBox(height: 8),
         if (isReading)
-          _buildDualProgressBars(isDark, daysLeft, pageProgress, l10n)
+          _buildDualProgressBars(isDark, pageProgress, l10n)
         else
           _buildProgressBar(isDark, pageProgress, isCompleted),
       ],
@@ -129,34 +136,15 @@ class BookListCard extends StatelessWidget {
 
   Widget _buildDualProgressBars(
     bool isDark,
-    int daysLeft,
     double pageProgress,
     AppLocalizations l10n,
   ) {
-    final pagesLeft = book.totalPages - book.currentPage;
-    final dailyTarget =
-        book.dailyTargetPages ??
-        (daysLeft > 0 ? (pagesLeft / daysLeft).ceil() : pagesLeft);
-
-    final now = DateTime.now();
-    final today = DateTime(now.year, now.month, now.day);
-    final start = DateTime(
-      book.startDate.year,
-      book.startDate.month,
-      book.startDate.day,
+    final todayGoalProgress = calculateTodayGoalProgress(
+      book: book,
+      todayPagesRead: todayPagesRead,
     );
-    final totalDays = book.targetDate
-        .difference(book.startDate)
-        .inDays
-        .clamp(1, 99999);
-    final daysPassed = today.difference(start).inDays;
-    final expectedPage = ((daysPassed + 1) * book.totalPages / totalDays)
-        .ceil()
-        .clamp(0, book.totalPages);
-    final scheduleProgress = expectedPage > 0
-        ? (book.currentPage / expectedPage).clamp(0.0, 1.0)
-        : 1.0;
-    final schedulePercent = (scheduleProgress * 100).toStringAsFixed(0);
+    final scheduleProgress = todayGoalProgress.progress;
+    final schedulePercent = todayGoalProgress.percentLabel;
     final overallPercent = (pageProgress * 100).toStringAsFixed(0);
 
     return Column(

--- a/app/lib/ui/book_list/widgets/book_list_progress_calculator.dart
+++ b/app/lib/ui/book_list/widgets/book_list_progress_calculator.dart
@@ -1,0 +1,46 @@
+import 'dart:math' as math;
+
+import 'package:book_golas/domain/models/book.dart';
+
+class TodayGoalProgress {
+  final int todayStartPage;
+  final int dailyTargetPages;
+  final double progress;
+
+  const TodayGoalProgress({
+    required this.todayStartPage,
+    required this.dailyTargetPages,
+    required this.progress,
+  });
+
+  String get percentLabel => '${(progress * 100).toStringAsFixed(0)}%';
+}
+
+TodayGoalProgress calculateTodayGoalProgress({
+  required Book book,
+  required int todayPagesRead,
+  DateTime? today,
+}) {
+  final safeTodayPagesRead = math.max(0, todayPagesRead);
+  final todayStartPage = math.max(0, book.currentPage - safeTodayPagesRead);
+  final remainingFromTodayStart = math.max(0, book.totalPages - todayStartPage);
+  final normalizedToday = _dateOnly(today ?? DateTime.now());
+  final normalizedTarget = _dateOnly(book.targetDate);
+  final daysLeft = normalizedTarget.difference(normalizedToday).inDays;
+  final readingDaysLeft = daysLeft >= 0 ? daysLeft + 1 : 1;
+  final dailyTargetPages = remainingFromTodayStart > 0
+      ? (remainingFromTodayStart / readingDaysLeft).ceil()
+      : 0;
+  final progress = dailyTargetPages > 0
+      ? (safeTodayPagesRead / dailyTargetPages).clamp(0.0, 1.0)
+      : 1.0;
+
+  return TodayGoalProgress(
+    todayStartPage: todayStartPage,
+    dailyTargetPages: dailyTargetPages,
+    progress: progress,
+  );
+}
+
+DateTime _dateOnly(DateTime value) =>
+    DateTime(value.year, value.month, value.day);

--- a/app/lib/ui/book_list/widgets/book_list_screen.dart
+++ b/app/lib/ui/book_list/widgets/book_list_screen.dart
@@ -304,14 +304,14 @@ class _BookListScreenState extends State<BookListScreen>
       case AllTabFilter.all:
         return _buildAllSectionsContent(vm, isDark);
       case AllTabFilter.reading:
-        return _buildSingleStatusContent(vm.readingBooks, '독서 중', isDark,
+        return _buildSingleStatusContent(vm, vm.readingBooks, '독서 중', isDark,
             isReading: true);
       case AllTabFilter.planned:
-        return _buildSingleStatusContent(vm.plannedBooks, '읽을 예정', isDark);
+        return _buildSingleStatusContent(vm, vm.plannedBooks, '읽을 예정', isDark);
       case AllTabFilter.completed:
-        return _buildSingleStatusContent(vm.completedBooks, '완독', isDark);
+        return _buildSingleStatusContent(vm, vm.completedBooks, '완독', isDark);
       case AllTabFilter.paused:
-        return _buildSingleStatusContent(vm.pausedBooks, '다시 읽을 책', isDark);
+        return _buildSingleStatusContent(vm, vm.pausedBooks, '다시 읽을 책', isDark);
     }
   }
 
@@ -320,6 +320,7 @@ class _BookListScreenState extends State<BookListScreen>
 
     if (vm.readingBooks.isNotEmpty) {
       widgets.addAll(_buildSection(
+        vm: vm,
         title: '독서 중',
         count: vm.readingBooks.length,
         books: vm.readingBooks,
@@ -330,6 +331,7 @@ class _BookListScreenState extends State<BookListScreen>
 
     if (vm.plannedBooks.isNotEmpty) {
       widgets.addAll(_buildSection(
+        vm: vm,
         title: '읽을 예정',
         count: vm.plannedBooks.length,
         books: vm.plannedBooks,
@@ -340,6 +342,7 @@ class _BookListScreenState extends State<BookListScreen>
 
     if (vm.completedBooks.isNotEmpty) {
       widgets.addAll(_buildSection(
+        vm: vm,
         title: '완독',
         count: vm.completedBooks.length,
         books: vm.completedBooks,
@@ -350,6 +353,7 @@ class _BookListScreenState extends State<BookListScreen>
 
     if (vm.pausedBooks.isNotEmpty) {
       widgets.addAll(_buildSection(
+        vm: vm,
         title: '다시 읽을 책',
         count: vm.pausedBooks.length,
         books: vm.pausedBooks,
@@ -362,6 +366,7 @@ class _BookListScreenState extends State<BookListScreen>
   }
 
   List<Widget> _buildSection({
+    required BookListViewModel vm,
     required String title,
     required int count,
     required List<Book> books,
@@ -387,6 +392,7 @@ class _BookListScreenState extends State<BookListScreen>
       ...books.map((book) => isReading
           ? BookListCard(
               book: book,
+              todayPagesRead: vm.todayPagesReadFor(book),
               onTap: () => _navigateToBookDetail(book),
             )
           : _buildBookCardByStatus(book, isDark)),
@@ -394,7 +400,7 @@ class _BookListScreenState extends State<BookListScreen>
   }
 
   List<Widget> _buildSingleStatusContent(
-      List<Book> books, String title, bool isDark,
+      BookListViewModel vm, List<Book> books, String title, bool isDark,
       {bool isReading = false}) {
     if (books.isEmpty) {
       return [
@@ -424,6 +430,7 @@ class _BookListScreenState extends State<BookListScreen>
       ...books.map((book) => isReading
           ? BookListCard(
               book: book,
+              todayPagesRead: vm.todayPagesReadFor(book),
               onTap: () => _navigateToBookDetail(book),
             )
           : _buildBookCardByStatus(book, isDark)),
@@ -478,6 +485,7 @@ class _BookListScreenState extends State<BookListScreen>
         children: readingBooks
             .map((book) => BookListCard(
                   book: book,
+                  todayPagesRead: vm.todayPagesReadFor(book),
                   onTap: () => _navigateToBookDetail(book),
                 ))
             .toList(),

--- a/app/lib/ui/book_list/widgets/book_list_screen.dart
+++ b/app/lib/ui/book_list/widgets/book_list_screen.dart
@@ -300,28 +300,35 @@ class _BookListScreenState extends State<BookListScreen>
   }
 
   List<Widget> _buildFilteredContent(BookListViewModel vm, bool isDark) {
+    final l10n = AppLocalizations.of(context);
+
     switch (vm.allTabFilter) {
       case AllTabFilter.all:
         return _buildAllSectionsContent(vm, isDark);
       case AllTabFilter.reading:
-        return _buildSingleStatusContent(vm, vm.readingBooks, '독서 중', isDark,
+        return _buildSingleStatusContent(
+            vm, vm.readingBooks, l10n.statusReading, isDark,
             isReading: true);
       case AllTabFilter.planned:
-        return _buildSingleStatusContent(vm, vm.plannedBooks, '읽을 예정', isDark);
+        return _buildSingleStatusContent(
+            vm, vm.plannedBooks, l10n.statusPlanned, isDark);
       case AllTabFilter.completed:
-        return _buildSingleStatusContent(vm, vm.completedBooks, '완독', isDark);
+        return _buildSingleStatusContent(
+            vm, vm.completedBooks, l10n.statusCompleted, isDark);
       case AllTabFilter.paused:
-        return _buildSingleStatusContent(vm, vm.pausedBooks, '다시 읽을 책', isDark);
+        return _buildSingleStatusContent(
+            vm, vm.pausedBooks, l10n.statusReread, isDark);
     }
   }
 
   List<Widget> _buildAllSectionsContent(BookListViewModel vm, bool isDark) {
+    final l10n = AppLocalizations.of(context);
     final List<Widget> widgets = [];
 
     if (vm.readingBooks.isNotEmpty) {
       widgets.addAll(_buildSection(
         vm: vm,
-        title: '독서 중',
+        title: l10n.statusReading,
         count: vm.readingBooks.length,
         books: vm.readingBooks,
         isDark: isDark,
@@ -332,7 +339,7 @@ class _BookListScreenState extends State<BookListScreen>
     if (vm.plannedBooks.isNotEmpty) {
       widgets.addAll(_buildSection(
         vm: vm,
-        title: '읽을 예정',
+        title: l10n.statusPlanned,
         count: vm.plannedBooks.length,
         books: vm.plannedBooks,
         isDark: isDark,
@@ -343,7 +350,7 @@ class _BookListScreenState extends State<BookListScreen>
     if (vm.completedBooks.isNotEmpty) {
       widgets.addAll(_buildSection(
         vm: vm,
-        title: '완독',
+        title: l10n.statusCompleted,
         count: vm.completedBooks.length,
         books: vm.completedBooks,
         isDark: isDark,
@@ -354,7 +361,7 @@ class _BookListScreenState extends State<BookListScreen>
     if (vm.pausedBooks.isNotEmpty) {
       widgets.addAll(_buildSection(
         vm: vm,
-        title: '다시 읽을 책',
+        title: l10n.statusReread,
         count: vm.pausedBooks.length,
         books: vm.pausedBooks,
         isDark: isDark,

--- a/app/test/ui/book_list/widgets/book_list_progress_calculator_test.dart
+++ b/app/test/ui/book_list/widgets/book_list_progress_calculator_test.dart
@@ -1,0 +1,76 @@
+import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/ui/book_list/widgets/book_list_progress_calculator.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('calculateTodayGoalProgress', () {
+    test('returns 0 percent when no page update was recorded today', () {
+      final book = Book(
+        id: 'book-1',
+        title: 'Test Book',
+        startDate: DateTime(2026, 6, 1),
+        targetDate: DateTime(2026, 6, 20),
+        currentPage: 100,
+        totalPages: 130,
+        status: BookStatus.reading.value,
+      );
+
+      final progress = calculateTodayGoalProgress(
+        book: book,
+        todayPagesRead: 0,
+        today: DateTime(2026, 6, 20),
+      );
+
+      expect(progress.todayStartPage, 100);
+      expect(progress.dailyTargetPages, 30);
+      expect(progress.progress, 0);
+      expect(progress.percentLabel, '0%');
+    });
+
+    test('uses pages read today divided by today target pages', () {
+      final book = Book(
+        id: 'book-1',
+        title: 'Test Book',
+        startDate: DateTime(2026, 6, 1),
+        targetDate: DateTime(2026, 6, 20),
+        currentPage: 110,
+        totalPages: 130,
+        status: BookStatus.reading.value,
+      );
+
+      final progress = calculateTodayGoalProgress(
+        book: book,
+        todayPagesRead: 10,
+        today: DateTime(2026, 6, 20),
+      );
+
+      expect(progress.todayStartPage, 100);
+      expect(progress.dailyTargetPages, 30);
+      expect(progress.progress, closeTo(1 / 3, 0.001));
+      expect(progress.percentLabel, '33%');
+    });
+
+    test('includes today and target date when computing catch-up target', () {
+      final book = Book(
+        id: 'book-1',
+        title: 'Moral Ambition',
+        startDate: DateTime(2026, 6, 1),
+        targetDate: DateTime(2026, 6, 21),
+        currentPage: 124,
+        totalPages: 404,
+        status: BookStatus.reading.value,
+      );
+
+      final progress = calculateTodayGoalProgress(
+        book: book,
+        todayPagesRead: 52,
+        today: DateTime(2026, 6, 20),
+      );
+
+      expect(progress.todayStartPage, 72);
+      expect(progress.dailyTargetPages, 166);
+      expect(progress.progress, closeTo(52 / 166, 0.001));
+      expect(progress.percentLabel, '31%');
+    });
+  });
+}


### PR DESCRIPTION
이번 PR은 독서 목록 카드의 `오늘 목표` 퍼센트를 실제 오늘 목표 달성률로 표시하도록 수정합니다.

## 📋 Changes

- `오늘 목표` 퍼센트 계산을 일정 대비 누적 진행률에서 `오늘 읽은 페이지 수 / 오늘 목표 페이지 수`로 변경
- 오늘 독서 진행 기록을 책별로 집계하는 `fetchTodayPagesReadByBook()` 추가
- 독서 목록 ViewModel에서 오늘 읽은 페이지 수를 카드에 전달
- 계산 로직을 `book_list_progress_calculator.dart`로 분리하고 회귀 테스트 추가

## 🧠 Context & Background

기존 독서 목록 카드의 초록색 `오늘 목표`는 라벨과 달리 `현재 페이지 / 일정상 오늘까지 도달했어야 하는 누적 페이지`에 가까웠습니다. 사용자가 기대한 의미는 “오늘 목표를 지금까지 얼마나 달성했는가”이므로, 오늘 페이지 업데이트가 없으면 0%, 오늘 목표 30p 중 10p를 읽으면 약 33%가 되도록 수정했습니다.

## ✅ How to Test

1. `cd app && flutter test test/ui/book_list/widgets/book_list_progress_calculator_test.dart`
2. `cd app && flutter test test/ui/book_detail/view_model/book_detail_view_model_test.dart test/ui/book_list/widgets/book_list_progress_calculator_test.dart`
3. `cd app && flutter analyze lib/ui/book_list/widgets/book_list_card.dart lib/ui/book_list/widgets/book_list_progress_calculator.dart lib/ui/book_list/view_model/book_list_view_model.dart lib/ui/book_list/widgets/book_list_screen.dart lib/data/services/reading_progress_service.dart test/ui/book_list/widgets/book_list_progress_calculator_test.dart`

## 🧾 Screenshots or Videos (Optional)

- N/A

## 🔗 Related Issues

- Related: BYU-book-list-today-goal-progress

## 🙌 Additional Notes (Optional)

- 로컬 미추적 생성물 `app/ios/build/`, `debug/`는 커밋하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily reading progress tracking to book cards, displaying pages read today versus daily reading goals.
  * Real-time updates of daily reading progress as you continue reading throughout the day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->