### PR TITLE
fix: accept authenticated RevenueCat test events

### DIFF
--- a/docs/guides/webhook-deployment.md
+++ b/docs/guides/webhook-deployment.md
@@ -56,6 +56,7 @@ where revenuecat_user_id is not null;
 검증 기준:
 
 - RevenueCat 테스트 전송이 HTTP 200을 반환합니다.
+- 인증된 RevenueCat `TEST` 이벤트는 사용자 데이터를 변경하지 않고 HTTP 200을 반환합니다.
 - 동일 이벤트 재전송이 중복 데이터나 잘못된 상태 전이를 만들지 않습니다.
 - `monthly`는 `pro_monthly`, `yearly`는 `pro_yearly`로 반영됩니다.
 - 만료·환불은 `free`, 취소·결제 문제는 만료일 유지로 반영됩니다.

--- a/supabase/functions/revenuecat-webhook/index.ts
+++ b/supabase/functions/revenuecat-webhook/index.ts
@@ -118,6 +118,13 @@ serve(async (req: Request) => {
       );
     }
 
+    if (event.type === "TEST") {
+      return new Response(
+        JSON.stringify({ success: true, event_type: event.type }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
     const supabaseClient = createClient(
       Deno.env.get("SUPABASE_URL") ?? "",
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",


### PR DESCRIPTION
RevenueCat의 공식 테스트 이벤트를 인증 후 데이터 변경 없이 성공 응답합니다.

## 📋 Changes

- 인증된 `TEST` 이벤트에 HTTP 200 반환
- 임의 테스트 사용자를 DB에서 조회하거나 구독 상태를 변경하지 않음
- 웹훅 연결 검증 동작을 배포 가이드에 문서화

## 🧠 Context & Background

JWT gateway 수정 후 요청은 함수까지 도달했지만 RevenueCat 테스트 이벤트의 임의 사용자 때문에 404가 발생했습니다. 실제 구매 이벤트와 분리해 공식 연결 테스트만 성공 처리합니다.

## ✅ How to Test

1. Deno format 및 type check 통과
2. Dev 재배포 후 RevenueCat Development 테스트 이벤트 전송
3. 응답 HTTP 200 확인
4. 사용자 및 `subscription_events` 데이터가 테스트 이벤트로 변경되지 않는지 확인

## 🧾 Screenshots or Videos (Optional)

- 이전 응답 흐름: 401 → gateway 수정 후 404

## 🔗 Related Issues

- #234
- #254
- #256
- #257

## 🙌 Additional Notes (Optional)

- 월간·연간 Sandbox 실제 구매 이벤트는 기존 처리 경로를 그대로 사용합니다.
