### PR TITLE
fix: secure RevenueCat webhook delivery

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -41,6 +41,20 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
+      - name: Configure RevenueCat Webhook Secret
+        run: |
+          if [ "${{ inputs.target }}" = "prod" ]; then
+            REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY_PROD"
+          else
+            REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY_DEV"
+          fi
+          test -n "$REVENUECAT_WEBHOOK_AUTH_KEY"
+          supabase secrets set REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          REVENUECAT_WEBHOOK_AUTH_KEY_DEV: ${{ secrets.REVENUECAT_WEBHOOK_AUTH_KEY_DEV }}
+          REVENUECAT_WEBHOOK_AUTH_KEY_PROD: ${{ secrets.REVENUECAT_WEBHOOK_AUTH_KEY_PROD }}
+
       - name: Deploy Edge Functions
         run: |
           TARGET="${{ inputs.target }}"

--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -38,6 +38,14 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
+      - name: Configure RevenueCat Webhook Secret
+        run: |
+          test -n "$REVENUECAT_WEBHOOK_AUTH_KEY"
+          supabase secrets set REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          REVENUECAT_WEBHOOK_AUTH_KEY: ${{ secrets.REVENUECAT_WEBHOOK_AUTH_KEY_PROD }}
+
       - name: Apply Migrations
         run: |
           echo "Applying migrations to Production database..."

--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -55,7 +55,6 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - name: Deploy Edge Functions (Production)
-        if: always()
         run: |
           echo "Deploying Edge Functions to Production..."
           for fn in supabase/functions/*/; do

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -36,6 +36,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - name: Configure RevenueCat Webhook Secret
+        id: revenuecat-secret
         run: |
           test -n "$REVENUECAT_WEBHOOK_AUTH_KEY"
           supabase secrets set REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY"
@@ -58,7 +59,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - name: Deploy Edge Functions (Dev)
-        if: always()
+        if: ${{ !cancelled() && steps.revenuecat-secret.outcome == 'success' }}
         run: |
           echo "Deploying Edge Functions to Dev..."
           for fn in supabase/functions/*/; do

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -35,6 +35,14 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
+      - name: Configure RevenueCat Webhook Secret
+        run: |
+          test -n "$REVENUECAT_WEBHOOK_AUTH_KEY"
+          supabase secrets set REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          REVENUECAT_WEBHOOK_AUTH_KEY: ${{ secrets.REVENUECAT_WEBHOOK_AUTH_KEY_DEV }}
+
       - name: Repair migration history (orphan remote migrations)
         run: |
           echo "Marking orphan remote migrations as reverted (idempotent)..."

--- a/docs/guides/app-store-connect-iap-setup.md
+++ b/docs/guides/app-store-connect-iap-setup.md
@@ -72,9 +72,10 @@ RevenueCat의 Integrations → Webhooks에 환경별 구성을 추가합니다.
 - [ ] 두 상품을 제출할 앱 버전에 연결
 - [ ] RevenueCat IAP Key 검증 완료
 - [ ] RevenueCat App Store Connect API Key 검증 완료
-- [ ] Entitlement `byungskerslab/북골라스 Pro` 연결 확인
-- [ ] Default offering의 두 패키지 확인
-- [ ] Development·Production webhook 구성 및 테스트 성공
+- [x] Entitlement `byungskerslab/북골라스 Pro` 연결 확인
+- [x] Default offering의 두 패키지 확인
+- [x] Development·Production webhook 구성
+- [ ] Development·Production webhook 테스트 성공
 - [ ] Sandbox 월간·연간 구매, 복원, 만료 테스트 성공
 
 최종 확인일: 2026-07-23

--- a/docs/guides/release-readiness.md
+++ b/docs/guides/release-readiness.md
@@ -2,13 +2,13 @@
 
 ## 자동 검증
 
-- [ ] Flutter localization 생성 성공
-- [ ] Flutter analyze 성공
-- [ ] Flutter 전체 테스트 성공
-- [ ] Web lint 성공
-- [ ] Web production build 성공
-- [ ] Edge Function type check 성공
-- [ ] TestFlight 업로드 성공
+- [x] Flutter localization 생성 성공
+- [x] Flutter analyze 성공
+- [x] Flutter 전체 테스트 성공
+- [x] Web lint 성공
+- [x] Web production build 성공
+- [x] Edge Function type check 성공
+- [x] TestFlight 업로드 성공
 - [ ] Production App Store Connect 업로드 성공
 
 ## GitHub Actions 비밀값
@@ -22,6 +22,8 @@
 - [x] App Store Connect API key 3종
 - [x] Production·Development Supabase URL/key/project ref
 - [x] RevenueCat public key
+- [x] `REVENUECAT_WEBHOOK_AUTH_KEY_DEV`
+- [x] `REVENUECAT_WEBHOOK_AUTH_KEY_PROD`
 
 `PROVISIONING_PROFILE_WIDGET_BASE64`가 없으면 운영 IPA의 Widget Extension을 수동
 서명할 수 없어 Production workflow가 실패합니다.
