### PR TITLE
feat: add evening progress reading reminder

### DIFF
--- a/app/lib/data/services/fcm_service.dart
+++ b/app/lib/data/services/fcm_service.dart
@@ -342,20 +342,14 @@ class FCMService {
         }).eq('id', existing['id']);
         debugPrint('FCM token updated (locale=$locale)');
       } else {
-        await supabase.from('fcm_tokens').insert({
-          'user_id': userId,
-          'token': _fcmToken,
-          'device_type': deviceType,
-          'locale': locale,
-          'daily_reminder_enabled': true,
-          'daily_reminder_hour': 9,
-          'daily_reminder_minute': 0,
-          'goal_alarm_enabled': true,
-          'goal_alarm_hour': 20,
-          'goal_alarm_minute': 0,
-          'event_nudge_enabled': true,
-          'notification_enabled': true,
-        });
+        await supabase.from('fcm_tokens').insert(
+              buildFcmTokenInsertPayload(
+                userId: userId,
+                token: _fcmToken!,
+                deviceType: deviceType,
+                locale: locale,
+              ),
+            );
         debugPrint('FCM token saved with default settings (locale=$locale)');
       }
     } catch (e) {
@@ -413,4 +407,24 @@ class FCMService {
       return false;
     }
   }
+}
+
+Map<String, dynamic> buildFcmTokenInsertPayload({
+  required String userId,
+  required String token,
+  required String deviceType,
+  required String locale,
+}) {
+  return {
+    'user_id': userId,
+    'token': token,
+    'device_type': deviceType,
+    'locale': locale,
+    'daily_reminder_enabled': true,
+    'goal_alarm_enabled': true,
+    'goal_alarm_hour': 20,
+    'goal_alarm_minute': 0,
+    'event_nudge_enabled': true,
+    'notification_enabled': true,
+  };
 }

