### PR TITLE
daily/2026-06-21

### DIFF
--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -185,9 +185,9 @@ jobs:
       - name: Build Flutter iOS
         run: |
           cd app
-          # Use a timestamp build number so reruns and App Store Connect retries stay monotonic.
-          BUILD_NUMBER=$(date -u +%Y%m%d%H%M%S)
-          flutter build ios --flavor prod -t lib/main_prod.dart --release --no-codesign --build-number=$BUILD_NUMBER
+          BUILD_NAME=$(grep '^version:' pubspec.yaml | sed -E 's/version: ([0-9]+\.[0-9]+\.[0-9]+)\+.*/\1/')
+          BUILD_NUMBER=$(( (${{ github.run_number }} + 135) * 100 + ${{ github.run_attempt }} ))
+          flutter build ios --flavor prod -t lib/main_prod.dart --release --no-codesign --build-name=$BUILD_NAME --build-number=$BUILD_NUMBER
 
       - name: Build and Upload to App Store
         env:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -197,9 +197,9 @@ jobs:
       - name: Build Flutter iOS
         run: |
           cd app
-          # Use a timestamp build number so reruns and App Store Connect retries stay monotonic.
-          BUILD_NUMBER=$(date -u +%Y%m%d%H%M%S)
-          flutter build ios --flavor dev -t lib/main_dev.dart --release --no-codesign --build-number=$BUILD_NUMBER
+          BUILD_NAME=$(grep '^version:' pubspec.yaml | sed -E 's/version: ([0-9]+\.[0-9]+\.[0-9]+)\+.*/\1/')
+          BUILD_NUMBER=$(( (${{ github.run_number }} + 135) * 100 + ${{ github.run_attempt }} ))
+          flutter build ios --flavor dev -t lib/main_dev.dart --release --no-codesign --build-name=$BUILD_NAME --build-number=$BUILD_NUMBER
 
       - name: Build and Upload to TestFlight
         env:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: "독서 목표를 설정하고 독서 진행 상황을 추적하는
 
 publish_to: "none"
 
-version: 1.0.0+1
+version: 1.0.1+1
 
 environment:
   sdk: ^3.5.3


### PR DESCRIPTION
## 📌 Summary
> 2026-06-21 daily 브랜치를 dev로 반영합니다.

## 📋 Changes
> - TestFlight/App Store 빌드 넘버가 timestamp처럼 과도하게 크게 표시되지 않도록 수정했습니다.
> - 앱 버전을 `1.0.1`로 올리고, 빌드 넘버를 GitHub run number와 retry attempt 기반으로 계산합니다.

## 🧠 Context and Background
> 기존 `1.0.0` 빌드에 timestamp 기반 빌드 번호가 업로드되어 TestFlight에서 큰 숫자가 표시되었습니다. 새 버전 `1.0.1`로 전환해 빌드 넘버를 다시 짧고 단조 증가하는 값으로 사용합니다.

## ✅ How to Test
> 1. PR #241 검증 통과
> 2. YAML 파싱 검증 완료
> 3. 빌드 번호 시뮬레이션 완료: 다음 run #138 attempt 1 → `27301`, attempt 2 → `27302`, run #139 attempt 1 → `27401`

## 🔗 Related Issues
> - Related: PR #241
