### PR TITLE
fix: allow RevenueCat webhook gateway requests

### DIFF
--- a/docs/guides/webhook-deployment.md
+++ b/docs/guides/webhook-deployment.md
@@ -23,6 +23,10 @@ GitHub에는 `REVENUECAT_WEBHOOK_AUTH_KEY_DEV`와
 Webhook의 Authorization header는 `Bearer <해당 환경 키>` 형식으로 일치해야
 합니다. 키를 저장소, 문서, 로그에 남기지 않습니다.
 
+`revenuecat-webhook`은 Supabase gateway JWT 검증을 비활성화하고 함수 내부에서
+전용 webhook key를 검증합니다. RevenueCat Authorization 값을 Supabase JWT로
+해석하면 함수 실행 전 401이 발생하므로 `verify_jwt = false`를 유지해야 합니다.
+
 ## RevenueCat 설정
 
 1. Integrations → Webhooks → Add new configuration을 엽니다.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -407,6 +407,9 @@ verify_jwt = false
 [functions.log-push-click]
 verify_jwt = false
 
+[functions.revenuecat-webhook]
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327


### PR DESCRIPTION
RevenueCat 테스트 이벤트가 Supabase JWT gateway에서 차단되는 문제를 수정합니다.

## 📋 Changes

- `revenuecat-webhook`의 Supabase gateway JWT 검증 비활성화
- 함수 내부 전용 webhook key 검증 유지
- RevenueCat Authorization 처리 방식을 배포 가이드에 명시

## 🧠 Context & Background

인증 secret과 함수 배포는 성공했지만 RevenueCat 테스트 요청은 함수 실행 전 HTTP 401을 반환했습니다. RevenueCat Bearer 값은 Supabase JWT가 아니므로 gateway 검증을 끄고 함수 내부 키 검증을 사용합니다.

## ✅ How to Test

1. Dev Edge Function 재배포 성공 확인
2. RevenueCat Development 테스트 이벤트 재전송
3. HTTP 200 응답 확인
4. 웹훅 이벤트 처리 로그 확인

## 🧾 Screenshots or Videos (Optional)

- 수정 전 응답: HTTP 401

## 🔗 Related Issues

- #234
- #254
- #255
- #256

## 🙌 Additional Notes (Optional)

- Sandbox 구매 검증 완료 전에는 `dev → main` PR을 병합하지 않습니다.