--- a/app/lib/data/services/notification_settings_service.dart
+++ b/app/lib/data/services/notification_settings_service.dart
@@ -19,7 +19,7 @@ class NotificationSettings {
   NotificationSettings({
     required this.notificationEnabled,
     this.dailyReminderEnabled = true,
-    this.dailyReminderHour = 9,
+    this.dailyReminderHour = 18,
     this.dailyReminderMinute = 0,
     this.goalAlarmEnabled = true,
     this.goalAlarmHour = 20,
@@ -32,7 +32,7 @@ class NotificationSettings {
     return NotificationSettings(
       notificationEnabled: json['notification_enabled'] ?? true,
       dailyReminderEnabled: json['daily_reminder_enabled'] ?? true,
-      dailyReminderHour: json['daily_reminder_hour'] ?? 9,
+      dailyReminderHour: json['daily_reminder_hour'] ?? 18,
       dailyReminderMinute: json['daily_reminder_minute'] ?? 0,
       goalAlarmEnabled: json['goal_alarm_enabled'] ?? true,
       goalAlarmHour: json['goal_alarm_hour'] ?? 20,

--- a/app/test/data/services/fcm_service_test.dart
+++ b/app/test/data/services/fcm_service_test.dart
@@ -1,0 +1,23 @@
+import 'package:book_golas/data/services/fcm_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('buildFcmTokenInsertPayload', () {
+    test('does not override database daily reminder time defaults', () {
+      final payload = buildFcmTokenInsertPayload(
+        userId: 'user-1',
+        token: 'token-1',
+        deviceType: 'ios',
+        locale: 'ko',
+      );
+
+      expect(payload['user_id'], 'user-1');
+      expect(payload['token'], 'token-1');
+      expect(payload['device_type'], 'ios');
+      expect(payload['locale'], 'ko');
+      expect(payload['daily_reminder_enabled'], true);
+      expect(payload.containsKey('daily_reminder_hour'), false);
+      expect(payload.containsKey('daily_reminder_minute'), false);
+    });
+  });
+}

--- a/app/test/data/services/notification_settings_service_test.dart
+++ b/app/test/data/services/notification_settings_service_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:book_golas/data/services/notification_settings_service.dart';
+
+void main() {
+  group('NotificationSettings', () {
+    test('uses 18:00 as the default daily reminder time', () {
+      final settings = NotificationSettings(notificationEnabled: true);
+
+      expect(settings.dailyReminderHour, 18);
+      expect(settings.dailyReminderMinute, 0);
+    });
+
+    test('uses 18:00 when persisted daily reminder time is missing', () {
+      final settings = NotificationSettings.fromJson({
+        'notification_enabled': true,
+        'daily_reminder_enabled': true,
+      });
+
+      expect(settings.dailyReminderHour, 18);
+      expect(settings.dailyReminderMinute, 0);
+    });
+
+    test('preserves a persisted custom daily reminder time', () {
+      final settings = NotificationSettings.fromJson({
+        'notification_enabled': true,
+        'daily_reminder_enabled': true,
+        'daily_reminder_hour': 20,
+        'daily_reminder_minute': 30,
+      });
+
+      expect(settings.dailyReminderHour, 20);
+      expect(settings.dailyReminderMinute, 30);
+    });
+  });
+}

--- a/supabase/functions/send-batch-nudge/daily-reminder.ts
+++ b/supabase/functions/send-batch-nudge/daily-reminder.ts
@@ -1,0 +1,45 @@
+export interface DailyReminderBook {
+  id: string;
+  user_id: string;
+  title: string;
+  current_page: number | null;
+  total_pages: number | null;
+  updated_at: string | null;
+  status: string | null;
+}
+
+export function selectDailyReminderBook(
+  books: DailyReminderBook[],
+): DailyReminderBook | null {
+  const readingBooks = books.filter((book) => book.status === "reading");
+  if (readingBooks.length === 0) return null;
+
+  return readingBooks.sort((a, b) => {
+    const aTime = a.updated_at ? new Date(a.updated_at).getTime() : 0;
+    const bTime = b.updated_at ? new Date(b.updated_at).getTime() : 0;
+    return bTime - aTime;
+  })[0];
+}
+
+export function buildDailyReminderVariables(
+  book: DailyReminderBook,
+): Record<string, string> {
+  return {
+    bookTitle: book.title,
+    percent: String(
+      calculateProgressPercent(book.current_page, book.total_pages),
+    ),
+  };
+}
+
+function calculateProgressPercent(
+  currentPage: number | null,
+  totalPages: number | null,
+): number {
+  if (!totalPages || totalPages <= 0) return 0;
+
+  const safeCurrentPage = Math.max(0, currentPage ?? 0);
+  const percent = Math.round((safeCurrentPage / totalPages) * 100);
+
+  return Math.min(100, Math.max(0, percent));
+}

--- a/supabase/functions/send-batch-nudge/daily-reminder_test.ts
+++ b/supabase/functions/send-batch-nudge/daily-reminder_test.ts
@@ -1,0 +1,100 @@
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
+
+import {
+  buildDailyReminderVariables,
+  selectDailyReminderBook,
+} from "./daily-reminder.ts";
+
+Deno.test("selectDailyReminderBook picks the latest reading book", () => {
+  const selected = selectDailyReminderBook([
+    {
+      id: "planned-book",
+      user_id: "user-1",
+      title: "Planned Book",
+      current_page: 10,
+      total_pages: 100,
+      updated_at: "2026-06-27T18:00:00Z",
+      status: "planned",
+    },
+    {
+      id: "older-reading-book",
+      user_id: "user-1",
+      title: "Older Reading Book",
+      current_page: 60,
+      total_pages: 200,
+      updated_at: "2026-06-26T18:00:00Z",
+      status: "reading",
+    },
+    {
+      id: "latest-reading-book",
+      user_id: "user-1",
+      title: "Latest Reading Book",
+      current_page: 120,
+      total_pages: 300,
+      updated_at: "2026-06-27T17:30:00Z",
+      status: "reading",
+    },
+  ]);
+
+  assertEquals(selected?.id, "latest-reading-book");
+});
+
+Deno.test("selectDailyReminderBook returns null when there is no reading book", () => {
+  const selected = selectDailyReminderBook([
+    {
+      id: "planned-book",
+      user_id: "user-1",
+      title: "Planned Book",
+      current_page: 10,
+      total_pages: 100,
+      updated_at: "2026-06-27T18:00:00Z",
+      status: "planned",
+    },
+  ]);
+
+  assertEquals(selected, null);
+});
+
+Deno.test("buildDailyReminderVariables includes clamped progress percent", () => {
+  assertEquals(
+    buildDailyReminderVariables({
+      id: "book-1",
+      user_id: "user-1",
+      title: "Reading Book",
+      current_page: 120,
+      total_pages: 300,
+      updated_at: "2026-06-27T18:00:00Z",
+      status: "reading",
+    }),
+    {
+      bookTitle: "Reading Book",
+      percent: "40",
+    },
+  );
+
+  assertEquals(
+    buildDailyReminderVariables({
+      id: "book-2",
+      user_id: "user-1",
+      title: "Invalid Total Pages",
+      current_page: 10,
+      total_pages: 0,
+      updated_at: "2026-06-27T18:00:00Z",
+      status: "reading",
+    }).percent,
+    "0",
+  );
+
+  assertEquals(
+    buildDailyReminderVariables({
+      id: "book-3",
+      user_id: "user-1",
+      title: "Over Read",
+      current_page: 120,
+      total_pages: 100,
+      updated_at: "2026-06-27T18:00:00Z",
+      status: "reading",
+    }).percent,
+    "100",
+  );
+});

--- a/supabase/functions/send-batch-nudge/index.ts
+++ b/supabase/functions/send-batch-nudge/index.ts
@@ -2,6 +2,12 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { create, getNumericDate } from "https://deno.land/x/djwt@v2.8/mod.ts";
 
+import {
+  buildDailyReminderVariables,
+  DailyReminderBook,
+  selectDailyReminderBook,
+} from "./daily-reminder.ts";
+
 const FIREBASE_SERVICE_ACCOUNT = Deno.env.get("FIREBASE_SERVICE_ACCOUNT");
 
 interface ServiceAccount {
@@ -329,17 +335,17 @@ serve(async (req) => {
 
       const { data: books } = await supabaseClient
         .from("books")
-        .select("user_id, title, status")
+        .select("user_id, id, title, current_page, total_pages, updated_at, status")
         .in("user_id", userIds)
         .eq("status", "reading")
         .order("updated_at", { ascending: false });
 
-      const userBookMap = new Map<string, string>();
+      const userBooksMap = new Map<string, DailyReminderBook[]>();
       if (books) {
-        books.forEach((b: any) => {
-          if (!userBookMap.has(b.user_id)) {
-            userBookMap.set(b.user_id, b.title);
-          }
+        books.forEach((book: DailyReminderBook) => {
+          const list = userBooksMap.get(book.user_id) || [];
+          list.push(book);
+          userBooksMap.set(book.user_id, list);
         });
       }
 
@@ -347,9 +353,14 @@ serve(async (req) => {
         dailyReminderUsers,
         FCM_BATCH_SIZE,
         async (user: any) => {
-          const bookTitle = userBookMap.get(user.user_id) || "";
-          const variables: Record<string, string> = { bookTitle };
-          return sendToTargets(
+          const book = selectDailyReminderBook(userBooksMap.get(user.user_id) || []);
+          if (!book) {
+            totalSkipped++;
+            return { sent: 0, failed: 0 };
+          }
+
+          const variables = buildDailyReminderVariables(book);
+          return await sendToTargets(
             accessToken,
             serviceAccount.project_id,
             [{ userId: user.user_id, token: user.token, locale: user.locale || "ko" }],
@@ -357,7 +368,7 @@ serve(async (req) => {
             variables,
             templates,
             supabaseClient,
-            {}
+            { bookId: book.id, bookTitle: book.title, percent: variables.percent }
           );
         }
       );

--- a/supabase/migrations/20260627014215_default_daily_reminder_18.sql
+++ b/supabase/migrations/20260627014215_default_daily_reminder_18.sql
@@ -1,0 +1,10 @@
+ALTER TABLE public.fcm_tokens
+  ALTER COLUMN daily_reminder_hour SET DEFAULT 18,
+  ALTER COLUMN daily_reminder_minute SET DEFAULT 0;
+
+UPDATE public.fcm_tokens
+SET daily_reminder_hour = 18,
+    daily_reminder_minute = 0
+WHERE daily_reminder_enabled = true
+  AND daily_reminder_hour = 9
+  AND daily_reminder_minute = 0;

--- a/supabase/migrations/20260627014216_update_daily_reminder_progress_template.sql
+++ b/supabase/migrations/20260627014216_update_daily_reminder_progress_template.sql
@@ -1,0 +1,6 @@
+UPDATE public.push_templates
+SET title = '오늘도 이어서 읽어볼까요? 📚',
+    body_template = '「{bookTitle}」 {percent}%까지 읽었어요. 저녁 독서 흐름을 이어가봐요!',
+    title_en = 'Keep reading tonight 📚',
+    body_template_en = 'You are {percent}% through "{bookTitle}". Keep your reading streak going tonight!'
+WHERE type = 'daily_reminder';


### PR DESCRIPTION
저녁 6시에 사용자가 읽고 있는 책의 진행률을 알려주며 독서 흐름을 이어가도록 독려하는 리마인드 푸시를 추가했습니다.

## 📋 Changes

- `daily_reminder` 기본 시간을 09:00에서 18:00으로 변경했습니다.
- 기존 기본값 09:00을 쓰던 enabled 토큰만 18:00으로 마이그레이션하고, 사용자가 직접 바꾼 커스텀 시간은 유지했습니다.
- `send-batch-nudge`의 daily reminder 경로에서 최신 `reading` 책을 선택하고 `{bookTitle}`, `{percent}` 변수를 생성하도록 분리했습니다.
- 푸시 템플릿 한국어/영어 문구를 진행률 기반 문구로 갱신했습니다.
- FCM data/log metadata에 `bookId`, `bookTitle`, `percent`를 포함했습니다.
- FCM 토큰 신규 등록 시 `daily_reminder_hour/minute`를 직접 insert하지 않도록 변경해 DB default가 적용되게 했습니다.
- Deno/Flutter 테스트를 추가했습니다.

## 🧠 Context & Background

저녁 6시에 유저가 현재 읽고 있는 책의 진행률을 알려주면서 연달아 독서하기를 독려하는 푸시가 필요했습니다.

관련 이슈:
- Obsidian: `project/bookgolas/issues/BOK-377.md`

CodeRabbit 리뷰에서 `fcm_service.dart` 신규 토큰 insert가 `daily_reminder_hour: 9`를 직접 넣고 있어 DB default 18:00을 우회한다는 지적이 있었고, 해당 부분도 함께 반영했습니다.

## ✅ How to Test

1. Supabase Edge Function 순수 함수 테스트를 실행합니다.
   ```bash
   cd /Users/byungskersmacbook/Documents/GitHub/book-golas
   npx -y deno test --allow-env supabase/functions/send-batch-nudge/daily-reminder_test.ts
   ```

2. Supabase Edge Function 타입 체크를 실행합니다.
   ```bash
   npx -y deno check supabase/functions/send-batch-nudge/index.ts
   ```

3. Flutter 알림 설정 기본값 테스트를 실행합니다.
   ```bash
   cd app
   flutter test test/data/services/notification_settings_service_test.dart
   ```

4. FCM 토큰 insert payload 테스트를 실행합니다.
   ```bash
   flutter test test/data/services/fcm_service_test.dart
   ```

5. 변경 Dart 파일 analyze를 실행합니다.
   ```bash
   flutter analyze lib/data/services/fcm_service.dart test/data/services/fcm_service_test.dart lib/data/services/notification_settings_service.dart test/data/services/notification_settings_service_test.dart
   ```

## 🧾 Screenshots or Videos (Optional)

UI 화면 변경은 없습니다.

## 🔗 Related Issues

- Related: BOK-377

## 🙌 Additional Notes (Optional)

- 진행 중인 책이 없는 유저는 이번 progress reminder를 보내지 않고 skip합니다.
- `flutter test` 실행 중 `app/pubspec.lock`이 변동될 수 있어, 의도하지 않은 lockfile 변경은 reset했습니다.
