### PR TITLE
chore: deploy authenticated RevenueCat webhooks

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -41,6 +41,20 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
+      - name: Configure RevenueCat Webhook Secret
+        run: |
+          if [ "${{ inputs.target }}" = "prod" ]; then
+            REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY_PROD"
+          else
+            REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY_DEV"
+          fi
+          test -n "$REVENUECAT_WEBHOOK_AUTH_KEY"
+          supabase secrets set REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          REVENUECAT_WEBHOOK_AUTH_KEY_DEV: ${{ secrets.REVENUECAT_WEBHOOK_AUTH_KEY_DEV }}
+          REVENUECAT_WEBHOOK_AUTH_KEY_PROD: ${{ secrets.REVENUECAT_WEBHOOK_AUTH_KEY_PROD }}
+
       - name: Deploy Edge Functions
         run: |
           TARGET="${{ inputs.target }}"

--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -38,6 +38,14 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
+      - name: Configure RevenueCat Webhook Secret
+        run: |
+          test -n "$REVENUECAT_WEBHOOK_AUTH_KEY"
+          supabase secrets set REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          REVENUECAT_WEBHOOK_AUTH_KEY: ${{ secrets.REVENUECAT_WEBHOOK_AUTH_KEY_PROD }}
+
       - name: Apply Migrations
         run: |
           echo "Applying migrations to Production database..."

--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -55,7 +55,6 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - name: Deploy Edge Functions (Production)
-        if: always()
         run: |
           echo "Deploying Edge Functions to Production..."
           for fn in supabase/functions/*/; do

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -36,6 +36,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - name: Configure RevenueCat Webhook Secret
+        id: revenuecat-secret
         run: |
           test -n "$REVENUECAT_WEBHOOK_AUTH_KEY"
           supabase secrets set REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY"
@@ -58,7 +59,7 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - name: Deploy Edge Functions (Dev)
-        if: always()
+        if: ${{ !cancelled() && steps.revenuecat-secret.outcome == 'success' }}
         run: |
           echo "Deploying Edge Functions to Dev..."
           for fn in supabase/functions/*/; do

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -35,6 +35,14 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
+      - name: Configure RevenueCat Webhook Secret
+        run: |
+          test -n "$REVENUECAT_WEBHOOK_AUTH_KEY"
+          supabase secrets set REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          REVENUECAT_WEBHOOK_AUTH_KEY: ${{ secrets.REVENUECAT_WEBHOOK_AUTH_KEY_DEV }}
+
       - name: Repair migration history (orphan remote migrations)
         run: |
           echo "Marking orphan remote migrations as reverted (idempotent)..."

--- a/docs/guides/app-store-connect-iap-setup.md
+++ b/docs/guides/app-store-connect-iap-setup.md
@@ -72,9 +72,10 @@ RevenueCat의 Integrations → Webhooks에 환경별 구성을 추가합니다.
 - [ ] 두 상품을 제출할 앱 버전에 연결
 - [ ] RevenueCat IAP Key 검증 완료
 - [ ] RevenueCat App Store Connect API Key 검증 완료
-- [ ] Entitlement `byungskerslab/북골라스 Pro` 연결 확인
-- [ ] Default offering의 두 패키지 확인
-- [ ] Development·Production webhook 구성 및 테스트 성공
+- [x] Entitlement `byungskerslab/북골라스 Pro` 연결 확인
+- [x] Default offering의 두 패키지 확인
+- [x] Development·Production webhook 구성
+- [ ] Development·Production webhook 테스트 성공
 - [ ] Sandbox 월간·연간 구매, 복원, 만료 테스트 성공
 
 최종 확인일: 2026-07-23

--- a/docs/guides/release-readiness.md
+++ b/docs/guides/release-readiness.md
@@ -2,13 +2,13 @@
 
 ## 자동 검증
 
-- [ ] Flutter localization 생성 성공
-- [ ] Flutter analyze 성공
-- [ ] Flutter 전체 테스트 성공
-- [ ] Web lint 성공
-- [ ] Web production build 성공
-- [ ] Edge Function type check 성공
-- [ ] TestFlight 업로드 성공
+- [x] Flutter localization 생성 성공
+- [x] Flutter analyze 성공
+- [x] Flutter 전체 테스트 성공
+- [x] Web lint 성공
+- [x] Web production build 성공
+- [x] Edge Function type check 성공
+- [x] TestFlight 업로드 성공
 - [ ] Production App Store Connect 업로드 성공
 
 ## GitHub Actions 비밀값
@@ -22,6 +22,8 @@
 - [x] App Store Connect API key 3종
 - [x] Production·Development Supabase URL/key/project ref
 - [x] RevenueCat public key
