### PR TITLE
ci: restore sane iOS build numbers

### DIFF
--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -185,9 +185,9 @@ jobs:
       - name: Build Flutter iOS
         run: |
           cd app
-          # Use a timestamp build number so reruns and App Store Connect retries stay monotonic.
-          BUILD_NUMBER=$(date -u +%Y%m%d%H%M%S)
-          flutter build ios --flavor prod -t lib/main_prod.dart --release --no-codesign --build-number=$BUILD_NUMBER
+          BUILD_NAME=$(grep '^version:' pubspec.yaml | sed -E 's/version: ([0-9]+\.[0-9]+\.[0-9]+)\+.*/\1/')
+          BUILD_NUMBER=$(( (${{ github.run_number }} + 135) * 100 + ${{ github.run_attempt }} ))
+          flutter build ios --flavor prod -t lib/main_prod.dart --release --no-codesign --build-name=$BUILD_NAME --build-number=$BUILD_NUMBER
 
       - name: Build and Upload to App Store
         env:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -197,9 +197,9 @@ jobs:
       - name: Build Flutter iOS
         run: |
           cd app
-          # Use a timestamp build number so reruns and App Store Connect retries stay monotonic.
-          BUILD_NUMBER=$(date -u +%Y%m%d%H%M%S)
-          flutter build ios --flavor dev -t lib/main_dev.dart --release --no-codesign --build-number=$BUILD_NUMBER
+          BUILD_NAME=$(grep '^version:' pubspec.yaml | sed -E 's/version: ([0-9]+\.[0-9]+\.[0-9]+)\+.*/\1/')
+          BUILD_NUMBER=$(( (${{ github.run_number }} + 135) * 100 + ${{ github.run_attempt }} ))
+          flutter build ios --flavor dev -t lib/main_dev.dart --release --no-codesign --build-name=$BUILD_NAME --build-number=$BUILD_NUMBER
 
       - name: Build and Upload to TestFlight
         env:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: "독서 목표를 설정하고 독서 진행 상황을 추적하는
 
 publish_to: "none"
 
-version: 1.0.0+1
+version: 1.0.1+1
 
 environment:
   sdk: ^3.5.3


### PR DESCRIPTION
## 📌 Summary
> TestFlight 빌드 넘버가 timestamp처럼 과도하게 크게 표시되는 문제를 수정했습니다.

## 📋 Changes
> - `app/pubspec.yaml`: 앱 버전을 `1.0.1`로 올려 기존 `1.0.0`에 업로드된 timestamp 빌드 넘버 제약을 피했습니다.
> - `.github/workflows/ios-testflight.yml`: timestamp 대신 GitHub run number와 retry attempt 기반의 짧은 빌드 넘버를 사용합니다.
> - `.github/workflows/ios-production.yml`: App Store 배포 워크플로우도 동일한 빌드 넘버 정책으로 맞췄습니다.

## 🧠 Context and Background
> 직전 CI 수정에서 App Store Connect 재시도 충돌을 피하려고 timestamp 빌드 넘버를 사용했지만, TestFlight에서 `202606...` 형태의 과도하게 큰 빌드 번호가 노출되는 문제가 있었습니다. 이미 `1.0.0`에는 timestamp 빌드가 올라갔기 때문에, 새 버전 `1.0.1`로 전환하고 빌드 넘버를 다시 짧은 단조 증가 숫자로 되돌립니다.

## ✅ How to Test
> 1. YAML 파싱 검증: `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ios-testflight.yml'); YAML.load_file('.github/workflows/ios-production.yml')"`
> 2. 다음 TestFlight run #138 기준 빌드 번호 시뮬레이션: `27301`
> 3. retry attempt 2 기준 빌드 번호 시뮬레이션: `27302`
> 4. 다음 run #139 기준 빌드 번호 시뮬레이션: `27401`

## 🔗 Related Issues
> - Related: BYU-sane-ios-build-number
