### PR TITLE
fix: allow authenticated RevenueCat webhook requests

### DIFF
--- a/docs/guides/webhook-deployment.md
+++ b/docs/guides/webhook-deployment.md
@@ -23,6 +23,10 @@ GitHub에는 `REVENUECAT_WEBHOOK_AUTH_KEY_DEV`와
 Webhook의 Authorization header는 `Bearer <해당 환경 키>` 형식으로 일치해야
 합니다. 키를 저장소, 문서, 로그에 남기지 않습니다.
 
+`revenuecat-webhook`은 Supabase gateway JWT 검증을 비활성화하고 함수 내부에서
+전용 webhook key를 검증합니다. RevenueCat Authorization 값을 Supabase JWT로
+해석하면 함수 실행 전 401이 발생하므로 `verify_jwt = false`를 유지해야 합니다.
+
 ## RevenueCat 설정
 
 1. Integrations → Webhooks → Add new configuration을 엽니다.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -407,6 +407,9 @@ verify_jwt = false
 [functions.log-push-click]
 verify_jwt = false
 
+[functions.revenuecat-webhook]
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327


### PR DESCRIPTION
RevenueCat의 전용 Authorization header가 Supabase JWT gateway에서 차단되지 않도록 웹훅 배포 설정을 수정합니다.

## 📋 Changes

- `revenuecat-webhook`의 Supabase gateway `verify_jwt` 비활성화
- 함수 내부 `REVENUECAT_WEBHOOK_AUTH_KEY` 검증을 유일한 인증 경계로 유지
- gateway 인증과 webhook 전용 인증의 역할을 배포 가이드에 문서화

## 🧠 Context & Background

RevenueCat 테스트 이벤트가 함수 실행 전에 HTTP 401로 거부됐습니다. RevenueCat의 Bearer 값은 Supabase JWT가 아니므로 gateway 검증을 끄고, 이미 fail-closed로 구현된 함수 내부 전용 키 검증을 사용해야 합니다.

## ✅ How to Test

1. Edge Function type check 통과
2. Dev에 재배포 후 RevenueCat Development 테스트 이벤트 전송
3. 응답 HTTP 200 확인
4. 잘못된 Authorization header가 HTTP 401을 반환하는지 확인

## 🧾 Screenshots or Videos (Optional)

- 기존 종단 간 테스트 응답: HTTP 401

## 🔗 Related Issues

- #234
- #254
- #255

## 🙌 Additional Notes (Optional)

- JWT gateway만 비활성화하며 webhook 인증 자체는 함수 내부에서 필수로 유지됩니다.
