### PR TITLE
fix: secure ES256 user Edge Functions (BOK-374)

### DIFF
--- a/app/lib/data/services/note_structure_service.dart
+++ b/app/lib/data/services/note_structure_service.dart
@@ -25,28 +25,16 @@ class NoteStructureService {
     try {
       debugPrint('🧠 Structuring notes for book: $bookId');
 
-      // Debug: Check user session and JWT token
-      final user = Supabase.instance.client.auth.currentUser;
-      final session = Supabase.instance.client.auth.currentSession;
-      debugPrint('👤 Current user: ${user?.id}');
-      debugPrint('🔑 Session exists: ${session != null}');
-      if (session?.accessToken != null && session!.accessToken.length >= 20) {
-        debugPrint(
-            '🎫 JWT token (first 20): ${session.accessToken.substring(0, 20)}');
-      } else {
-        debugPrint('🎫 JWT token: NOT AVAILABLE');
-      }
-
-      final response = await _supabase.functions.invoke(
-        'structure-notes',
-        body: {'bookId': bookId},
-      ).timeout(const Duration(seconds: 60));
+      final response = await _supabase.functions
+          .invoke('structure-notes', body: {'bookId': bookId})
+          .timeout(const Duration(seconds: 60));
 
       debugPrint('🧠 Structure response status: ${response.status}');
 
       if (response.status != 200) {
         debugPrint(
-            '🔴 Structure failed: ${response.status} - ${response.data}');
+          '🔴 Structure failed: ${response.status} - ${response.data}',
+        );
         return null;
       }
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -368,15 +368,31 @@ deno_version = 2
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 
-# Per-function overrides.
-# verify_jwt=false is required for functions that accept user JWTs signed with
-# the project's asymmetric (ES256) signing key. The platform-level verify_jwt
-# gate does not accept these tokens, so each function below performs its own
-# auth.getUser() check in-code instead.
 [functions.recall-search]
 verify_jwt = false
 
 [functions.generate-embedding]
+verify_jwt = false
+
+[functions.extract-keywords]
+verify_jwt = false
+
+[functions.generate-book-review]
+verify_jwt = false
+
+[functions.structure-notes]
+verify_jwt = false
+
+[functions.reading-insights]
+verify_jwt = false
+
+[functions.recommend-next-books]
+verify_jwt = false
+
+[functions.export-reading-data]
+verify_jwt = false
+
+[functions.send-fcm-push]
 verify_jwt = false
 
 [analytics]

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -368,6 +368,17 @@ deno_version = 2
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 
+# Per-function overrides.
+# verify_jwt=false is required for functions that accept user JWTs signed with
+# the project's asymmetric (ES256) signing key. The platform-level verify_jwt
+# gate does not accept these tokens, so each function below performs its own
+# auth.getUser() check in-code instead.
+[functions.recall-search]
+verify_jwt = false
+
+[functions.generate-embedding]
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/export-reading-data/index.ts
+++ b/supabase/functions/export-reading-data/index.ts
@@ -41,7 +41,9 @@ function formatDate(dateStr: string | null): string {
   if (!dateStr) return "";
   try {
     const date = new Date(dateStr);
-    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+    return `${date.getFullYear()}-${
+      String(date.getMonth() + 1).padStart(2, "0")
+    }-${String(date.getDate()).padStart(2, "0")}`;
   } catch {
     return "";
   }
@@ -94,14 +96,15 @@ function generateCsv(books: BookData[]): string {
   ]);
 
   const bom = "\uFEFF";
-  return bom + [headers.join(","), ...rows.map((row) => row.join(","))].join("\n");
+  return bom +
+    [headers.join(","), ...rows.map((row) => row.join(","))].join("\n");
 }
 
 async function sendEmailWithResend(
   email: string,
   csvContent: string,
   year: number,
-  bookCount: number
+  bookCount: number,
 ): Promise<void> {
   const base64Csv = btoa(unescape(encodeURIComponent(csvContent)));
 
@@ -168,8 +171,26 @@ Deno.serve(async (req: Request) => {
     if (!RESEND_API_KEY) {
       return new Response(
         JSON.stringify({ error: "RESEND_API_KEY not configured" }),
-        { status: 500, headers: { "Content-Type": "application/json" } }
+        { status: 500, headers: { "Content-Type": "application/json" } },
       );
+    }
+
+    const authHeader = req.headers.get("Authorization");
+    const authClient = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+      { global: { headers: { Authorization: authHeader ?? "" } } },
+    );
+    const {
+      data: { user },
+      error: userError,
+    } = await authClient.auth.getUser();
+
+    if (userError || !user) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
     const { userId, email, year }: ExportRequest = await req.json();
@@ -177,7 +198,16 @@ Deno.serve(async (req: Request) => {
     if (!userId || !email) {
       return new Response(
         JSON.stringify({ error: "Missing required fields: userId, email" }),
-        { status: 400, headers: { "Content-Type": "application/json" } }
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    if (
+      userId !== user.id || email.toLowerCase() !== user.email?.toLowerCase()
+    ) {
+      return new Response(
+        JSON.stringify({ error: "Request does not match authenticated user" }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
       );
     }
 
@@ -191,7 +221,7 @@ Deno.serve(async (req: Request) => {
           autoRefreshToken: false,
           persistSession: false,
         },
-      }
+      },
     );
 
     const startOfYear = new Date(targetYear, 0, 1).toISOString();
@@ -215,7 +245,7 @@ Deno.serve(async (req: Request) => {
         start_date,
         updated_at,
         total_pages
-      `
+      `,
       )
       .eq("user_id", userId)
       .is("deleted_at", null)
@@ -243,19 +273,26 @@ Deno.serve(async (req: Request) => {
             acc[memo.book_id] = (acc[memo.book_id] || 0) + 1;
             return acc;
           },
-          {}
+          {},
         );
       }
     }
 
-    const booksWithMemoCount: BookData[] = (books || []).map((book: BookData) => ({
+    const booksWithMemoCount: BookData[] = (books || []).map((
+      book: BookData,
+    ) => ({
       ...book,
       memoCount: memoCounts[book.id] || 0,
     }));
 
     const csvContent = generateCsv(booksWithMemoCount);
 
-    await sendEmailWithResend(email, csvContent, targetYear, booksWithMemoCount.length);
+    await sendEmailWithResend(
+      email,
+      csvContent,
+      targetYear,
+      booksWithMemoCount.length,
+    );
 
     return new Response(
       JSON.stringify({
@@ -269,7 +306,7 @@ Deno.serve(async (req: Request) => {
           "Content-Type": "application/json",
           "Access-Control-Allow-Origin": "*",
         },
-      }
+      },
     );
   } catch (error) {
     console.error("Error:", error);
@@ -281,7 +318,7 @@ Deno.serve(async (req: Request) => {
           "Content-Type": "application/json",
           "Access-Control-Allow-Origin": "*",
         },
-      }
+      },
     );
   }
 });

--- a/supabase/functions/export-reading-data/index.ts
+++ b/supabase/functions/export-reading-data/index.ts
@@ -189,7 +189,10 @@ Deno.serve(async (req: Request) => {
     if (userError || !user) {
       return new Response(JSON.stringify({ error: "Unauthorized" }), {
         status: 401,
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
       });
     }
 
@@ -198,7 +201,13 @@ Deno.serve(async (req: Request) => {
     if (!userId || !email) {
       return new Response(
         JSON.stringify({ error: "Missing required fields: userId, email" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
       );
     }
 
@@ -207,7 +216,13 @@ Deno.serve(async (req: Request) => {
     ) {
       return new Response(
         JSON.stringify({ error: "Request does not match authenticated user" }),
-        { status: 403, headers: { "Content-Type": "application/json" } },
+        {
+          status: 403,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
       );
     }
 

--- a/supabase/functions/generate-embedding/index.ts
+++ b/supabase/functions/generate-embedding/index.ts
@@ -87,7 +87,13 @@ serve(async (req: Request) => {
     if (!userId || !bookId || !contentType || !contentText) {
       return new Response(
         JSON.stringify({ error: "Missing required fields" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
+        {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        },
       );
     }
 

--- a/supabase/functions/generate-embedding/index.ts
+++ b/supabase/functions/generate-embedding/index.ts
@@ -55,6 +55,30 @@ serve(async (req: Request) => {
       );
     }
 
+    // Platform-level verify_jwt is disabled (config.toml) because the project
+    // uses asymmetric (ES256) JWTs which the platform gate does not accept.
+    // Validate the caller's JWT here instead so the service role upsert below
+    // cannot be abused to write rows for arbitrary users.
+    const authHeader = req.headers.get("Authorization");
+    const authClient = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+      { global: { headers: { Authorization: authHeader ?? "" } } }
+    );
+    const {
+      data: { user },
+      error: userError,
+    } = await authClient.auth.getUser();
+    if (userError || !user) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      });
+    }
+
     const {
       userId,
       bookId,
@@ -68,6 +92,19 @@ serve(async (req: Request) => {
       return new Response(
         JSON.stringify({ error: "Missing required fields" }),
         { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    if (userId !== user.id) {
+      return new Response(
+        JSON.stringify({ error: "userId does not match authenticated user" }),
+        {
+          status: 403,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+          },
+        }
       );
     }
 

--- a/supabase/functions/generate-embedding/index.ts
+++ b/supabase/functions/generate-embedding/index.ts
@@ -51,19 +51,15 @@ serve(async (req: Request) => {
     if (!OPENAI_API_KEY) {
       return new Response(
         JSON.stringify({ error: "OPENAI_API_KEY not configured" }),
-        { status: 500, headers: { "Content-Type": "application/json" } }
+        { status: 500, headers: { "Content-Type": "application/json" } },
       );
     }
 
-    // Platform-level verify_jwt is disabled (config.toml) because the project
-    // uses asymmetric (ES256) JWTs which the platform gate does not accept.
-    // Validate the caller's JWT here instead so the service role upsert below
-    // cannot be abused to write rows for arbitrary users.
     const authHeader = req.headers.get("Authorization");
     const authClient = createClient(
       Deno.env.get("SUPABASE_URL") ?? "",
       Deno.env.get("SUPABASE_ANON_KEY") ?? "",
-      { global: { headers: { Authorization: authHeader ?? "" } } }
+      { global: { headers: { Authorization: authHeader ?? "" } } },
     );
     const {
       data: { user },
@@ -91,7 +87,7 @@ serve(async (req: Request) => {
     if (!userId || !bookId || !contentType || !contentText) {
       return new Response(
         JSON.stringify({ error: "Missing required fields" }),
-        { status: 400, headers: { "Content-Type": "application/json" } }
+        { status: 400, headers: { "Content-Type": "application/json" } },
       );
     }
 
@@ -104,7 +100,7 @@ serve(async (req: Request) => {
             "Content-Type": "application/json",
             "Access-Control-Allow-Origin": "*",
           },
-        }
+        },
       );
     }
 
@@ -116,7 +112,7 @@ serve(async (req: Request) => {
           autoRefreshToken: false,
           persistSession: false,
         },
-      }
+      },
     );
 
     const embedding = await generateEmbedding(contentText);
@@ -137,7 +133,7 @@ serve(async (req: Request) => {
         },
         {
           onConflict: "content_type,source_id",
-        }
+        },
       )
       .select("id")
       .single();
@@ -154,11 +150,11 @@ serve(async (req: Request) => {
           "Content-Type": "application/json",
           "Access-Control-Allow-Origin": "*",
         },
-      }
+      },
     );
   } catch (error) {
     console.error("Error:", error);
-    return new Response(JSON.stringify({ error: error.message }), {
+    return new Response(JSON.stringify({ error: (error as Error).message }), {
       status: 500,
       headers: {
         "Content-Type": "application/json",

--- a/supabase/functions/reading-insights/config.ts
+++ b/supabase/functions/reading-insights/config.ts
@@ -6,6 +6,7 @@ export const config = {
   },
   supabase: {
     url: Deno.env.get("SUPABASE_URL") || "",
+    anonKey: Deno.env.get("SUPABASE_ANON_KEY") || "",
     serviceRoleKey: Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "",
   },
   insights: {
@@ -21,7 +22,11 @@ export function validateConfig(): void {
   if (!config.openai.apiKey) {
     throw new Error("OPENAI_API_KEY not configured");
   }
-  if (!config.supabase.url || !config.supabase.serviceRoleKey) {
+  if (
+    !config.supabase.url ||
+    !config.supabase.anonKey ||
+    !config.supabase.serviceRoleKey
+  ) {
     throw new Error("Supabase credentials not configured");
   }
 }

--- a/supabase/functions/reading-insights/index.ts
+++ b/supabase/functions/reading-insights/index.ts
@@ -20,6 +20,24 @@ serve(async (req: Request) => {
   try {
     validateConfig();
 
+    const authHeader = req.headers.get("Authorization");
+    const authClient = createClient(
+      config.supabase.url,
+      config.supabase.anonKey,
+      { global: { headers: { Authorization: authHeader ?? "" } } },
+    );
+    const {
+      data: { user },
+      error: userError,
+    } = await authClient.auth.getUser();
+
+    if (userError || !user) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json", ...corsHeaders },
+      });
+    }
+
     const { userId } = await req.json();
     if (!userId) {
       return new Response(
@@ -27,13 +45,23 @@ serve(async (req: Request) => {
         {
           status: 400,
           headers: { "Content-Type": "application/json", ...corsHeaders },
-        }
+        },
+      );
+    }
+
+    if (userId !== user.id) {
+      return new Response(
+        JSON.stringify({ error: "userId does not match authenticated user" }),
+        {
+          status: 403,
+          headers: { "Content-Type": "application/json", ...corsHeaders },
+        },
       );
     }
 
     const supabase = createClient(
       config.supabase.url,
-      config.supabase.serviceRoleKey
+      config.supabase.serviceRoleKey,
     );
 
     console.log(`[reading-insights] Processing insights for user: ${userId}`);
@@ -42,11 +70,13 @@ serve(async (req: Request) => {
     const insightService = new InsightService(supabase);
 
     const patterns = await patternCollector.collect(userId);
-    console.log(`[reading-insights] Patterns collected: ${JSON.stringify({
-      books: patterns.completionRates.totalStarted,
-      completed: patterns.completionRates.completed,
-      highlights: patterns.highlightStats.totalCount,
-    })}`);
+    console.log(`[reading-insights] Patterns collected: ${
+      JSON.stringify({
+        books: patterns.completionRates.totalStarted,
+        completed: patterns.completionRates.completed,
+        highlights: patterns.highlightStats.totalCount,
+      })
+    }`);
 
     const insights = await insightService.generate(userId, patterns);
     console.log(`[reading-insights] Generated ${insights.length} insights`);
@@ -61,8 +91,9 @@ serve(async (req: Request) => {
       headers: { "Content-Type": "application/json", ...corsHeaders },
     });
   } catch (error: unknown) {
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error";
+    const errorMessage = error instanceof Error
+      ? error.message
+      : "Unknown error";
     console.error("[reading-insights] Error:", errorMessage);
 
     const isRateLimitError = errorMessage.includes("Rate limit exceeded");
@@ -73,7 +104,7 @@ serve(async (req: Request) => {
       {
         status,
         headers: { "Content-Type": "application/json", ...corsHeaders },
-      }
+      },
     );
   }
 });

--- a/supabase/functions/recommend-next-books/config.ts
+++ b/supabase/functions/recommend-next-books/config.ts
@@ -6,6 +6,7 @@ export const config = {
   },
   supabase: {
     url: Deno.env.get("SUPABASE_URL") || "",
+    anonKey: Deno.env.get("SUPABASE_ANON_KEY") || "",
     serviceRoleKey: Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "",
   },
   rag: {
@@ -22,7 +23,11 @@ export function validateConfig(): void {
   if (!config.openai.apiKey) {
     throw new Error("OPENAI_API_KEY not configured");
   }
-  if (!config.supabase.url || !config.supabase.serviceRoleKey) {
+  if (
+    !config.supabase.url ||
+    !config.supabase.anonKey ||
+    !config.supabase.serviceRoleKey
+  ) {
     throw new Error("Supabase credentials not configured");
   }
 }

--- a/supabase/functions/recommend-next-books/index.ts
+++ b/supabase/functions/recommend-next-books/index.ts
@@ -100,16 +100,17 @@ serve(async (req: Request) => {
       },
     };
 
-    try {
-      await supabase.from("book_recommendations").insert({
+    const { error: saveError } = await supabase
+      .from("book_recommendations")
+      .insert({
         user_id: userId,
         recommendations: response.recommendations,
         profile_summary: response.profile,
       });
-    } catch (error) {
+    if (saveError) {
       console.error(
         "[recommend-next-books] Failed to save recommendations:",
-        error,
+        saveError,
       );
     }
 

--- a/supabase/functions/recommend-next-books/index.ts
+++ b/supabase/functions/recommend-next-books/index.ts
@@ -20,23 +20,53 @@ serve(async (req: Request) => {
   try {
     validateConfig();
 
-    const { userId, locale = 'ko' } = await req.json();
+    const authHeader = req.headers.get("Authorization");
+    const authClient = createClient(
+      config.supabase.url,
+      config.supabase.anonKey,
+      { global: { headers: { Authorization: authHeader ?? "" } } },
+    );
+    const {
+      data: { user },
+      error: userError,
+    } = await authClient.auth.getUser();
+
+    if (userError || !user) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json", ...corsHeaders },
+      });
+    }
+
+    const { userId, locale = "ko" } = await req.json();
     if (!userId) {
       return new Response(
         JSON.stringify({ error: "userId is required" }),
         {
           status: 400,
           headers: { "Content-Type": "application/json", ...corsHeaders },
-        }
+        },
+      );
+    }
+
+    if (userId !== user.id) {
+      return new Response(
+        JSON.stringify({ error: "userId does not match authenticated user" }),
+        {
+          status: 403,
+          headers: { "Content-Type": "application/json", ...corsHeaders },
+        },
       );
     }
 
     const supabase = createClient(
       config.supabase.url,
-      config.supabase.serviceRoleKey
+      config.supabase.serviceRoleKey,
     );
 
-    console.log(`[recommend-next-books] Collecting profile for user: ${userId}`);
+    console.log(
+      `[recommend-next-books] Collecting profile for user: ${userId}`,
+    );
     const profileCollector = new ProfileCollector(supabase);
     const profile = await profileCollector.collect(userId);
 
@@ -51,11 +81,13 @@ serve(async (req: Request) => {
         {
           status: 200,
           headers: { "Content-Type": "application/json", ...corsHeaders },
-        }
+        },
       );
     }
 
-    console.log(`[recommend-next-books] Generating recommendations (locale: ${locale})...`);
+    console.log(
+      `[recommend-next-books] Generating recommendations (locale: ${locale})...`,
+    );
     const recommendationService = new RecommendationService(locale);
     const recommendations = await recommendationService.generate(profile);
 
@@ -68,38 +100,34 @@ serve(async (req: Request) => {
       },
     };
 
-    await saveRecommendations(supabase, userId, response);
+    try {
+      await supabase.from("book_recommendations").insert({
+        user_id: userId,
+        recommendations: response.recommendations,
+        profile_summary: response.profile,
+      });
+    } catch (error) {
+      console.error(
+        "[recommend-next-books] Failed to save recommendations:",
+        error,
+      );
+    }
 
     return new Response(JSON.stringify(response), {
       status: 200,
       headers: { "Content-Type": "application/json", ...corsHeaders },
     });
   } catch (error: unknown) {
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error";
+    const errorMessage = error instanceof Error
+      ? error.message
+      : "Unknown error";
     console.error("[recommend-next-books] Error:", errorMessage);
     return new Response(
       JSON.stringify({ error: errorMessage }),
       {
         status: 500,
         headers: { "Content-Type": "application/json", ...corsHeaders },
-      }
+      },
     );
   }
 });
-
-async function saveRecommendations(
-  supabase: ReturnType<typeof createClient>,
-  userId: string,
-  response: RecommendationResponse
-): Promise<void> {
-  try {
-    await supabase.from("book_recommendations").insert({
-      user_id: userId,
-      recommendations: response.recommendations,
-      profile_summary: response.profile,
-    });
-  } catch (error) {
-    console.error("[recommend-next-books] Failed to save recommendations:", error);
-  }
-}

--- a/supabase/functions/send-fcm-push/index.ts
+++ b/supabase/functions/send-fcm-push/index.ts
@@ -27,6 +27,22 @@ interface ServiceAccount {
   token_uri: string;
 }
 
+async function hashSecret(secret: string): Promise<Uint8Array> {
+  return new Uint8Array(
+    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret)),
+  );
+}
+
+function timingSafeEqual(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) return false;
+
+  let difference = 0;
+  for (let index = 0; index < left.length; index++) {
+    difference |= left[index] ^ right[index];
+  }
+  return difference === 0;
+}
+
 // OAuth 2.0 액세스 토큰 캐시
 let cachedAccessToken: string | null = null;
 let tokenExpiry: number = 0;
@@ -196,8 +212,10 @@ serve(async (req) => {
     const authHeader = req.headers.get("Authorization");
     const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
     const bearerToken = authHeader?.replace(/^Bearer\s+/i, "") ?? "";
-    const isServiceRole = serviceRoleKey.length > 0 &&
-      bearerToken === serviceRoleKey;
+    const isServiceRole = serviceRoleKey.length > 0 && timingSafeEqual(
+      await hashSecret(bearerToken),
+      await hashSecret(serviceRoleKey),
+    );
 
     if (!isServiceRole) {
       const authClient = createClient(

--- a/supabase/functions/send-fcm-push/index.ts
+++ b/supabase/functions/send-fcm-push/index.ts
@@ -57,7 +57,7 @@ async function getAccessToken(serviceAccount: ServiceAccount): Promise<string> {
     binaryDer,
     { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
     false,
-    ["sign"]
+    ["sign"],
   );
 
   // JWT 페이로드
@@ -102,9 +102,10 @@ async function sendFCMMessage(
   fcmToken: string,
   title: string,
   body: string,
-  data?: Record<string, string>
+  data?: Record<string, string>,
 ): Promise<any> {
-  const fcmUrl = `https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`;
+  const fcmUrl =
+    `https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`;
 
   const message = {
     message: {
@@ -171,7 +172,7 @@ serve(async (req) => {
         {
           status: 500,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -185,12 +186,44 @@ serve(async (req) => {
         {
           status: 500,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
     // 요청 본문 파싱
     const { userId, token, title, body, data }: FCMRequest = await req.json();
+
+    const authHeader = req.headers.get("Authorization");
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+    const bearerToken = authHeader?.replace(/^Bearer\s+/i, "") ?? "";
+    const isServiceRole = serviceRoleKey.length > 0 &&
+      bearerToken === serviceRoleKey;
+
+    if (!isServiceRole) {
+      const authClient = createClient(
+        Deno.env.get("SUPABASE_URL") ?? "",
+        Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+        { global: { headers: { Authorization: authHeader ?? "" } } },
+      );
+      const {
+        data: { user },
+        error: userError,
+      } = await authClient.auth.getUser();
+
+      if (userError || !user) {
+        return new Response(JSON.stringify({ error: "Unauthorized" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      if (!userId || userId !== user.id || token) {
+        return new Response(JSON.stringify({ error: "Forbidden" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
 
     // Supabase 클라이언트 생성
     const supabaseClient = createClient(
@@ -201,7 +234,7 @@ serve(async (req) => {
           autoRefreshToken: false,
           persistSession: false,
         },
-      }
+      },
     );
 
     let tokens: string[] = [];
@@ -223,7 +256,7 @@ serve(async (req) => {
           {
             status: 500,
             headers: { "Content-Type": "application/json" },
-          }
+          },
         );
       }
 
@@ -236,7 +269,7 @@ serve(async (req) => {
         {
           status: 400,
           headers: { "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -259,9 +292,9 @@ serve(async (req) => {
           fcmToken,
           title,
           body,
-          data
+          data,
         )
-      )
+      ),
     );
 
     // 결과 집계
@@ -304,11 +337,11 @@ serve(async (req) => {
           "Content-Type": "application/json",
           "Access-Control-Allow-Origin": "*",
         },
-      }
+      },
     );
   } catch (error) {
     console.error("Error:", error);
-    return new Response(JSON.stringify({ error: error.message }), {
+    return new Response(JSON.stringify({ error: (error as Error).message }), {
       status: 500,
       headers: {
         "Content-Type": "application/json",
@@ -317,11 +350,3 @@ serve(async (req) => {
     });
   }
 });
-
-
-
-
-
-
-
-

--- a/supabase/functions/structure-notes/index.ts
+++ b/supabase/functions/structure-notes/index.ts
@@ -45,8 +45,9 @@ serve(async (req: Request) => {
     } = await supabaseClient.auth.getUser();
 
     if (userError || !user) {
+      console.error("Authentication failed:", userError);
       return new Response(
-        JSON.stringify({ error: "Unauthorized", details: userError?.message }),
+        JSON.stringify({ error: "Unauthorized" }),
         {
           status: 401,
           headers: { "Content-Type": "application/json" },
@@ -56,7 +57,7 @@ serve(async (req: Request) => {
 
     const { bookId }: StructureRequest = await req.json();
 
-    if (!bookId) {
+    if (typeof bookId !== "string" || bookId.trim().length === 0) {
       return new Response(
         JSON.stringify({ error: "Missing required field: bookId" }),
         { status: 400, headers: { "Content-Type": "application/json" } },

--- a/supabase/functions/structure-notes/index.ts
+++ b/supabase/functions/structure-notes/index.ts
@@ -28,20 +28,15 @@ serve(async (req: Request) => {
     if (!OPENAI_API_KEY) {
       return new Response(
         JSON.stringify({ error: "OPENAI_API_KEY not configured" }),
-        { status: 500, headers: { "Content-Type": "application/json" } }
+        { status: 500, headers: { "Content-Type": "application/json" } },
       );
     }
 
     const authHeader = req.headers.get("Authorization");
-    console.log("🔑 Auth header present:", !!authHeader);
-    console.log("🔑 Auth header (first 30):", authHeader?.substring(0, 30));
-    console.log("🌐 SUPABASE_URL:", Deno.env.get("SUPABASE_URL"));
-    console.log("🔐 SUPABASE_ANON_KEY present:", !!Deno.env.get("SUPABASE_ANON_KEY"));
-    
     const supabaseClient = createClient(
       Deno.env.get("SUPABASE_URL") ?? "",
       Deno.env.get("SUPABASE_ANON_KEY") ?? "",
-      { global: { headers: { Authorization: authHeader ?? "" } } }
+      { global: { headers: { Authorization: authHeader ?? "" } } },
     );
 
     const {
@@ -49,14 +44,14 @@ serve(async (req: Request) => {
       error: userError,
     } = await supabaseClient.auth.getUser();
 
-    console.log("👤 User from getUser():", user?.id);
-    console.log("❌ User error:", userError?.message);
-
     if (userError || !user) {
-      return new Response(JSON.stringify({ error: "Unauthorized", details: userError?.message }), {
-        status: 401,
-        headers: { "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ error: "Unauthorized", details: userError?.message }),
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     const { bookId }: StructureRequest = await req.json();
@@ -64,7 +59,7 @@ serve(async (req: Request) => {
     if (!bookId) {
       return new Response(
         JSON.stringify({ error: "Missing required field: bookId" }),
-        { status: 400, headers: { "Content-Type": "application/json" } }
+        { status: 400, headers: { "Content-Type": "application/json" } },
       );
     }
 
@@ -76,7 +71,7 @@ serve(async (req: Request) => {
           autoRefreshToken: false,
           persistSession: false,
         },
-      }
+      },
     );
 
     const { data: contents, error: fetchError } = await serviceClient
@@ -104,7 +99,7 @@ serve(async (req: Request) => {
             "Content-Type": "application/json",
             "Access-Control-Allow-Origin": "*",
           },
-        }
+        },
       );
     }
 
@@ -125,7 +120,7 @@ serve(async (req: Request) => {
         },
         {
           onConflict: "user_id,book_id",
-        }
+        },
       );
 
     if (upsertError) {
@@ -150,7 +145,7 @@ serve(async (req: Request) => {
           "Content-Type": "application/json",
           "Access-Control-Allow-Origin": "*",
         },
-      }
+      },
     );
   }
 });


### PR DESCRIPTION
독서 기록 검색을 포함한 사용자 호출 Edge Function이 ES256 JWT 환경에서 정상적으로 인증되도록 수정했습니다.

## 📋 Changes

- 사용자 호출 Edge Function의 플랫폼 JWT 검증을 함수 내부 검증 방식으로 전환
- `reading-insights`, `recommend-next-books`, `export-reading-data`, `send-fcm-push`에 사용자 소유권 검증 추가
- `generate-embedding`의 service role 쓰기 경로에 호출자 검증 적용
- JWT 일부를 출력하던 디버그 로그 제거

## 🧠 Context & Background

- Supabase JWT Signing Keys가 ES256으로 전환된 뒤 플랫폼 `verify_jwt` 단계에서 정상 사용자 토큰이 거부되었습니다.
- service role을 사용하는 함수는 플랫폼 검증을 끈 뒤에도 함수 내부에서 사용자와 요청 데이터의 소유권을 확인해야 합니다.

## ✅ How to Test

1. Deno type check로 변경된 Edge Function의 타입을 검증
2. dev 배포 후 로그인 사용자의 AI Recall, 임베딩, 독서 인사이트, 추천 기능 호출 확인
3. 다른 `userId`로 요청할 때 403 응답 확인

## 🧾 Screenshots or Videos (Optional)

- 해당 없음

## 🔗 Related Issues

- BOK-374

## 🙌 Additional Notes (Optional)

- Production 배포는 `dev → main` 병합 후 CI를 통해서만 진행합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Access**
  * Added stronger authentication and ownership checks across reading, recommendation, embedding, export, notes, and notification services.
  * Improved handling of unauthorized, invalid, and mismatched requests with clearer error responses.

* **New Features**
  * Push notifications can now include additional data payloads.
  * Recommendation results continue saving without blocking successful responses if persistence fails.

* **Reliability**
  * Added configuration checks for required service credentials and API keys.
  * Improved timeout and error handling for note structuring and related services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->