+- [x] `REVENUECAT_WEBHOOK_AUTH_KEY_DEV`
+- [x] `REVENUECAT_WEBHOOK_AUTH_KEY_PROD`
 
 `PROVISIONING_PROFILE_WIDGET_BASE64`가 없으면 운영 IPA의 Widget Extension을 수동
 서명할 수 없어 Production workflow가 실패합니다.
@@ -36,7 +38,8 @@
 - [ ] RevenueCat 이메일 인증
 - [ ] RevenueCat IAP key 검증 완료
 - [ ] RevenueCat App Store Connect API key 등록·검증 완료
-- [ ] RevenueCat Development·Production webhook 구성
+- [x] RevenueCat Development·Production webhook 구성
+- [x] App Store Connect Production·Sandbox 서버 알림 URL 구성
 - [ ] Sandbox 구매·복원·갱신·취소·만료 검증
 - [ ] 심사용 계정 로그인 및 Pro 권한 검증
 

--- a/docs/guides/webhook-deployment.md
+++ b/docs/guides/webhook-deployment.md
@@ -17,9 +17,11 @@
 | Development | `reoiqefoymdsqzpbouxi` | `https://reoiqefoymdsqzpbouxi.supabase.co/functions/v1/revenuecat-webhook` |
 | Production | `enyxrgxixrnoazzgqyyd` | `https://enyxrgxixrnoazzgqyyd.supabase.co/functions/v1/revenuecat-webhook` |
 
-각 Supabase 프로젝트에는 서로 다른 `REVENUECAT_WEBHOOK_AUTH_KEY`를 저장합니다.
-RevenueCat Webhook의 Authorization header는 `Bearer <해당 환경 키>` 형식으로
-일치해야 합니다. 키를 저장소, 문서, 로그에 남기지 않습니다.
+GitHub에는 `REVENUECAT_WEBHOOK_AUTH_KEY_DEV`와
+`REVENUECAT_WEBHOOK_AUTH_KEY_PROD`를 서로 다른 값으로 저장합니다. 배포 workflow가
+대상 Supabase 프로젝트의 `REVENUECAT_WEBHOOK_AUTH_KEY`로 주입합니다. RevenueCat
+Webhook의 Authorization header는 `Bearer <해당 환경 키>` 형식으로 일치해야
+합니다. 키를 저장소, 문서, 로그에 남기지 않습니다.
 
 ## RevenueCat 설정
 

--- a/supabase/functions/revenuecat-webhook/index.ts
+++ b/supabase/functions/revenuecat-webhook/index.ts
@@ -87,11 +87,16 @@ serve(async (req: Request) => {
   }
 
   try {
+    if (!REVENUECAT_WEBHOOK_AUTH_KEY) {
+      console.error("RevenueCat webhook authentication is not configured");
+      return new Response(
+        JSON.stringify({ error: "Webhook authentication is unavailable" }),
+        { status: 503, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
     const authHeader = req.headers.get("authorization");
-    if (
-      REVENUECAT_WEBHOOK_AUTH_KEY &&
-      authHeader !== `Bearer ${REVENUECAT_WEBHOOK_AUTH_KEY}`
-    ) {
+    if (authHeader !== `Bearer ${REVENUECAT_WEBHOOK_AUTH_KEY}`) {
       console.error("Unauthorized webhook request");
       return new Response(
         JSON.stringify({ error: "Unauthorized" }),


### PR DESCRIPTION
RevenueCat 웹훅 인증 및 알림 구성을 개발 환경에 배포합니다.

## 📋 Changes

- Dev·Production RevenueCat 웹훅 인증 키 GitHub Secrets 등록
- 대상 Supabase에 인증 키를 먼저 주입하도록 배포 workflow 보강
- 인증 키 누락 시 `revenuecat-webhook` 요청을 503으로 차단
- 인증 키 주입 실패 시 Edge Function 배포도 차단
- App Store Connect Production·Sandbox 서버 알림 URL 및 RevenueCat 양 환경 webhook 구성

## 🧠 Context & Background

구독 상태 동기화를 출시 전에 종단 간 검증하려면 RevenueCat → Supabase 웹훅이 인증된 상태로 배포되어야 합니다. 이 병합으로 dev Supabase에 새 secret과 함수가 배포됩니다.

## ✅ How to Test

1. Dev migration job에서 RevenueCat secret 설정 성공 확인
2. 15개 Edge Function 배포 성공 확인
3. RevenueCat Development 테스트 이벤트 HTTP 200 확인
4. `subscription_events` 및 사용자 구독 상태 갱신 확인
5. TestFlight 1.0.1 빌드 업로드 성공 확인

## 🧾 Screenshots or Videos (Optional)

- RevenueCat Development·Production webhook 모두 Active

## 🔗 Related Issues

- #234
- #254

## 🙌 Additional Notes (Optional)

- Sandbox 결제 검증 완료 전에는 `dev → main` PR을 병합하지 않습니다.
