### PR TITLE
feat: add deadline escalation reminders

### DIFF
--- a/supabase/functions/send-batch-nudge/deadline-reminder.ts
+++ b/supabase/functions/send-batch-nudge/deadline-reminder.ts
@@ -1,0 +1,200 @@
+export interface DeadlineReminderBook {
+  id: string;
+  user_id: string;
+  title: string;
+  current_page: number | null;
+  total_pages: number | null;
+  target_date: string | null;
+  updated_at: string | null;
+  status: string | null;
+}
+
+export type DeadlineReminderStage =
+  | "deadline_warmup"
+  | "deadline_soon"
+  | "deadline_tomorrow"
+  | "deadline_today"
+  | "deadline_overdue";
+
+export interface DeadlineReminderState {
+  book: DeadlineReminderBook;
+  stage: DeadlineReminderStage;
+  daysLeft: number;
+  remainingPages: number;
+  targetPages: number;
+  percent: number;
+}
+
+export interface SendDecision {
+  shouldSend: boolean;
+  slotLabel: string | null;
+}
+
+export const MAX_BOOKS_PER_SLOT = 3;
+const DEADLINE_WINDOW_DAYS = 7;
+const OVERDUE_WINDOW_DAYS = 7;
+
+export function selectDeadlineReminderBooks(
+  books: DeadlineReminderBook[],
+  now: Date,
+): DeadlineReminderBook[] {
+  return books
+    .filter((book) => calculateDeadlineState(book, now) !== null)
+    .sort((a, b) => {
+      const aDaysLeft = getKstDaysLeft(now, a.target_date!);
+      const bDaysLeft = getKstDaysLeft(now, b.target_date!);
+      if (aDaysLeft !== bDaysLeft) return aDaysLeft - bDaysLeft;
+
+      return remainingPages(b) - remainingPages(a);
+    });
+}
+
+export function calculateDeadlineState(
+  book: DeadlineReminderBook,
+  now: Date,
+): DeadlineReminderState | null {
+  if (book.status !== "reading") return null;
+  if (!book.target_date) return null;
+  if (!book.total_pages || book.total_pages <= 0) return null;
+
+  const currentPage = Math.max(0, book.current_page ?? 0);
+  if (currentPage >= book.total_pages) return null;
+
+  const daysLeft = getKstDaysLeft(now, book.target_date);
+  if (daysLeft > DEADLINE_WINDOW_DAYS) return null;
+  if (daysLeft < -OVERDUE_WINDOW_DAYS) return null;
+
+  const remaining = Math.max(0, book.total_pages - currentPage);
+  const inclusiveDays = Math.max(1, daysLeft + 1);
+  const targetPages = Math.ceil(remaining / inclusiveDays);
+  const percent = calculateProgressPercent(currentPage, book.total_pages);
+
+  return {
+    book,
+    stage: stageForDaysLeft(daysLeft),
+    daysLeft,
+    remainingPages: remaining,
+    targetPages,
+    percent,
+  };
+}
+
+export function buildDeadlineReminderVariables(
+  state: DeadlineReminderState,
+): Record<string, string> {
+  return {
+    bookTitle: state.book.title,
+    daysLeft: String(Math.max(0, state.daysLeft)),
+    remainingPages: String(state.remainingPages),
+    targetPages: String(state.targetPages),
+    percent: String(state.percent),
+  };
+}
+
+export function shouldSendDeadlineReminder({
+  stage,
+  kstHour,
+  kstMinute,
+  goalHour,
+  goalMinute,
+  dedupeKey,
+  sentKeys,
+}: {
+  stage: DeadlineReminderStage;
+  kstHour: number;
+  kstMinute: number;
+  goalHour: number;
+  goalMinute: number;
+  dedupeKey: string;
+  sentKeys: Set<string>;
+}): SendDecision {
+  if (sentKeys.has(dedupeKey)) {
+    return { shouldSend: false, slotLabel: null };
+  }
+
+  if (kstHour < 8 || kstHour > 22) {
+    return { shouldSend: false, slotLabel: null };
+  }
+
+  if (kstHour === goalHour && kstMinute === goalMinute) {
+    return { shouldSend: true, slotLabel: "goal" };
+  }
+
+  if (stage === "deadline_warmup" || stage === "deadline_overdue") {
+    return { shouldSend: false, slotLabel: null };
+  }
+
+  if (kstMinute !== 0) {
+    return { shouldSend: false, slotLabel: null };
+  }
+
+  if (kstHour === 18 && !(goalHour === 18 && goalMinute === 0)) {
+    return { shouldSend: true, slotLabel: "secondary_18" };
+  }
+
+  if (kstHour === 20 && !(goalHour === 20 && goalMinute === 0)) {
+    return { shouldSend: true, slotLabel: "secondary_20" };
+  }
+
+  return { shouldSend: false, slotLabel: null };
+}
+
+export function buildDeadlineDedupeKey({
+  kstDate,
+  userId,
+  bookId,
+  stage,
+  slotLabel,
+}: {
+  kstDate: string;
+  userId: string;
+  bookId: string;
+  stage: DeadlineReminderStage;
+  slotLabel: string;
+}): string {
+  return `deadline:${kstDate}:${userId}:${bookId}:${stage}:${slotLabel}`;
+}
+
+export function getKstDateString(date: Date): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(date);
+}
+
+function stageForDaysLeft(daysLeft: number): DeadlineReminderStage {
+  if (daysLeft < 0) return "deadline_overdue";
+  if (daysLeft === 0) return "deadline_today";
+  if (daysLeft === 1) return "deadline_tomorrow";
+  if (daysLeft <= 3) return "deadline_soon";
+  return "deadline_warmup";
+}
+
+export function getKstDaysLeft(now: Date, targetDate: string): number {
+  const nowKst = parseKstDate(getKstDateString(now));
+  const targetKst = parseKstDate(targetDate.slice(0, 10));
+  return Math.round((targetKst.getTime() - nowKst.getTime()) / 86_400_000);
+}
+
+function parseKstDate(value: string): Date {
+  const [year, month, day] = value.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function remainingPages(book: DeadlineReminderBook): number {
+  return Math.max(
+    0,
+    (book.total_pages ?? 0) - Math.max(0, book.current_page ?? 0),
+  );
+}
+
+function calculateProgressPercent(
+  currentPage: number,
+  totalPages: number,
+): number {
+  if (totalPages <= 0) return 0;
+  const percent = Math.round((Math.max(0, currentPage) / totalPages) * 100);
+  return Math.min(100, Math.max(0, percent));
+}

--- a/supabase/functions/send-batch-nudge/deadline-reminder_test.ts
+++ b/supabase/functions/send-batch-nudge/deadline-reminder_test.ts
@@ -1,0 +1,198 @@
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
+
+import {
+  buildDeadlineDedupeKey,
+  buildDeadlineReminderVariables,
+  calculateDeadlineState,
+  selectDeadlineReminderBooks,
+  shouldSendDeadlineReminder,
+} from "./deadline-reminder.ts";
+
+const nowKst = new Date("2026-07-10T03:00:00.000Z");
+
+function book(overrides: Record<string, unknown>) {
+  return {
+    id: "book-1",
+    user_id: "user-1",
+    title: "Book",
+    current_page: 100,
+    total_pages: 300,
+    target_date: "2026-07-13",
+    updated_at: "2026-07-09T12:00:00.000Z",
+    status: "reading",
+    ...overrides,
+  };
+}
+
+Deno.test("selectDeadlineReminderBooks includes every close reading book in priority order", () => {
+  const selected = selectDeadlineReminderBooks([
+    book({
+      id: "d3",
+      title: "D3",
+      target_date: "2026-07-13",
+      current_page: 200,
+      total_pages: 300,
+    }),
+    book({
+      id: "d1",
+      title: "D1",
+      target_date: "2026-07-11",
+      current_page: 50,
+      total_pages: 300,
+    }),
+    book({
+      id: "d0",
+      title: "D0",
+      target_date: "2026-07-10",
+      current_page: 250,
+      total_pages: 300,
+    }),
+    book({
+      id: "d3-more",
+      title: "D3 More",
+      target_date: "2026-07-13",
+      current_page: 10,
+      total_pages: 300,
+    }),
+    book({
+      id: "d10",
+      title: "D10",
+      target_date: "2026-07-20",
+      current_page: 0,
+      total_pages: 300,
+    }),
+  ], nowKst);
+
+  assertEquals(selected.map((item) => item.id), ["d0", "d1", "d3-more", "d3"]);
+});
+
+Deno.test("selectDeadlineReminderBooks filters out invalid or non-actionable books", () => {
+  const selected = selectDeadlineReminderBooks([
+    book({ id: "planned", status: "planned" }),
+    book({ id: "no-target", target_date: null }),
+    book({ id: "no-pages", total_pages: 0 }),
+    book({ id: "finished", current_page: 300, total_pages: 300 }),
+    book({ id: "too-overdue", target_date: "2026-07-02" }),
+    book({ id: "valid-overdue", target_date: "2026-07-05" }),
+  ], nowKst);
+
+  assertEquals(selected.map((item) => item.id), ["valid-overdue"]);
+});
+
+Deno.test("calculateDeadlineState uses KST calendar dates for stage selection", () => {
+  assertEquals(
+    calculateDeadlineState(book({ target_date: "2026-07-17" }), nowKst)?.stage,
+    "deadline_warmup",
+  );
+  assertEquals(
+    calculateDeadlineState(book({ target_date: "2026-07-13" }), nowKst)?.stage,
+    "deadline_soon",
+  );
+  assertEquals(
+    calculateDeadlineState(book({ target_date: "2026-07-11" }), nowKst)?.stage,
+    "deadline_tomorrow",
+  );
+  assertEquals(
+    calculateDeadlineState(book({ target_date: "2026-07-10" }), nowKst)?.stage,
+    "deadline_today",
+  );
+  assertEquals(
+    calculateDeadlineState(book({ target_date: "2026-07-09" }), nowKst)?.stage,
+    "deadline_overdue",
+  );
+  assertEquals(
+    calculateDeadlineState(book({ target_date: "2026-07-18" }), nowKst),
+    null,
+  );
+  assertEquals(
+    calculateDeadlineState(book({ target_date: "2026-07-02" }), nowKst),
+    null,
+  );
+});
+
+Deno.test("buildDeadlineReminderVariables includes remaining pages and catch-up target", () => {
+  const state = calculateDeadlineState(
+    book({
+      title: "Deadline Book",
+      current_page: 120,
+      total_pages: 300,
+      target_date: "2026-07-13",
+    }),
+    nowKst,
+  );
+
+  assertEquals(buildDeadlineReminderVariables(state!), {
+    bookTitle: "Deadline Book",
+    daysLeft: "3",
+    remainingPages: "180",
+    targetPages: "45",
+    percent: "40",
+  });
+});
+
+Deno.test("shouldSendDeadlineReminder respects stage slots, quiet hours, and dedupe", () => {
+  assertEquals(
+    shouldSendDeadlineReminder({
+      stage: "deadline_warmup",
+      kstHour: 20,
+      kstMinute: 0,
+      goalHour: 20,
+      goalMinute: 0,
+      dedupeKey: "warmup",
+      sentKeys: new Set(),
+    }),
+    { shouldSend: true, slotLabel: "goal" },
+  );
+
+  assertEquals(
+    shouldSendDeadlineReminder({
+      stage: "deadline_soon",
+      kstHour: 18,
+      kstMinute: 0,
+      goalHour: 20,
+      goalMinute: 0,
+      dedupeKey: "soon-evening",
+      sentKeys: new Set(),
+    }),
+    { shouldSend: true, slotLabel: "secondary_18" },
+  );
+
+  assertEquals(
+    shouldSendDeadlineReminder({
+      stage: "deadline_soon",
+      kstHour: 7,
+      kstMinute: 30,
+      goalHour: 20,
+      goalMinute: 0,
+      dedupeKey: "quiet",
+      sentKeys: new Set(),
+    }).shouldSend,
+    false,
+  );
+
+  assertEquals(
+    shouldSendDeadlineReminder({
+      stage: "deadline_today",
+      kstHour: 20,
+      kstMinute: 0,
+      goalHour: 20,
+      goalMinute: 0,
+      dedupeKey: "sent",
+      sentKeys: new Set(["sent"]),
+    }).shouldSend,
+    false,
+  );
+});
+
+Deno.test("buildDeadlineDedupeKey includes date, user, book, stage, and slot", () => {
+  assertEquals(
+    buildDeadlineDedupeKey({
+      kstDate: "2026-07-10",
+      userId: "user-1",
+      bookId: "book-1",
+      stage: "deadline_today",
+      slotLabel: "goal",
+    }),
+    "deadline:2026-07-10:user-1:book-1:deadline_today:goal",
+  );
+});

--- a/supabase/functions/send-batch-nudge/index.ts
+++ b/supabase/functions/send-batch-nudge/index.ts
@@ -7,6 +7,17 @@ import {
   DailyReminderBook,
   selectDailyReminderBook,
 } from "./daily-reminder.ts";
+import {
+  buildDeadlineDedupeKey,
+  buildDeadlineReminderVariables,
+  calculateDeadlineState,
+  DeadlineReminderBook,
+  getKstDateString,
+  getKstDaysLeft,
+  MAX_BOOKS_PER_SLOT,
+  selectDeadlineReminderBooks,
+  shouldSendDeadlineReminder,
+} from "./deadline-reminder.ts";
 
 const FIREBASE_SERVICE_ACCOUNT = Deno.env.get("FIREBASE_SERVICE_ACCOUNT");
 
@@ -59,7 +70,7 @@ async function getAccessToken(serviceAccount: ServiceAccount): Promise<string> {
     binaryDer,
     { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
     false,
-    ["sign"]
+    ["sign"],
   );
 
   const jwtPayload = {
@@ -100,9 +111,10 @@ async function sendFCMMessage(
   fcmToken: string,
   title: string,
   body: string,
-  data?: Record<string, string>
+  data?: Record<string, string>,
 ): Promise<any> {
-  const fcmUrl = `https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`;
+  const fcmUrl =
+    `https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`;
 
   const message = {
     message: {
@@ -143,7 +155,9 @@ async function sendFCMMessage(
 
 let templatesCache: Map<string, TemplateRow> | null = null;
 
-async function loadPushTemplates(supabaseClient: any): Promise<Map<string, TemplateRow>> {
+async function loadPushTemplates(
+  supabaseClient: any,
+): Promise<Map<string, TemplateRow>> {
   if (templatesCache) return templatesCache;
 
   const { data: templates } = await supabaseClient
@@ -162,15 +176,21 @@ async function loadPushTemplates(supabaseClient: any): Promise<Map<string, Templ
 
 function getLocalizedTemplate(
   template: TemplateRow,
-  locale: string
+  locale: string,
 ): { title: string; bodyTemplate: string } {
   if (locale === "en" && template.title_en && template.body_template_en) {
-    return { title: template.title_en, bodyTemplate: template.body_template_en };
+    return {
+      title: template.title_en,
+      bodyTemplate: template.body_template_en,
+    };
   }
   return { title: template.title, bodyTemplate: template.body_template };
 }
 
-function replaceTemplateVariables(template: string, variables: Record<string, string>): string {
+function replaceTemplateVariables(
+  template: string,
+  variables: Record<string, string>,
+): string {
   let result = template;
   for (const [key, value] of Object.entries(variables)) {
     result = result.replace(new RegExp(`\\{${key}\\}`, "g"), value);
@@ -180,6 +200,14 @@ function replaceTemplateVariables(template: string, variables: Record<string, st
 
 const FCM_BATCH_SIZE = 100;
 
+function stableTokenHash(token: string): string {
+  let hash = 5381;
+  for (let i = 0; i < token.length; i++) {
+    hash = ((hash << 5) + hash + token.charCodeAt(i)) >>> 0;
+  }
+  return hash.toString(36);
+}
+
 async function sendToTargets(
   accessToken: string,
   projectId: string,
@@ -188,7 +216,8 @@ async function sendToTargets(
   variables: Record<string, string>,
   templates: Map<string, TemplateRow>,
   supabaseClient: any,
-  extraData?: Record<string, string>
+  extraData?: Record<string, string>,
+  dedupeKey?: string,
 ): Promise<{ sent: number; failed: number }> {
   const template = templates.get(templateType);
   if (!template) return { sent: 0, failed: 0 };
@@ -201,29 +230,98 @@ async function sendToTargets(
     const batch = targets.slice(i, i + FCM_BATCH_SIZE);
     const results = await Promise.allSettled(
       batch.map(async (target) => {
-        const { title, bodyTemplate } = getLocalizedTemplate(template, target.locale);
+        const { title, bodyTemplate } = getLocalizedTemplate(
+          template,
+          target.locale,
+        );
+        const resolvedTitle = replaceTemplateVariables(title, variables);
         const body = replaceTemplateVariables(bodyTemplate, variables);
+        let reservedLogId: string | null = null;
 
-        await sendFCMMessage(accessToken, projectId, target.token, title, body, {
-          type: templateType,
-          ...extraData,
-        });
+        if (dedupeKey) {
+          const { data: reservation, error: reservationError } =
+            await supabaseClient
+              .from("push_logs")
+              .insert({
+                user_id: target.userId,
+                push_type: templateType,
+                book_id: extraData?.bookId || null,
+                title: resolvedTitle,
+                body,
+                sent_at: null,
+                dedupe_key: dedupeKey,
+              })
+              .select("id")
+              .single();
 
-        await supabaseClient.from("push_logs").insert({
-          user_id: target.userId,
-          push_type: templateType,
-          book_id: extraData?.bookId || null,
-          title: title,
-          body: body,
-        });
+          if (reservationError) {
+            const isDuplicate = reservationError.code === "23505" ||
+              String(reservationError.message || "").includes(
+                "duplicate key",
+              );
+            if (isDuplicate) {
+              return { target, status: "skipped" as const };
+            }
+            throw reservationError;
+          }
 
-        return target;
-      })
+          reservedLogId = reservation?.id ?? null;
+        }
+
+        try {
+          await sendFCMMessage(
+            accessToken,
+            projectId,
+            target.token,
+            resolvedTitle,
+            body,
+            {
+              type: templateType,
+              ...extraData,
+            },
+          );
+        } catch (error) {
+          if (reservedLogId) {
+            const { error: releaseError } = await supabaseClient
+              .from("push_logs")
+              .delete()
+              .eq("id", reservedLogId);
+            if (releaseError) {
+              console.error("Failed to release push dedupe reservation", {
+                dedupeKey,
+                releaseError,
+              });
+            }
+          }
+          throw error;
+        }
+
+        if (reservedLogId) {
+          const { error: markSentError } = await supabaseClient
+            .from("push_logs")
+            .update({ sent_at: new Date().toISOString() })
+            .eq("id", reservedLogId);
+          if (markSentError) {
+            throw markSentError;
+          }
+        } else {
+          await supabaseClient.from("push_logs").insert({
+            user_id: target.userId,
+            push_type: templateType,
+            book_id: extraData?.bookId || null,
+            title: resolvedTitle,
+            body,
+            dedupe_key: null,
+          });
+        }
+
+        return { target, status: "sent" as const };
+      }),
     );
 
     results.forEach((result, idx) => {
       if (result.status === "fulfilled") {
-        sent++;
+        if (result.value.status === "sent") sent++;
       } else {
         const msg = result.reason?.message || "";
         if (msg.includes("UNREGISTERED") || msg.includes("INVALID_ARGUMENT")) {
@@ -245,7 +343,7 @@ async function sendToTargets(
 async function runInBatches<T, R>(
   items: T[],
   batchSize: number,
-  fn: (item: T) => Promise<R>
+  fn: (item: T) => Promise<R>,
 ): Promise<{ results: R[]; errors: any[] }> {
   const results: R[] = [];
   const errors: any[] = [];
@@ -284,7 +382,7 @@ serve(async (req) => {
     if (!FIREBASE_SERVICE_ACCOUNT) {
       return new Response(
         JSON.stringify({ error: "FIREBASE_SERVICE_ACCOUNT not configured" }),
-        { status: 500, headers: { "Content-Type": "application/json" } }
+        { status: 500, headers: { "Content-Type": "application/json" } },
       );
     }
 
@@ -294,7 +392,7 @@ serve(async (req) => {
     } catch {
       return new Response(
         JSON.stringify({ error: "Invalid FIREBASE_SERVICE_ACCOUNT format" }),
-        { status: 500, headers: { "Content-Type": "application/json" } }
+        { status: 500, headers: { "Content-Type": "application/json" } },
       );
     }
 
@@ -306,13 +404,15 @@ serve(async (req) => {
           autoRefreshToken: false,
           persistSession: false,
         },
-      }
+      },
     );
 
     const now = new Date();
     const kstHour = (now.getUTCHours() + 9) % 24;
     const kstMinute = now.getUTCMinutes() < 30 ? 0 : 30;
-    console.log(`Current KST slot: ${kstHour}:${kstMinute === 0 ? "00" : "30"}`);
+    console.log(
+      `Current KST slot: ${kstHour}:${kstMinute === 0 ? "00" : "30"}`,
+    );
 
     const accessToken = await getAccessToken(serviceAccount);
     const templates = await loadPushTemplates(supabaseClient);
@@ -331,11 +431,15 @@ serve(async (req) => {
       .eq("daily_reminder_minute", kstMinute);
 
     if (dailyReminderUsers && dailyReminderUsers.length > 0) {
-      const userIds = [...new Set(dailyReminderUsers.map((u: any) => u.user_id))];
+      const userIds = [
+        ...new Set(dailyReminderUsers.map((u: any) => u.user_id)),
+      ];
 
       const { data: books } = await supabaseClient
         .from("books")
-        .select("user_id, id, title, current_page, total_pages, updated_at, status")
+        .select(
+          "user_id, id, title, current_page, total_pages, updated_at, status",
+        )
         .in("user_id", userIds)
         .eq("status", "reading")
         .order("updated_at", { ascending: false });
@@ -353,7 +457,9 @@ serve(async (req) => {
         dailyReminderUsers,
         FCM_BATCH_SIZE,
         async (user: any) => {
-          const book = selectDailyReminderBook(userBooksMap.get(user.user_id) || []);
+          const book = selectDailyReminderBook(
+            userBooksMap.get(user.user_id) || [],
+          );
           if (!book) {
             totalSkipped++;
             return { sent: 0, failed: 0 };
@@ -363,48 +469,72 @@ serve(async (req) => {
           return await sendToTargets(
             accessToken,
             serviceAccount.project_id,
-            [{ userId: user.user_id, token: user.token, locale: user.locale || "ko" }],
+            [{
+              userId: user.user_id,
+              token: user.token,
+              locale: user.locale || "ko",
+            }],
             "daily_reminder",
             variables,
             templates,
             supabaseClient,
-            { bookId: book.id, bookTitle: book.title, percent: variables.percent }
+            {
+              bookId: book.id,
+              bookTitle: book.title,
+              percent: variables.percent,
+            },
           );
-        }
+        },
       );
       dailyResults.results.forEach((r) => {
         totalSent += r.sent;
         totalFailed += r.failed;
       });
-      console.log(`daily_reminder: ${dailyReminderUsers.length} targets, sent=${totalSent}, failed=${totalFailed}`);
+      console.log(
+        `daily_reminder: ${dailyReminderUsers.length} targets, sent=${totalSent}, failed=${totalFailed}`,
+      );
     }
 
-    // ── Phase 1: goal_alarm ──
+    // ── Phase 1: deadline escalation / goal_alarm ──
     const { data: goalAlarmUsers } = await supabaseClient
       .from("fcm_tokens")
-      .select("user_id, token, locale")
+      .select("user_id, token, locale, goal_alarm_hour, goal_alarm_minute")
       .eq("notification_enabled", true)
-      .eq("goal_alarm_enabled", true)
-      .eq("goal_alarm_hour", kstHour)
-      .eq("goal_alarm_minute", kstMinute);
+      .eq("goal_alarm_enabled", true);
 
     if (goalAlarmUsers && goalAlarmUsers.length > 0) {
       const userIds = [...new Set(goalAlarmUsers.map((u: any) => u.user_id))];
+      const kstDate = getKstDateString(now);
+
+      const { data: sentDeadlineLogs } = await supabaseClient
+        .from("push_logs")
+        .select("dedupe_key")
+        .in("user_id", userIds)
+        .like("dedupe_key", `deadline:${kstDate}:%`);
+
+      const sentDeadlineKeys = new Set<string>();
+      if (sentDeadlineLogs) {
+        sentDeadlineLogs.forEach((log: any) => {
+          if (log.dedupe_key) sentDeadlineKeys.add(log.dedupe_key);
+        });
+      }
 
       const { data: books } = await supabaseClient
         .from("books")
-        .select("user_id, id, title, current_page, total_pages, target_date, status")
+        .select(
+          "user_id, id, title, current_page, total_pages, target_date, updated_at, status",
+        )
         .in("user_id", userIds)
         .eq("status", "reading")
         .not("target_date", "is", null)
         .order("target_date", { ascending: true });
 
-      const userGoalMap = new Map<string, any>();
+      const userBooksMap = new Map<string, DeadlineReminderBook[]>();
       if (books) {
-        books.forEach((b: any) => {
-          if (!userGoalMap.has(b.user_id)) {
-            userGoalMap.set(b.user_id, b);
-          }
+        books.forEach((book: DeadlineReminderBook) => {
+          const list = userBooksMap.get(book.user_id) || [];
+          list.push(book);
+          userBooksMap.set(book.user_id, list);
         });
       }
 
@@ -412,62 +542,173 @@ serve(async (req) => {
         goalAlarmUsers,
         FCM_BATCH_SIZE,
         async (user: any) => {
-          const book = userGoalMap.get(user.user_id);
-          if (!book) {
+          const userBooks = userBooksMap.get(user.user_id) || [];
+          const deadlineBooks = selectDeadlineReminderBooks(userBooks, now);
+          const results: { sent: number; failed: number }[] = [];
+          let currentSlotCandidateCount = 0;
+          let hasCurrentSlotDeadlineCandidate = false;
+
+          for (const book of deadlineBooks) {
+            const state = calculateDeadlineState(book, now);
+            if (!state) continue;
+
+            const slotProbe = shouldSendDeadlineReminder({
+              stage: state.stage,
+              kstHour,
+              kstMinute,
+              goalHour: user.goal_alarm_hour ?? 20,
+              goalMinute: user.goal_alarm_minute ?? 0,
+              dedupeKey: "",
+              sentKeys: new Set(),
+            });
+            if (!slotProbe.shouldSend || !slotProbe.slotLabel) continue;
+            hasCurrentSlotDeadlineCandidate = true;
+            currentSlotCandidateCount++;
+            if (currentSlotCandidateCount > MAX_BOOKS_PER_SLOT) break;
+
+            const baseDedupeKey = buildDeadlineDedupeKey({
+              kstDate,
+              userId: user.user_id,
+              bookId: book.id,
+              stage: state.stage,
+              slotLabel: slotProbe.slotLabel,
+            });
+            const dedupeKey = `${baseDedupeKey}:${stableTokenHash(user.token)}`;
+
+            const decision = shouldSendDeadlineReminder({
+              stage: state.stage,
+              kstHour,
+              kstMinute,
+              goalHour: user.goal_alarm_hour ?? 20,
+              goalMinute: user.goal_alarm_minute ?? 0,
+              dedupeKey,
+              sentKeys: sentDeadlineKeys,
+            });
+            if (!decision.shouldSend) {
+              totalSkipped++;
+              continue;
+            }
+
+            const variables = buildDeadlineReminderVariables(state);
+            const result = await sendToTargets(
+              accessToken,
+              serviceAccount.project_id,
+              [{
+                userId: user.user_id,
+                token: user.token,
+                locale: user.locale || "ko",
+              }],
+              state.stage,
+              variables,
+              templates,
+              supabaseClient,
+              {
+                bookId: book.id,
+                bookTitle: book.title,
+                stage: state.stage,
+                daysLeft: String(state.daysLeft),
+                remainingPages: variables.remainingPages,
+                targetPages: variables.targetPages,
+                percent: variables.percent,
+              },
+              dedupeKey,
+            );
+            sentDeadlineKeys.add(dedupeKey);
+            results.push(result);
+          }
+
+          if (results.length > 0) {
+            return results.reduce(
+              (acc, result) => ({
+                sent: acc.sent + result.sent,
+                failed: acc.failed + result.failed,
+              }),
+              { sent: 0, failed: 0 },
+            );
+          }
+
+          if (hasCurrentSlotDeadlineCandidate) {
             totalSkipped++;
             return { sent: 0, failed: 0 };
           }
 
-          const daysLeft = Math.max(
-            0,
-            Math.ceil(
-              (new Date(book.target_date).getTime() - now.getTime()) /
-                (1000 * 60 * 60 * 24)
-            )
-          );
-          const remainingPages = Math.max(0, book.total_pages - book.current_page);
-          const targetPages = daysLeft > 0 ? Math.ceil(remainingPages / daysLeft) : remainingPages;
+          const fallbackBook = userBooks
+            .filter((book) => {
+              if (book.status !== "reading") return false;
+              if (!book.target_date) return false;
+              if (!book.total_pages || book.total_pages <= 0) return false;
+              if (Math.max(0, book.current_page ?? 0) >= book.total_pages) {
+                return false;
+              }
+              return getKstDaysLeft(now, book.target_date) > 7;
+            })
+            .sort((a, b) =>
+              getKstDaysLeft(now, a.target_date!) -
+              getKstDaysLeft(now, b.target_date!)
+            )[0];
 
-          let templateType = "goal_alarm";
+          if (
+            !fallbackBook || kstHour !== (user.goal_alarm_hour ?? 20) ||
+            kstMinute !== (user.goal_alarm_minute ?? 0)
+          ) {
+            totalSkipped++;
+            return { sent: 0, failed: 0 };
+          }
+
+          const remainingPages = Math.max(
+            0,
+            (fallbackBook.total_pages ?? 0) - (fallbackBook.current_page ?? 0),
+          );
+          const fallbackDaysLeft = fallbackBook.target_date
+            ? Math.max(1, getKstDaysLeft(now, fallbackBook.target_date))
+            : 1;
+          const targetPages = Math.ceil(remainingPages / fallbackDaysLeft);
           const variables: Record<string, string> = {
-            bookTitle: book.title,
+            bookTitle: fallbackBook.title,
             targetPages: String(targetPages),
-            daysLeft: String(daysLeft),
+            daysLeft: String(fallbackDaysLeft),
             percent: String(
-              book.total_pages > 0
-                ? Math.round((book.current_page / book.total_pages) * 100)
-                : 0
+              fallbackBook.total_pages && fallbackBook.total_pages > 0
+                ? Math.round(
+                  ((fallbackBook.current_page ?? 0) /
+                    fallbackBook.total_pages) * 100,
+                )
+                : 0,
             ),
           };
-
-          if (daysLeft === 0 || !book.target_date) {
-            templateType = "daily_reminder";
-            variables.bookTitle = book.title;
-          }
 
           return sendToTargets(
             accessToken,
             serviceAccount.project_id,
-            [{ userId: user.user_id, token: user.token, locale: user.locale || "ko" }],
-            templateType,
+            [{
+              userId: user.user_id,
+              token: user.token,
+              locale: user.locale || "ko",
+            }],
+            "goal_alarm",
             variables,
             templates,
             supabaseClient,
-            { bookId: book.id, bookTitle: book.title }
+            { bookId: fallbackBook.id, bookTitle: fallbackBook.title },
           );
-        }
+        },
       );
       goalResults.results.forEach((r) => {
         totalSent += r.sent;
         totalFailed += r.failed;
       });
-      console.log(`goal_alarm: ${goalAlarmUsers.length} targets, sent=${totalSent}, failed=${totalFailed}`);
+      console.log(
+        `deadline/goal_alarm: ${goalAlarmUsers.length} targets, sent=${totalSent}, failed=${totalFailed}`,
+      );
     }
 
     // ── Phase 2: event nudge (batch SQL) ──
     let eligibleNudges = null;
     try {
-      const rpcResult = await supabaseClient.rpc("get_eligible_event_nudges", {});
+      const rpcResult = await supabaseClient.rpc(
+        "get_eligible_event_nudges",
+        {},
+      );
       eligibleNudges = rpcResult.data;
     } catch {
       eligibleNudges = null;
@@ -479,7 +720,7 @@ serve(async (req) => {
         accessToken,
         serviceAccount.project_id,
         templates,
-        now
+        now,
       );
       totalSent += nudgeResult.sent;
       totalFailed += nudgeResult.failed;
@@ -515,9 +756,12 @@ serve(async (req) => {
             nudge.variables || {},
             templates,
             supabaseClient,
-            { bookId: nudge.book_id || "", bookTitle: nudge.variables?.bookTitle || "" }
+            {
+              bookId: nudge.book_id || "",
+              bookTitle: nudge.variables?.bookTitle || "",
+            },
           );
-        }
+        },
       );
       eventResults.results.forEach((r) => {
         totalSent += r.sent;
@@ -541,7 +785,7 @@ serve(async (req) => {
           "Content-Type": "application/json",
           "Access-Control-Allow-Origin": "*",
         },
-      }
+      },
     );
   } catch (error: any) {
     console.error("Error:", error);
@@ -560,7 +804,7 @@ async function processEventNudgesFallback(
   accessToken: string,
   projectId: string,
   templates: Map<string, TemplateRow>,
-  now: Date
+  now: Date,
 ): Promise<{ sent: number; failed: number; skipped: number }> {
   let sent = 0;
   let failed = 0;
@@ -577,7 +821,11 @@ async function processEventNudgesFallback(
   const userTokensMap = new Map<string, PushTarget[]>();
   nudgeUsers.forEach((row: any) => {
     const targets = userTokensMap.get(row.user_id) || [];
-    targets.push({ userId: row.user_id, token: row.token, locale: row.locale || "ko" });
+    targets.push({
+      userId: row.user_id,
+      token: row.token,
+      locale: row.locale || "ko",
+    });
     userTokensMap.set(row.user_id, targets);
   });
 
@@ -588,7 +836,13 @@ async function processEventNudgesFallback(
     .from("push_logs")
     .select("user_id, push_type")
     .in("user_id", userIds)
-    .in("push_type", ["inactive", "deadline", "progress", "streak", "achievement"])
+    .in("push_type", [
+      "inactive",
+      "deadline",
+      "progress",
+      "streak",
+      "achievement",
+    ])
     .gte("created_at", `${todayStr}T00:00:00`);
 
   const sentToday = new Set<string>();
@@ -600,7 +854,9 @@ async function processEventNudgesFallback(
 
   const { data: books } = await supabaseClient
     .from("books")
-    .select("user_id, id, title, current_page, total_pages, target_date, updated_at, status")
+    .select(
+      "user_id, id, title, current_page, total_pages, target_date, updated_at, status",
+    )
     .in("user_id", userIds)
     .order("updated_at", { ascending: false });
 
@@ -624,16 +880,25 @@ async function processEventNudgesFallback(
       }
 
       const currentBook = userBooks[0];
-      const lastReadingDate = currentBook.updated_at ? new Date(currentBook.updated_at) : null;
+      const lastReadingDate = currentBook.updated_at
+        ? new Date(currentBook.updated_at)
+        : null;
       const daysSinceLastReading = lastReadingDate
-        ? Math.floor((now.getTime() - lastReadingDate.getTime()) / (1000 * 60 * 60 * 24))
+        ? Math.floor(
+          (now.getTime() - lastReadingDate.getTime()) / (1000 * 60 * 60 * 24),
+        )
         : null;
 
-      const progress =
-        currentBook.total_pages > 0 ? currentBook.current_page / currentBook.total_pages : 0;
-      const targetDate = currentBook.target_date ? new Date(currentBook.target_date) : null;
+      const progress = currentBook.total_pages > 0
+        ? currentBook.current_page / currentBook.total_pages
+        : 0;
+      const targetDate = currentBook.target_date
+        ? new Date(currentBook.target_date)
+        : null;
       const daysUntilDeadline = targetDate
-        ? Math.ceil((targetDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+        ? Math.ceil(
+          (targetDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24),
+        )
         : null;
 
       const sevenDaysAgo = new Date(now);
@@ -643,7 +908,9 @@ async function processEventNudgesFallback(
         if (book.updated_at) {
           const date = new Date(book.updated_at);
           if (date >= sevenDaysAgo) {
-            readingDates.add(`${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`);
+            readingDates.add(
+              `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`,
+            );
           }
         }
       });
@@ -654,16 +921,28 @@ async function processEventNudgesFallback(
 
       if (daysSinceLastReading !== null && daysSinceLastReading >= 3) {
         nudgeType = "inactive";
-        variables = { days: String(daysSinceLastReading), bookTitle: currentBook.title };
+        variables = {
+          days: String(daysSinceLastReading),
+          bookTitle: currentBook.title,
+        };
       } else if (progress >= 1.0 && currentBook.status === "reading") {
         nudgeType = "achievement";
         variables = { bookTitle: currentBook.title };
-      } else if (daysUntilDeadline !== null && daysUntilDeadline > 0 && daysUntilDeadline <= 3) {
+      } else if (
+        daysUntilDeadline !== null && daysUntilDeadline > 0 &&
+        daysUntilDeadline <= 3
+      ) {
         nudgeType = "deadline";
-        variables = { days: String(daysUntilDeadline), bookTitle: currentBook.title };
+        variables = {
+          days: String(daysUntilDeadline),
+          bookTitle: currentBook.title,
+        };
       } else if (progress >= 0.8 && progress < 1.0) {
         nudgeType = "progress";
-        variables = { percent: String(Math.round(progress * 100)), bookTitle: currentBook.title };
+        variables = {
+          percent: String(Math.round(progress * 100)),
+          bookTitle: currentBook.title,
+        };
       } else if (streak > 0 && streak < 7) {
         nudgeType = "streak";
         variables = { days: String(streak) };
@@ -683,10 +962,10 @@ async function processEventNudgesFallback(
         variables,
         templates,
         supabaseClient,
-        { bookId: currentBook.id, bookTitle: currentBook.title }
+        { bookId: currentBook.id, bookTitle: currentBook.title },
       );
       return { sent: result.sent, failed: result.failed, skipped: 0 };
-    }
+    },
   );
 
   fallbackResults.results.forEach((r) => {

--- a/supabase/migrations/20260710115439_add_deadline_escalation_push.sql
+++ b/supabase/migrations/20260710115439_add_deadline_escalation_push.sql
@@ -1,0 +1,68 @@
+ALTER TABLE public.push_logs
+  ADD COLUMN IF NOT EXISTS dedupe_key TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_push_logs_dedupe_key
+  ON public.push_logs (dedupe_key)
+  WHERE dedupe_key IS NOT NULL;
+
+INSERT INTO public.push_templates
+  (type, name, title, body_template, title_en, body_template_en, is_active, priority)
+VALUES
+  (
+    'deadline_warmup',
+    '마감 준비',
+    '마감까지 {daysLeft}일 남았어요 📚',
+    '「{bookTitle}」 남은 {remainingPages}p, 하루 {targetPages}p면 충분해요.',
+    '{daysLeft} days left 📚',
+    'You have {remainingPages} pages left in "{bookTitle}" — about {targetPages} pages a day.',
+    true,
+    25
+  ),
+  (
+    'deadline_soon',
+    '마감 임박',
+    '이제 {daysLeft}일 남았어요 ⏰',
+    '「{bookTitle}」 오늘 {targetPages}p 읽으면 완독 흐름을 지킬 수 있어요.',
+    '{daysLeft} days to go ⏰',
+    'Read {targetPages} pages of "{bookTitle}" today to stay on track.',
+    true,
+    26
+  ),
+  (
+    'deadline_tomorrow',
+    '내일 마감',
+    '내일 마감이에요 🔥',
+    '「{bookTitle}」 남은 {remainingPages}p. 오늘 {targetPages}p부터 끊어가요.',
+    'Due tomorrow 🔥',
+    '"{bookTitle}" has {remainingPages} pages left. Start with {targetPages} pages today.',
+    true,
+    27
+  ),
+  (
+    'deadline_today',
+    '오늘 마감',
+    '오늘 마감이에요 🚨',
+    '「{bookTitle}」 남은 {remainingPages}p. 지금 조금만 읽어도 완독 가능성이 올라가요.',
+    'Due today 🚨',
+    '"{bookTitle}" is due today with {remainingPages} pages left. A short session now helps.',
+    true,
+    28
+  ),
+  (
+    'deadline_overdue',
+    '마감 지남',
+    '목표일이 지났어요 🗓️',
+    '「{bookTitle}」 남은 {remainingPages}p. 목표를 다시 잡거나 오늘 마무리해봐요.',
+    'Past the target date 🗓️',
+    '"{bookTitle}" has {remainingPages} pages left. Reset the target or finish a small part today.',
+    true,
+    29
+  )
+ON CONFLICT (type) DO UPDATE SET
+  name = EXCLUDED.name,
+  title = EXCLUDED.title,
+  body_template = EXCLUDED.body_template,
+  title_en = EXCLUDED.title_en,
+  body_template_en = EXCLUDED.body_template_en,
+  is_active = EXCLUDED.is_active,
+  priority = EXCLUDED.priority;


### PR DESCRIPTION
독서중인 책의 마감일이 가까워질수록 책별 단계형 리마인드 푸시를 발송합니다.

## 📋 Changes

- `deadline-reminder.ts` 순수 모듈 추가
  - D-7~D+7 범위의 마감 임박/초과 책 판단
  - 여러 대상 책을 모두 평가하되 슬롯당 최대 3권까지 제한
  - KST calendar date 기준 stage 계산
  - stage/slot/date/book/recipient-token-hash 기반 dedupe key 생성
- `send-batch-nudge`의 goal alarm phase를 deadline escalation과 통합
  - `deadline_warmup`, `deadline_soon`, `deadline_tomorrow`, `deadline_today`, `deadline_overdue` 템플릿 발송
  - D-8 이상 책은 기존 `goal_alarm` fallback 유지
  - FCM data payload에 `stage`, `daysLeft`, `remainingPages`, `targetPages`, `percent` 포함
- Supabase migration 추가
  - `push_logs.dedupe_key` 컬럼 및 unique index 추가
  - 단계형 deadline push template 한/영 문구 추가
- Deno 테스트 추가
  - 대상 책 선택
  - stage 계산
  - 변수 생성
  - 슬롯/중복 방지 정책

## 🧠 Context & Background

BOK-379 요구사항입니다.

독서중인 책의 목표 마감일이 가까워질수록 리마인드 강도와 빈도를 높여야 합니다. 특히 사용자가 여러 권을 동시에 읽고 있을 수 있으므로, 대표 1권만 고르지 않고 `마감 임박` 기준에 들어온 책을 모두 평가하도록 설계했습니다.

정책:

- D-7~D-4: 하루 1회 `deadline_warmup`
- D-3~D-2: 하루 최대 2회 `deadline_soon`
- D-1: 하루 최대 2회 `deadline_tomorrow`
- D-day: 하루 최대 2회 `deadline_today`
- D+1~D+7: 하루 1회 `deadline_overdue`

## ✅ How to Test

1. Deno 순수 함수 테스트 실행
   ```bash
   cd /Users/byungskersmacbook/Documents/GitHub/book-golas
   npx -y deno test --allow-env supabase/functions/send-batch-nudge/deadline-reminder_test.ts
   ```

2. 기존 daily reminder 테스트 회귀 확인
   ```bash
   npx -y deno test --allow-env supabase/functions/send-batch-nudge/daily-reminder_test.ts
   ```

3. Edge Function type check
   ```bash
   npx -y deno check supabase/functions/send-batch-nudge/index.ts
   ```

결과:

- `deadline-reminder_test.ts`: 6 passed
- `daily-reminder_test.ts`: 3 passed
- `send-batch-nudge/index.ts`: check passed

## 🧾 Screenshots or Videos (Optional)

없음. 서버 푸시 로직 및 migration 변경입니다.

## 🔗 Related Issues

- Related: BOK-379

## 🙌 Additional Notes (Optional)

- 첫 push 시 GitHub CLI active account가 `bwlee-dix`라 push가 403으로 실패했지만, `gh auth switch -u byungsker` 후 정상 push했습니다.
- `dedupe_key`는 같은 사용자/책/stage/slot/date에서 중복 발송을 막기 위한 값이며, 멀티 디바이스 사용자를 고려해 원문 토큰을 저장하지 않고 token hash suffix를 포함합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deadline-aware reading reminders for upcoming and overdue goals.
  * Notifications now include progress details such as remaining pages, target pages, and completion percentage.
  * Added Korean and English notification templates for each deadline stage.
  * Prevented duplicate reminders while supporting scheduled reminder slots.

* **Bug Fixes**
  * Improved reminder scheduling, quiet-hour handling, and deadline prioritization.
  * Added safeguards to exclude invalid, completed, or unsupported reading goals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->