### PR TITLE
fix: deploy RevenueCat test event handling

### DIFF
--- a/docs/guides/webhook-deployment.md
+++ b/docs/guides/webhook-deployment.md
@@ -56,6 +56,7 @@ where revenuecat_user_id is not null;
 검증 기준:
 
 - RevenueCat 테스트 전송이 HTTP 200을 반환합니다.
+- 인증된 RevenueCat `TEST` 이벤트는 사용자 데이터를 변경하지 않고 HTTP 200을 반환합니다.
 - 동일 이벤트 재전송이 중복 데이터나 잘못된 상태 전이를 만들지 않습니다.
 - `monthly`는 `pro_monthly`, `yearly`는 `pro_yearly`로 반영됩니다.
 - 만료·환불은 `free`, 취소·결제 문제는 만료일 유지로 반영됩니다.

--- a/supabase/functions/revenuecat-webhook/index.ts
+++ b/supabase/functions/revenuecat-webhook/index.ts
@@ -118,6 +118,13 @@ serve(async (req: Request) => {
       );
     }
 
+    if (event.type === "TEST") {
+      return new Response(
+        JSON.stringify({ success: true, event_type: event.type }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
     const supabaseClient = createClient(
       Deno.env.get("SUPABASE_URL") ?? "",
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",


### PR DESCRIPTION
RevenueCat 공식 테스트 이벤트가 연결 검증용으로 HTTP 200을 반환하도록 개발 환경에 배포합니다.

## 📋 Changes

- 인증된 `TEST` 이벤트를 데이터 변경 없이 성공 처리
- 실제 월간·연간 구독 이벤트 처리 경로 유지
- 웹훅 연결 검증 기준 문서화

## 🧠 Context & Background

gateway와 인증을 통과한 RevenueCat 테스트 이벤트가 임의 사용자 때문에 404를 반환했습니다. 테스트 전용 이벤트를 명시적으로 처리해 종단 간 연결 상태를 검증합니다.

## ✅ How to Test

1. Dev Edge Function 재배포 성공 확인
2. RevenueCat Development 테스트 이벤트 전송
3. HTTP 200 응답 확인
4. 사용자 구독 데이터가 변경되지 않는지 확인

## 🧾 Screenshots or Videos (Optional)

- 수정 전 응답: HTTP 404

## 🔗 Related Issues

- #234
- #258

## 🙌 Additional Notes (Optional)

- Sandbox 실제 구매·복원·만료 검증은 별도로 진행합니다.
