### PR TITLE
fix: handle reading limit paywall fallback

### DIFF
--- a/app/lib/data/services/book_limit_calculator.dart
+++ b/app/lib/data/services/book_limit_calculator.dart
@@ -1,0 +1,13 @@
+import 'package:book_golas/domain/models/book.dart';
+
+class BookLimitCalculator {
+  static int countConcurrentReadingBooks(
+    Iterable<Book> books, {
+    String? excludeBookId,
+  }) {
+    return books.where((book) {
+      if (excludeBookId != null && book.id == excludeBookId) return false;
+      return book.status == BookStatus.reading.value;
+    }).length;
+  }
+}

--- a/app/lib/data/services/book_service.dart
+++ b/app/lib/data/services/book_service.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/data/services/book_limit_calculator.dart';
 import 'package:book_golas/data/services/widget_data_service.dart';
 import 'package:book_golas/utils/subscription_utils.dart';
 import 'package:book_golas/exceptions/subscription_exceptions.dart';
@@ -43,11 +44,15 @@ class BookService {
   }
 
   Future<Book?> addBook(Book book) async {
-    // Check concurrent reading limit for free users
-    if (!await SubscriptionUtils.canAddMoreConcurrentBooks(_books.length)) {
-      throw ConcurrentReadingLimitException(
-        '동시 읽기 제한에 도달했습니다. Pro 업그레이드로 무제한 이용하세요.',
-      );
+    if (book.status == BookStatus.reading.value) {
+      final currentReadingCount =
+          BookLimitCalculator.countConcurrentReadingBooks(_books);
+      if (!await SubscriptionUtils.canAddMoreConcurrentBooks(
+          currentReadingCount)) {
+        throw ConcurrentReadingLimitException(
+          '무료 사용자는 동시에 3권까지 독서 중으로 등록할 수 있습니다. 기존 책을 완독/중단하거나 Pro로 업그레이드하세요.',
+        );
+      }
     }
 
     try {
@@ -69,11 +74,15 @@ class BookService {
   }
 
   Future<Book?> addBookWithUserId(Map<String, dynamic> bookData) async {
-    // Check concurrent reading limit for free users
-    if (!await SubscriptionUtils.canAddMoreConcurrentBooks(_books.length)) {
-      throw ConcurrentReadingLimitException(
-        '동시 읽기 제한에 도달했습니다. Pro 업그레이드로 무제한 이용하세요.',
-      );
+    if (bookData['status'] == BookStatus.reading.value) {
+      final currentReadingCount =
+          BookLimitCalculator.countConcurrentReadingBooks(_books);
+      if (!await SubscriptionUtils.canAddMoreConcurrentBooks(
+          currentReadingCount)) {
+        throw ConcurrentReadingLimitException(
+          '무료 사용자는 동시에 3권까지 독서 중으로 등록할 수 있습니다. 기존 책을 완독/중단하거나 Pro로 업그레이드하세요.',
+        );
+      }
     }
 
     try {
@@ -348,9 +357,10 @@ class BookService {
     DateTime? newTargetDate,
     bool incrementAttempt = true,
   }) async {
-    final currentReadingCount = _books
-        .where((b) => b.status == BookStatus.reading.value && b.id != bookId)
-        .length;
+    final currentReadingCount = BookLimitCalculator.countConcurrentReadingBooks(
+      _books,
+      excludeBookId: bookId,
+    );
     if (!await SubscriptionUtils.canAddMoreConcurrentBooks(
         currentReadingCount)) {
       throw ConcurrentReadingLimitException(

--- a/app/lib/data/services/subscription_service.dart
+++ b/app/lib/data/services/subscription_service.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:book_golas/config/app_config.dart';
 
 /// Service for managing in-app subscriptions via RevenueCat.
 ///
@@ -9,6 +12,34 @@ import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
 /// and managing customer center interactions.
 class SubscriptionService {
   static const String _proEntitlementId = 'byungskerslab/북골라스 Pro';
+
+  Future<bool> ensureConfigured() async {
+    try {
+      if (await Purchases.isConfigured) return true;
+
+      final rcKey = AppConfig.revenueCatPublicKey.trim();
+      if (rcKey.isEmpty) {
+        debugPrint('⚠️ RevenueCat unavailable: API key is not configured');
+        return false;
+      }
+
+      final userId = Supabase.instance.client.auth.currentUser?.id;
+      if (userId == null) {
+        debugPrint('⚠️ RevenueCat unavailable: user is not authenticated');
+        return false;
+      }
+
+      await Purchases.setLogLevel(LogLevel.info);
+      await Purchases.configure(
+        PurchasesConfiguration(rcKey)..appUserID = userId,
+      );
+      debugPrint('✅ RevenueCat configured lazily');
+      return true;
+    } catch (e) {
+      debugPrint('❌ RevenueCat configuration failed: $e');
+      return false;
+    }
+  }
 
   /// Gets the current customer info from RevenueCat.
   ///
@@ -55,6 +86,8 @@ class SubscriptionService {
   /// Returns true if paywall was shown, false if configuration is unavailable.
   Future<bool> showPaywall(BuildContext context) async {
     try {
+      if (!await ensureConfigured()) return false;
+
       final offerings = await Purchases.getOfferings();
       if (offerings.current == null ||
           offerings.current!.availablePackages.isEmpty) {

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1584,6 +1584,8 @@
 
            "subscriptionUnavailable": "Subscription service is currently unavailable.",
            "@subscriptionUnavailable": {"description": "Snackbar message when paywall cannot be presented"},
+           "subscriptionUnavailableDuringBookLimit": "Free users can read up to 3 books simultaneously.\nWe couldn't open the subscription screen, so Pro upgrade is unavailable right now. Please try again later, or finish/pause an existing book first.",
+           "@subscriptionUnavailableDuringBookLimit": {"description": "Snackbar message when the reading limit blocks book registration and the paywall cannot be presented"},
 
            "myPagePasswordSameAsOld": "New password must be different from the current password",
            "@myPagePasswordSameAsOld": {"description": "Error when new password is same as old"},

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3124,6 +3124,8 @@
 
          "subscriptionUnavailable": "구독 서비스를 현재 이용할 수 없습니다.",
          "@subscriptionUnavailable": {"description": "Snackbar message when paywall cannot be presented"},
+         "subscriptionUnavailableDuringBookLimit": "무료 사용자는 동시에 3권까지 독서 중으로 등록할 수 있습니다.\n구독 화면을 열 수 없어 Pro 업그레이드를 진행하지 못했습니다. 잠시 후 다시 시도하거나 기존 책을 완독/중단해 주세요.",
+         "@subscriptionUnavailableDuringBookLimit": {"description": "Snackbar message when the reading limit blocks book registration and the paywall cannot be presented"},
 
          "myPagePasswordSameAsOld": "새 비밀번호는 기존 비밀번호와 달라야 합니다",
          "@myPagePasswordSameAsOld": {"description": "Error when new password is same as old"},

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -6605,6 +6605,12 @@ abstract class AppLocalizations {
   /// **'구독 서비스를 현재 이용할 수 없습니다.'**
   String get subscriptionUnavailable;
 
+  /// Snackbar message when the reading limit blocks book registration and the paywall cannot be presented
+  ///
+  /// In ko, this message translates to:
+  /// **'무료 사용자는 동시에 3권까지 독서 중으로 등록할 수 있습니다.\n구독 화면을 열 수 없어 Pro 업그레이드를 진행하지 못했습니다. 잠시 후 다시 시도하거나 기존 책을 완독/중단해 주세요.'**
+  String get subscriptionUnavailableDuringBookLimit;
+
   /// Error when new password is same as old
   ///
   /// In ko, this message translates to:

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -3618,6 +3618,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Subscription service is currently unavailable.';
 
   @override
+  String get subscriptionUnavailableDuringBookLimit =>
+      'Free users can read up to 3 books simultaneously.\nWe couldn\'t open the subscription screen, so Pro upgrade is unavailable right now. Please try again later, or finish/pause an existing book first.';
+
+  @override
   String get myPagePasswordSameAsOld =>
       'New password must be different from the current password';
 

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -3533,6 +3533,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get subscriptionUnavailable => '구독 서비스를 현재 이용할 수 없습니다.';
 
   @override
+  String get subscriptionUnavailableDuringBookLimit =>
+      '무료 사용자는 동시에 3권까지 독서 중으로 등록할 수 있습니다.\n구독 화면을 열 수 없어 Pro 업그레이드를 진행하지 못했습니다. 잠시 후 다시 시도하거나 기존 책을 완독/중단해 주세요.';
+
+  @override
   String get myPagePasswordSameAsOld => '새 비밀번호는 기존 비밀번호와 달라야 합니다';
 
   @override

--- a/app/lib/ui/reading_start/widgets/reading_start_screen.dart
+++ b/app/lib/ui/reading_start/widgets/reading_start_screen.dart
@@ -550,7 +550,8 @@ class _ReadingStartContentState extends State<_ReadingStartContent>
                   : Container(
                       width: 48,
                       height: 64,
-                      color: isDark ? BLabColors.elevatedDark : Colors.grey[200],
+                      color:
+                          isDark ? BLabColors.elevatedDark : Colors.grey[200],
                       child: Icon(
                         Icons.menu_book_rounded,
                         color: isDark ? Colors.white38 : Colors.grey[400],
@@ -607,8 +608,8 @@ class _ReadingStartContentState extends State<_ReadingStartContent>
                                   vertical: 4,
                                 ),
                                 decoration: BoxDecoration(
-                                  color:
-                                      BLabColors.primary.withValues(alpha: 0.12),
+                                  color: BLabColors.primary
+                                      .withValues(alpha: 0.12),
                                   borderRadius: BorderRadius.circular(6),
                                 ),
                                 child: Text(
@@ -1432,8 +1433,9 @@ class _ReadingStartContentState extends State<_ReadingStartContent>
                     vertical: 14,
                   ),
                   decoration: BoxDecoration(
-                    color:
-                        isDark ? BLabColors.subtleDark : BLabColors.elevatedLight,
+                    color: isDark
+                        ? BLabColors.subtleDark
+                        : BLabColors.elevatedLight,
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Column(
@@ -1459,8 +1461,7 @@ class _ReadingStartContentState extends State<_ReadingStartContent>
                       ),
                       const SizedBox(height: 8),
                       Text(
-                        AppLocalizations.of(context)
-                            .readingStartTargetDateNote,
+                        AppLocalizations.of(context).readingStartTargetDateNote,
                         style: TextStyle(
                           fontSize: 12,
                           color: isDark ? Colors.grey[500] : Colors.grey[500],
@@ -1525,9 +1526,15 @@ class _ReadingStartContentState extends State<_ReadingStartContent>
                           } else if (mounted && !success) {
                             if (vm.shouldShowPaywall) {
                               vm.clearPaywallState();
-                              final paywallSuccess = await SubscriptionService().showPaywall(context);
+                              final paywallSuccess = await SubscriptionService()
+                                  .showPaywall(context);
                               if (!paywallSuccess && mounted) {
-                                CustomSnackbar.show(context, message: AppLocalizations.of(context).subscriptionUnavailable, type: BLabSnackbarType.info);
+                                CustomSnackbar.show(
+                                  context,
+                                  message: AppLocalizations.of(context)
+                                      .subscriptionUnavailableDuringBookLimit,
+                                  type: BLabSnackbarType.info,
+                                );
                               }
                             } else {
                               ScaffoldMessenger.of(context).showSnackBar(
@@ -1562,8 +1569,7 @@ class _ReadingStartContentState extends State<_ReadingStartContent>
                         )
                       : Text(
                           vm.readingStatus == BookStatus.planned
-                              ? AppLocalizations.of(context)
-                                  .readingStartReserve
+                              ? AppLocalizations.of(context).readingStartReserve
                               : AppLocalizations.of(context).readingStartBegin,
                           style: const TextStyle(
                             fontSize: 16,

--- a/app/test/data/services/book_limit_calculator_test.dart
+++ b/app/test/data/services/book_limit_calculator_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:book_golas/data/services/book_limit_calculator.dart';
+import 'package:book_golas/domain/models/book.dart';
+
+void main() {
+  group('BookLimitCalculator', () {
+    Book book(String id, BookStatus status) {
+      return Book(
+        id: id,
+        title: 'Book $id',
+        startDate: DateTime(2026),
+        targetDate: DateTime(2026, 2),
+        status: status.value,
+      );
+    }
+
+    test('counts only currently reading books for concurrent limit', () {
+      final books = [
+        book('reading-1', BookStatus.reading),
+        book('reading-2', BookStatus.reading),
+        book('planned', BookStatus.planned),
+        book('completed', BookStatus.completed),
+        book('retry', BookStatus.willRetry),
+      ];
+
+      expect(BookLimitCalculator.countConcurrentReadingBooks(books), 2);
+    });
+
+    test('can exclude the book being resumed from the reading count', () {
+      final books = [
+        book('reading-1', BookStatus.reading),
+        book('resume-target', BookStatus.reading),
+        book('reading-2', BookStatus.reading),
+      ];
+
+      expect(
+        BookLimitCalculator.countConcurrentReadingBooks(
+          books,
+          excludeBookId: 'resume-target',
+        ),
+        2,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 📌 Summary
> 동시 읽기 3권 제한과 구독 paywall 실패 UX를 개선합니다.

## 📋 Changes
> - 독서 제한 계산을 전체 책 수가 아닌 현재 독서 중(reading) 책 수 기준으로 변경
> - RevenueCat paywall 표시 전에 SDK lazy configuration 보강
> - 독서 등록 제한 상황에서 구독 화면을 열 수 없을 때 원인과 대안을 설명하는 UX 문구 추가
> - 동시 읽기 카운트 회귀 테스트 추가

## 🧠 Context & Background
> 무료 사용자는 동시에 3권까지 독서 중으로 등록할 수 있어야 하지만, 기존 구현은 전체 책 수를 기준으로 제한될 수 있었습니다. 또한 제한 상황에서 paywall 표시가 실패하면 사용자가 왜 등록이 안 되는지 알기 어려웠습니다.

## ✅ How to Test
> 1. `cd app && flutter test test/data/services/book_limit_calculator_test.dart test/data/services/book_service_test.dart`
> 2. `cd app && dart analyze lib/data/services/book_limit_calculator.dart lib/data/services/book_service.dart lib/data/services/subscription_service.dart lib/ui/reading_start/widgets/reading_start_screen.dart test/data/services/book_limit_calculator_test.dart`
> 3. 무료 계정에서 독서 중 3권 상태로 4번째 독서 시작 시 제한 문구와 Pro 업그레이드 흐름 확인
> 4. 읽을 예정/완독/다시 읽을 책이 3권 이상이어도 독서 중 3권 미만이면 등록 가능한지 확인

## 🧾 Screenshots or Videos (Optional)
> N/A

## 🔗 Related Issues
> - Related: BYU subscription paywall reading limit

## 🙌 Additional Notes (Optional)
> 전체 `flutter analyze`는 기존 코드베이스 warning/info가 있어 실패하지만, 이번 변경 파일 대상 분석은 통과했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pro upgrade flow is now accessible at any point during app use.
  * Enhanced error messaging when free users reach the concurrent reading book limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->