### PR TITLE
daily/2026-07-01

### DIFF
--- a/app/lib/data/services/book_service.dart
+++ b/app/lib/data/services/book_service.dart
@@ -106,6 +106,7 @@ class BookService {
     String? isbn,
     String? genre,
     String? aladinUrl,
+    int? price,
   }) async {
     try {
       final updateData = <String, dynamic>{
@@ -115,6 +116,7 @@ class BookService {
       if (isbn != null) updateData['isbn'] = isbn;
       if (genre != null) updateData['genre'] = genre;
       if (aladinUrl != null) updateData['aladin_url'] = aladinUrl;
+      if (price != null) updateData['price'] = price;
 
       if (updateData.length <= 1) return null;
 

--- a/app/lib/domain/models/book.dart
+++ b/app/lib/domain/models/book.dart
@@ -22,6 +22,7 @@ class BookSearchResult {
   final String? genre;
   final String? publisher;
   final String? aladinUrl;
+  final int? price;
 
   BookSearchResult({
     required this.title,
@@ -32,6 +33,7 @@ class BookSearchResult {
     this.genre,
     this.publisher,
     this.aladinUrl,
+    this.price,
   });
 
   factory BookSearchResult.fromJson(Map<String, dynamic> json) {
@@ -67,8 +69,16 @@ class BookSearchResult {
       genre: parsedGenre,
       publisher: json['publisher'] as String?,
       aladinUrl: json['link'] as String?,
+      price: _parseInt(json['priceStandard'] ?? json['priceSales']),
     );
   }
+}
+
+int? _parseInt(dynamic value) {
+  if (value == null) return null;
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  return int.tryParse(value.toString());
 }
 
 class Book {
@@ -97,6 +107,7 @@ class Book {
   final String? reviewLink;
   final String? aladinUrl;
   final String? longReview;
+  final int? price;
 
   Book({
     this.id,
@@ -124,6 +135,7 @@ class Book {
     this.reviewLink,
     this.aladinUrl,
     this.longReview,
+    this.price,
   });
 
   Book copyWith({
@@ -152,6 +164,7 @@ class Book {
     String? reviewLink,
     String? aladinUrl,
     String? longReview,
+    int? price,
   }) {
     return Book(
       id: id ?? this.id,
@@ -179,6 +192,7 @@ class Book {
       reviewLink: reviewLink ?? this.reviewLink,
       aladinUrl: aladinUrl ?? this.aladinUrl,
       longReview: longReview ?? this.longReview,
+      price: price ?? this.price,
     );
   }
 
@@ -210,6 +224,7 @@ class Book {
       if (reviewLink != null) 'review_link': reviewLink,
       if (aladinUrl != null) 'aladin_url': aladinUrl,
       if (longReview != null) 'long_review': longReview,
+      if (price != null) 'price': price,
     };
   }
 
@@ -249,6 +264,7 @@ class Book {
       reviewLink: json['review_link'] as String?,
       aladinUrl: json['aladin_url'] as String?,
       longReview: json['long_review'] as String?,
+      price: _parseInt(json['price']),
     );
   }
 }

--- a/app/lib/domain/models/book_detail_info.dart
+++ b/app/lib/domain/models/book_detail_info.dart
@@ -11,6 +11,7 @@ class BookDetailInfo {
   final String? imageUrl;
   final String? publisher;
   final String? isbn;
+  final int? price;
 
   BookDetailInfo({
     this.description,
@@ -23,6 +24,7 @@ class BookDetailInfo {
     this.imageUrl,
     this.publisher,
     this.isbn,
+    this.price,
   });
 
   factory BookDetailInfo.fromGoogleBooks(Map<String, dynamic> volumeInfo) {
@@ -71,6 +73,7 @@ class BookDetailInfo {
       imageUrl: book.imageUrl,
       publisher: book.publisher,
       isbn: book.isbn,
+      price: book.price,
       pageCount: book.totalPages > 0 ? book.totalPages : null,
     );
   }
@@ -86,6 +89,7 @@ class BookDetailInfo {
     String? imageUrl,
     String? publisher,
     String? isbn,
+    int? price,
   }) {
     return BookDetailInfo(
       description: description ?? this.description,
@@ -98,6 +102,7 @@ class BookDetailInfo {
       imageUrl: imageUrl ?? this.imageUrl,
       publisher: publisher ?? this.publisher,
       isbn: isbn ?? this.isbn,
+      price: price ?? this.price,
     );
   }
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1441,7 +1441,10 @@
               "bookInfoPublisher": "Publisher",
               "bookInfoIsbn": "ISBN",
               "bookInfoPageCount": "Pages",
-              "bookInfoGenre": "Genre",
+              "bookInfoPrice": "Price",
+  "@bookInfoPrice": {"description": "Price label in book info sheet"},
+  
+  "bookInfoGenre": "Genre",
               "bookInfoViewInBookstore": "View in Bookstore",
 
            "myPageAccountSection": "Account",

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2981,7 +2981,10 @@
          "bookInfoPublisher": "출판사",
          "bookInfoIsbn": "ISBN",
          "bookInfoPageCount": "페이지",
-         "bookInfoGenre": "장르",
+         "bookInfoPrice": "가격",
+  "@bookInfoPrice": {"description": "Price label in book info sheet"},
+  
+  "bookInfoGenre": "장르",
          "bookInfoViewInBookstore": "서점에서 보기",
 
          "myPageAccountSection": "계정",

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -6359,6 +6359,12 @@ abstract class AppLocalizations {
   /// **'페이지'**
   String get bookInfoPageCount;
 
+  /// Price label in book info sheet
+  ///
+  /// In ko, this message translates to:
+  /// **'가격'**
+  String get bookInfoPrice;
+
   /// No description provided for @bookInfoGenre.
   ///
   /// In ko, this message translates to:

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -3484,6 +3484,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get bookInfoPageCount => 'Pages';
 
   @override
+  String get bookInfoPrice => 'Price';
+
+  @override
   String get bookInfoGenre => 'Genre';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -3402,6 +3402,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get bookInfoPageCount => '페이지';
 
   @override
+  String get bookInfoPrice => '가격';
+
+  @override
   String get bookInfoGenre => '장르';
 
   @override

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -342,13 +342,23 @@ class _BookDetailContentState extends State<_BookDetailContent>
                                 currentPage: book.currentPage,
                                 totalPages: book.totalPages,
                                 status: book.status,
-                                onImageTap: _showFullScreenImage,
+                                onImageTap: (_, __) => showBookInfoSheet(
+                                  context,
+                                  book,
+                                  onCoverTap: _showFullScreenImage,
+                                ),
                                 // onTitleTap: () => showFullTitleSheet(
                                 //     context: context, title: book.title),
-                                onTitleTap: () =>
-                                    showBookInfoSheet(context, book),
-                                onBookInfoTap: () =>
-                                    showBookInfoSheet(context, book),
+                                onTitleTap: () => showBookInfoSheet(
+                                  context,
+                                  book,
+                                  onCoverTap: _showFullScreenImage,
+                                ),
+                                onBookInfoTap: () => showBookInfoSheet(
+                                  context,
+                                  book,
+                                  onCoverTap: _showFullScreenImage,
+                                ),
                               ),
                               const SizedBox(height: 10),
                               CompactReadingSchedule(
@@ -1500,8 +1510,7 @@ class _BookDetailContentState extends State<_BookDetailContent>
 
   Future<void> _showStartNowDialog(BookDetailViewModel bookVm) async {
     final book = bookVm.currentBook;
-    final defaultTarget =
-        book.targetDate ?? DateTime.now().add(const Duration(days: 14));
+    final defaultTarget = book.targetDate;
 
     await UpdateTargetDateDialog.show(
       context: context,
@@ -1516,8 +1525,7 @@ class _BookDetailContentState extends State<_BookDetailContent>
               duration: const Duration(milliseconds: 500),
               curve: Curves.easeOutCubic);
           CustomSnackbar.show(context,
-              message: AppLocalizations.of(context)
-                  .bookDetailAttemptStarted(1),
+              message: AppLocalizations.of(context).bookDetailAttemptStarted(1),
               type: BLabSnackbarType.success,
               icon: Icons.play_arrow_rounded);
         } else if (!success && mounted && bookVm.shouldShowPaywall) {
@@ -1526,8 +1534,7 @@ class _BookDetailContentState extends State<_BookDetailContent>
               await SubscriptionService().showPaywall(context);
           if (!paywallSuccess && mounted) {
             CustomSnackbar.show(context,
-                message:
-                    AppLocalizations.of(context).subscriptionUnavailable,
+                message: AppLocalizations.of(context).subscriptionUnavailable,
                 type: BLabSnackbarType.info);
           }
         }

--- a/app/lib/ui/book_detail/widgets/sheets/book_info_sheet.dart
+++ b/app/lib/ui/book_detail/widgets/sheets/book_info_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
 import 'package:shimmer/shimmer.dart';
 
 import 'package:book_golas/data/services/aladin_api_service.dart';
@@ -15,21 +16,26 @@ import 'package:book_golas/ui/core/widgets/book_image_widget.dart';
 import 'package:book_golas/ui/core/widgets/bookstore_select_sheet.dart';
 import 'package:book_golas/ui/core/widgets/custom_snackbar.dart';
 
-Future<void> showBookInfoSheet(BuildContext context, Book book) {
+Future<void> showBookInfoSheet(
+  BuildContext context,
+  Book book, {
+  void Function(String imageId, String imageUrl)? onCoverTap,
+}) {
   return showModalBottomSheet(
     context: context,
     isScrollControlled: true,
     backgroundColor: Colors.transparent,
     isDismissible: true,
     enableDrag: true,
-    builder: (_) => _BookInfoSheetContent(book: book),
+    builder: (_) => _BookInfoSheetContent(book: book, onCoverTap: onCoverTap),
   );
 }
 
 class _BookInfoSheetContent extends StatefulWidget {
   final Book book;
+  final void Function(String imageId, String imageUrl)? onCoverTap;
 
-  const _BookInfoSheetContent({required this.book});
+  const _BookInfoSheetContent({required this.book, this.onCoverTap});
 
   @override
   State<_BookInfoSheetContent> createState() => _BookInfoSheetContentState();
@@ -176,13 +182,15 @@ class _BookInfoSheetContentState extends State<_BookInfoSheetContent>
           (widget.book.publisher == null ||
               widget.book.isbn == null ||
               widget.book.genre == null ||
-              widget.book.aladinUrl == null);
+              widget.book.aladinUrl == null ||
+              widget.book.price == null);
 
       if (needsBackfill) {
         debugPrint(
           '📚 [BookInfo] 메타데이터 보정 시작: '
           'publisher=${widget.book.publisher}, isbn=${widget.book.isbn}, '
-          'genre=${widget.book.genre}, aladinUrl=${widget.book.aladinUrl}',
+          'genre=${widget.book.genre}, aladinUrl=${widget.book.aladinUrl}, '
+          'price=${widget.book.price}',
         );
         BookSearchResult? aladinResult;
 
@@ -218,36 +226,42 @@ class _BookInfoSheetContentState extends State<_BookInfoSheetContent>
               widget.book.genre == null ? aladinResult.genre : null;
           final backfillAladinUrl =
               widget.book.aladinUrl == null ? aladinResult.aladinUrl : null;
+          final backfillPrice =
+              widget.book.price == null ? aladinResult.price : null;
 
           detail = detail.copyWith(
             publisher: detail.publisher ?? aladinResult.publisher,
             isbn: detail.isbn ?? aladinResult.isbn,
             categories: detail.categories ??
                 (aladinResult.genre != null ? [aladinResult.genre!] : null),
+            price: detail.price ?? aladinResult.price,
           );
 
           debugPrint(
             '📚 [BookInfo] detail 보정 후: '
             'publisher=${detail.publisher}, isbn=${detail.isbn}, '
-            'categories=${detail.categories}',
+            'categories=${detail.categories}, price=${detail.price}',
           );
 
           if (backfillPublisher != null ||
               backfillIsbn != null ||
               backfillGenre != null ||
-              backfillAladinUrl != null) {
+              backfillAladinUrl != null ||
+              backfillPrice != null) {
             BookService().updateBookMetadata(
               widget.book.id!,
               publisher: backfillPublisher,
               isbn: backfillIsbn,
               genre: backfillGenre,
               aladinUrl: backfillAladinUrl,
+              price: backfillPrice,
             );
 
             debugPrint(
               '📚 [BookInfo] DB 보정 요청: '
               'publisher=$backfillPublisher, isbn=$backfillIsbn, '
-              'genre=$backfillGenre, aladinUrl=${backfillAladinUrl != null}',
+              'genre=$backfillGenre, aladinUrl=${backfillAladinUrl != null}, '
+              'price=$backfillPrice',
             );
           }
         }
@@ -328,27 +342,38 @@ class _BookInfoSheetContentState extends State<_BookInfoSheetContent>
   }
 
   Widget _buildCoverImage(bool isDark) {
-    return Center(
-      child: Container(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(12),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: isDark ? 0.4 : 0.15),
-              blurRadius: 16,
-              offset: const Offset(0, 6),
-            ),
-          ],
-        ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(12),
-          child: BookImageWidget(
-            imageUrl: widget.book.imageUrl,
-            width: 140,
-            height: 200,
-            iconSize: 48,
+    final imageUrl = widget.book.imageUrl;
+    final cover = Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: isDark ? 0.4 : 0.15),
+            blurRadius: 16,
+            offset: const Offset(0, 6),
           ),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(12),
+        child: BookImageWidget(
+          imageUrl: imageUrl,
+          width: 140,
+          height: 200,
+          iconSize: 48,
         ),
+      ),
+    );
+
+    return Center(
+      child: GestureDetector(
+        onTap: imageUrl == null || imageUrl.isEmpty || widget.onCoverTap == null
+            ? null
+            : () => widget.onCoverTap!(
+                  'book_info_cover_${widget.book.id ?? widget.book.title}',
+                  imageUrl,
+                ),
+        child: cover,
       ),
     );
   }
@@ -625,8 +650,10 @@ class _BookInfoSheetContentState extends State<_BookInfoSheetContent>
     final pageCount =
         detail?.pageCount ?? (book.totalPages > 0 ? book.totalPages : null);
     final genre = detail?.categories?.join(', ') ?? book.genre ?? '-';
+    final price = detail?.price ?? book.price;
 
     final rows = <MapEntry<String, String>>[
+      MapEntry(l10n.bookInfoPrice, _formatPrice(l10n, price)),
       MapEntry(l10n.bookInfoPublisher, publisher),
       MapEntry(l10n.bookInfoIsbn, isbn),
       MapEntry(l10n.bookInfoPageCount, pageCount?.toString() ?? '-'),
@@ -649,6 +676,13 @@ class _BookInfoSheetContentState extends State<_BookInfoSheetContent>
             .toList(),
       ),
     );
+  }
+
+  String _formatPrice(AppLocalizations l10n, int? price) {
+    if (price == null || price <= 0) return '-';
+    final formatted =
+        NumberFormat.decimalPattern(l10n.localeName).format(price);
+    return l10n.localeName == 'ko' ? '$formatted원' : formatted;
   }
 
   Widget _buildInfoRow(bool isDark, String label, String value) {

--- a/app/lib/ui/reading_start/view_model/reading_start_view_model.dart
+++ b/app/lib/ui/reading_start/view_model/reading_start_view_model.dart
@@ -346,7 +346,7 @@ class ReadingStartViewModel extends BaseViewModel {
     _readingStatus = status;
     if (status == BookStatus.planned) {
       _targetDate = _plannedStartDate.add(const Duration(days: 14));
-      _hasPlannedDate = true;
+      _hasPlannedDate = false;
     } else {
       _targetDate = DateTime.now().add(const Duration(days: 14));
     }
@@ -355,6 +355,7 @@ class ReadingStartViewModel extends BaseViewModel {
 
   void setPlannedStartDate(DateTime date) {
     _plannedStartDate = date;
+    _hasPlannedDate = true;
     if (_readingStatus == BookStatus.planned) {
       _targetDate = date.add(const Duration(days: 14));
     }
@@ -437,6 +438,7 @@ class ReadingStartViewModel extends BaseViewModel {
         genre: _selectedBook?.genre,
         publisher: _selectedBook?.publisher,
         aladinUrl: _selectedBook?.aladinUrl,
+        price: _selectedBook?.price,
       );
 
       final bookData = book.toJson();

--- a/app/test/domain/models/book_detail_info_test.dart
+++ b/app/test/domain/models/book_detail_info_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/domain/models/book_detail_info.dart';
+
+void main() {
+  group('BookDetailInfo', () {
+    test('fromLocal copies price from book', () {
+      final book = Book(
+        title: 'Test Book',
+        startDate: DateTime.parse('2026-01-01T00:00:00.000Z'),
+        targetDate: DateTime.parse('2026-02-01T00:00:00.000Z'),
+        price: 18000,
+      );
+
+      final detail = BookDetailInfo.fromLocal(book);
+
+      expect(detail.price, 18000);
+    });
+
+    test('copyWith updates price while preserving existing values', () {
+      final detail = BookDetailInfo(
+        title: 'Test Book',
+        price: 18000,
+      );
+
+      final copied = detail.copyWith(price: 22000);
+
+      expect(copied.title, 'Test Book');
+      expect(copied.price, 22000);
+    });
+  });
+}

--- a/app/test/domain/models/book_test.dart
+++ b/app/test/domain/models/book_test.dart
@@ -73,6 +73,7 @@ void main() {
           'review': 'Great book!',
           'review_link': 'https://blog.example.com/review',
           'aladin_url': 'https://aladin.co.kr/book/123',
+          'price': 18000,
         };
 
         final book = Book.fromJson(json);
@@ -95,6 +96,7 @@ void main() {
         expect(book.review, 'Great book!');
         expect(book.reviewLink, 'https://blog.example.com/review');
         expect(book.aladinUrl, 'https://aladin.co.kr/book/123');
+        expect(book.price, 18000);
       });
 
       test('should parse longReview field from JSON', () {
@@ -136,6 +138,7 @@ void main() {
           status: 'reading',
           rating: 4,
           review: 'Good read',
+          price: 22000,
         );
 
         final json = book.toJson();
@@ -150,6 +153,7 @@ void main() {
         expect(json['status'], 'reading');
         expect(json['rating'], 4);
         expect(json['review'], 'Good read');
+        expect(json['price'], 22000);
       });
 
       test('should include longReview when present', () {
@@ -182,6 +186,7 @@ void main() {
         expect(json.containsKey('genre'), false);
         expect(json.containsKey('publisher'), false);
         expect(json.containsKey('isbn'), false);
+        expect(json.containsKey('price'), false);
       });
 
       test('should be reversible with fromJson', () {

--- a/app/test/ui/reading_start/view_model/reading_start_view_model_test.dart
+++ b/app/test/ui/reading_start/view_model/reading_start_view_model_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:book_golas/data/services/book_service.dart';
+import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/ui/reading_start/view_model/reading_start_view_model.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    await Supabase.initialize(
+      url: 'http://localhost:54321',
+      anonKey: 'test-anon-key',
+    );
+  });
+
+  group('ReadingStartViewModel', () {
+    test(
+        'selecting planned status defaults the planned start date to undetermined',
+        () {
+      final viewModel = ReadingStartViewModel(BookService());
+
+      viewModel.setReadingStatus(BookStatus.planned);
+
+      expect(viewModel.readingStatus, BookStatus.planned);
+      expect(viewModel.hasPlannedDate, isFalse);
+    });
+  });
+}

--- a/supabase/migrations/20260701072809_add_price_to_books.sql
+++ b/supabase/migrations/20260701072809_add_price_to_books.sql
@@ -1,0 +1,2 @@
+-- BOK-378: Store book list price from Aladin metadata
+ALTER TABLE public.books ADD COLUMN IF NOT EXISTS price INTEGER;


### PR DESCRIPTION
daily/2026-07-01 하루 작업 통합

## 📋 Changes

- `PR #247`: feature/BOK-378-book-detail-info-ux
  - 독서 상세 표지 탭 → 책 정보 모달 진입
  - 책 정보 모달 내부 표지 → 전체화면 이미지 보기
  - 가격 메타데이터 파싱/저장/표시 및 `books.price` migration 추가
  - 독서 예정 선택 시 시작일 미정 기본값 적용

## 🧠 Context & Background

BOK-378 기능 개선 작업을 daily 브랜치에 반영했고, dev로 통합해 TestFlight 배포 흐름을 진행합니다.

## ✅ How to Test

1. feature PR #247 변경 사항이 dev에 포함되는지 확인합니다.
2. GitHub Actions / TestFlight 배포 CI가 성공하는지 확인합니다.
3. 앱에서 독서 상세 표지, 책 정보 모달 가격, 독서 예정 시작일 미정 기본값을 확인합니다.

## 🧾 Screenshots or Videos (Optional)

- N/A

## 🔗 Related Issues

- Related: BOK-378

## 🙌 Additional Notes (Optional)

- Feature PR #247의 Vercel preview는 성공했습니다.
- CodeRabbit은 처리 지연으로 pending 상태였지만, actionable review/comment는 없는 상태에서 사용자 배포 요청에 따라 daily 통합을 진행합니다.