@@ -36,7 +38,8 @@
 - [ ] RevenueCat 이메일 인증
 - [ ] RevenueCat IAP key 검증 완료
 - [ ] RevenueCat App Store Connect API key 등록·검증 완료
-- [ ] RevenueCat Development·Production webhook 구성
+- [x] RevenueCat Development·Production webhook 구성
+- [x] App Store Connect Production·Sandbox 서버 알림 URL 구성
 - [ ] Sandbox 구매·복원·갱신·취소·만료 검증
 - [ ] 심사용 계정 로그인 및 Pro 권한 검증
 

--- a/docs/guides/webhook-deployment.md
+++ b/docs/guides/webhook-deployment.md
@@ -17,9 +17,11 @@
 | Development | `reoiqefoymdsqzpbouxi` | `https://reoiqefoymdsqzpbouxi.supabase.co/functions/v1/revenuecat-webhook` |
 | Production | `enyxrgxixrnoazzgqyyd` | `https://enyxrgxixrnoazzgqyyd.supabase.co/functions/v1/revenuecat-webhook` |
 
-각 Supabase 프로젝트에는 서로 다른 `REVENUECAT_WEBHOOK_AUTH_KEY`를 저장합니다.
-RevenueCat Webhook의 Authorization header는 `Bearer <해당 환경 키>` 형식으로
-일치해야 합니다. 키를 저장소, 문서, 로그에 남기지 않습니다.
+GitHub에는 `REVENUECAT_WEBHOOK_AUTH_KEY_DEV`와
+`REVENUECAT_WEBHOOK_AUTH_KEY_PROD`를 서로 다른 값으로 저장합니다. 배포 workflow가
+대상 Supabase 프로젝트의 `REVENUECAT_WEBHOOK_AUTH_KEY`로 주입합니다. RevenueCat
+Webhook의 Authorization header는 `Bearer <해당 환경 키>` 형식으로 일치해야
+합니다. 키를 저장소, 문서, 로그에 남기지 않습니다.
 
 ## RevenueCat 설정
 

--- a/supabase/functions/revenuecat-webhook/index.ts
+++ b/supabase/functions/revenuecat-webhook/index.ts
@@ -87,11 +87,16 @@ serve(async (req: Request) => {
   }
 
   try {
+    if (!REVENUECAT_WEBHOOK_AUTH_KEY) {
+      console.error("RevenueCat webhook authentication is not configured");
+      return new Response(
+        JSON.stringify({ error: "Webhook authentication is unavailable" }),
+        { status: 503, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
     const authHeader = req.headers.get("authorization");
-    if (
-      REVENUECAT_WEBHOOK_AUTH_KEY &&
-      authHeader !== `Bearer ${REVENUECAT_WEBHOOK_AUTH_KEY}`
-    ) {
+    if (authHeader !== `Bearer ${REVENUECAT_WEBHOOK_AUTH_KEY}`) {
       console.error("Unauthorized webhook request");
       return new Response(
         JSON.stringify({ error: "Unauthorized" }),


### PR DESCRIPTION
RevenueCat 웹훅의 환경별 인증 키를 배포 파이프라인에서 안전하게 주입하고 미설정 시 요청을 차단합니다.

## 📋 Changes

- Dev·Production용 RevenueCat 웹훅 인증 키를 GitHub Secrets로 분리
- TestFlight·Production·수동 Edge Function 배포 전에 대상 Supabase secret으로 주입
- `revenuecat-webhook` 인증 키 누락 시 HTTP 503으로 fail-closed 처리
- App Store 서버 알림과 RevenueCat webhook 구성 상태를 출시 문서에 반영

## 🧠 Context & Background

기존 함수는 `REVENUECAT_WEBHOOK_AUTH_KEY`가 없으면 인증 검사를 건너뛰었습니다. 출시 전에 인증 키 배포를 자동화하고, 누락 상태에서 웹훅 요청이 허용되지 않도록 보강했습니다.

## ✅ How to Test

1. `deno fmt --check supabase/functions/revenuecat-webhook/index.ts`
2. `deno check supabase/functions/revenuecat-webhook/index.ts`
3. GitHub workflow YAML 파싱 확인
4. `daily → dev` 병합 후 dev Supabase secret·Edge Function 배포 성공 확인
5. RevenueCat Development 테스트 이벤트가 HTTP 200을 반환하는지 확인

## 🧾 Screenshots or Videos (Optional)

- RevenueCat Development·Production webhook 모두 Active
- App Store Connect Production·Sandbox 서버 알림 URL 구성 완료

## 🔗 Related Issues

- #234

## 🙌 Additional Notes (Optional)

- Production secret은 `main` 배포 workflow에서만 운영 Supabase에 주입됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RevenueCat webhooks now require a configured environment-specific authorization key.
  * Requests with missing or incorrect authorization are rejected consistently, improving webhook security.
  * The service reports a clear unavailable status when webhook authentication is not configured.

* **Documentation**
  * Updated deployment guidance for managing development and production webhook keys.
  * Refined release checklists to reflect completed webhook, build, testing, and external-console configuration tasks.

* **Chores**
  * Deployment workflows now automatically configure the appropriate webhook authorization key for each environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->