### PR TITLE
fix: fetch production provisioning profiles via API

### DIFF
--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -173,23 +173,16 @@ jobs:
           echo "REVENUECAT_PUBLIC_KEY=${{ secrets.REVENUECAT_PUBLIC_KEY }}" >> .env
           echo "ENVIRONMENT=production" >> .env
 
-      - name: Install Certificate and Provisioning Profiles
-        id: install-cert
+      - name: Install Certificate
         env:
           CERTIFICATE_P12_BASE64: ${{ secrets.CERTIFICATE_P12_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
-          PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
-          PROVISIONING_PROFILE_WIDGET_BASE64: ${{ secrets.PROVISIONING_PROFILE_WIDGET_BASE64 }}
           KEYCHAIN_PASSWORD: ${{ github.run_id }}
         run: |
           CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
-          PROVISIONING_PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
-          WIDGET_PROFILE_PATH=$RUNNER_TEMP/widget_profile.mobileprovision
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
           echo -n "$CERTIFICATE_P12_BASE64" | base64 --decode > $CERTIFICATE_PATH
-          echo -n "$PROVISIONING_PROFILE_BASE64" | base64 --decode > $PROVISIONING_PROFILE_PATH
-          echo -n "$PROVISIONING_PROFILE_WIDGET_BASE64" | base64 --decode > $WIDGET_PROFILE_PATH
 
           security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
@@ -199,31 +192,6 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH login.keychain-db
 
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-
-          PROFILE_PLIST=$(/usr/bin/security cms -D -i $PROVISIONING_PROFILE_PATH)
-          PROFILE_UUID=$(echo "$PROFILE_PLIST" | /usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin)
-          PROFILE_NAME=$(echo "$PROFILE_PLIST" | /usr/libexec/PlistBuddy -c "Print Name" /dev/stdin)
-
-          cp $PROVISIONING_PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/$PROFILE_UUID.mobileprovision
-
-          WIDGET_PLIST=$(/usr/bin/security cms -D -i $WIDGET_PROFILE_PATH)
-          WIDGET_UUID=$(echo "$WIDGET_PLIST" | /usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin)
-          WIDGET_NAME=$(echo "$WIDGET_PLIST" | /usr/libexec/PlistBuddy -c "Print Name" /dev/stdin)
-          cp $WIDGET_PROFILE_PATH ~/Library/MobileDevice/Provisioning\ Profiles/$WIDGET_UUID.mobileprovision
-
-          echo "PROVISIONING_PROFILE_UUID=$PROFILE_UUID" >> $GITHUB_OUTPUT
-          echo "PROVISIONING_PROFILE_NAME=$PROFILE_NAME" >> $GITHUB_OUTPUT
-          echo "WIDGET_PROFILE_UUID=$WIDGET_UUID" >> $GITHUB_OUTPUT
-          echo "WIDGET_PROFILE_NAME=$WIDGET_NAME" >> $GITHUB_OUTPUT
-
-          echo "Installed provisioning profiles:"
-          echo "  App - UUID: $PROFILE_UUID, Name: $PROFILE_NAME"
-          echo "  Widget - UUID: $WIDGET_UUID, Name: $WIDGET_NAME"
-          echo ""
-          echo "Installed profiles:"
-          ls -la ~/Library/MobileDevice/Provisioning\ Profiles/
-          echo ""
           echo "Keychain certificates:"
           security find-identity -v -p codesigning $KEYCHAIN_PATH
 
@@ -239,8 +207,6 @@ jobs:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
-          PROVISIONING_PROFILE_NAME: ${{ steps.install-cert.outputs.PROVISIONING_PROFILE_NAME }}
-          WIDGET_PROFILE_NAME: ${{ steps.install-cert.outputs.WIDGET_PROFILE_NAME }}
           LANG: en_US.UTF-8
           LC_ALL: en_US.UTF-8
         run: |

--- a/app/ios/fastlane/Fastfile
+++ b/app/ios/fastlane/Fastfile
@@ -79,6 +79,24 @@ platform :ios do
       is_key_content_base64: true
     )
 
+    get_provisioning_profile(
+      api_key: api_key,
+      app_identifier: "com.bookgolas.app",
+      team_id: "7PFH55UQ86",
+      provisioning_name: "Bookgolas App Store",
+      ignore_profiles_with_different_name: true,
+      readonly: true
+    )
+
+    get_provisioning_profile(
+      api_key: api_key,
+      app_identifier: "com.bookgolas.app.BookgolasWidget",
+      team_id: "7PFH55UQ86",
+      provisioning_name: "Bookgolas Widget App Store",
+      ignore_profiles_with_different_name: true,
+      readonly: true
+    )
+
     update_code_signing_settings(
       use_automatic_signing: false,
       path: "Runner.xcodeproj",

--- a/docs/guides/app-store-connect-iap-setup.md
+++ b/docs/guides/app-store-connect-iap-setup.md
@@ -67,7 +67,8 @@ RevenueCat의 Integrations → Webhooks에 환경별 구성을 추가합니다.
 
 ## 출시 체크리스트
 
-- [ ] App Store Connect 로그인 및 계약 상태 확인
+- [x] App Store Connect 로그인 및 계약 상태 확인
+- [ ] 유료 앱 계약·세금·은행 정보 활성화
 - [ ] `monthly`, `yearly` 메타데이터와 심사 스크린샷 완료
 - [ ] 두 상품을 제출할 앱 버전에 연결
 - [ ] RevenueCat IAP Key 검증 완료
@@ -75,7 +76,8 @@ RevenueCat의 Integrations → Webhooks에 환경별 구성을 추가합니다.
 - [x] Entitlement `byungskerslab/북골라스 Pro` 연결 확인
 - [x] Default offering의 두 패키지 확인
 - [x] Development·Production webhook 구성
-- [ ] Development·Production webhook 테스트 성공
+- [x] Development webhook 테스트 성공
+- [ ] Production webhook 테스트 성공
 - [ ] Sandbox 월간·연간 구매, 복원, 만료 테스트 성공
 
 최종 확인일: 2026-07-23

--- a/docs/guides/release-readiness.md
+++ b/docs/guides/release-readiness.md
@@ -11,12 +11,13 @@
 - [x] TestFlight 업로드 성공
 - [ ] Production App Store Connect 업로드 성공
 
-## GitHub Actions 비밀값
+## 코드 서명과 GitHub Actions 비밀값
 
 앱과 위젯은 서로 다른 provisioning profile이 필요합니다.
 
-- [x] `PROVISIONING_PROFILE_BASE64`
-- [ ] `PROVISIONING_PROFILE_WIDGET_BASE64`
+- [x] Production App ID `com.bookgolas.app` provisioning profile
+- [x] Production Widget ID `com.bookgolas.app.BookgolasWidget` provisioning profile
+- [x] Production workflow의 App Store Connect API profile 자동 설치
 - [x] `PROVISIONING_PROFILE_DEV_BASE64`
 - [x] `PROVISIONING_PROFILE_WIDGET_DEV_BASE64`
 - [x] App Store Connect API key 3종
@@ -25,20 +26,23 @@
 - [x] `REVENUECAT_WEBHOOK_AUTH_KEY_DEV`
 - [x] `REVENUECAT_WEBHOOK_AUTH_KEY_PROD`
 
-`PROVISIONING_PROFILE_WIDGET_BASE64`가 없으면 운영 IPA의 Widget Extension을 수동
-서명할 수 없어 Production workflow가 실패합니다.
+Production workflow는 App Store Connect API key로 `Bookgolas App Store`와
+`Bookgolas Widget App Store` profile을 Apple에서 직접 받아 설치합니다.
 
 ## 외부 콘솔
 
-- [ ] App Store Connect 로그인 및 계약·세금·은행 상태 확인
+- [x] App Store Connect 로그인 및 계약·세금·은행 상태 확인
+- [ ] 유료 앱 계약·한국 세금·미국 세금·은행 정보 활성화
 - [ ] 앱 버전, 개인정보, 연령 등급, 카테고리, 지원 URL 완료
-- [ ] iPhone 필수 사이즈 스크린샷 완료
+- [x] iPhone 필수 사이즈 스크린샷 완료
 - [ ] 월간·연간 구독 메타데이터와 심사 스크린샷 완료
 - [ ] 앱 버전에 두 구독 연결
-- [ ] RevenueCat 이메일 인증
+- [x] RevenueCat 이메일 인증
 - [ ] RevenueCat IAP key 검증 완료
 - [ ] RevenueCat App Store Connect API key 등록·검증 완료
 - [x] RevenueCat Development·Production webhook 구성
+- [x] RevenueCat Development webhook 테스트 성공
+- [ ] RevenueCat Production webhook 테스트 성공
 - [x] App Store Connect Production·Sandbox 서버 알림 URL 구성
 - [ ] Sandbox 구매·복원·갱신·취소·만료 검증
 - [ ] 심사용 계정 로그인 및 Pro 권한 검증


### PR DESCRIPTION
프로덕션 앱·위젯의 provisioning profile을 App Store Connect API에서 직접 설치하도록 배포 경로를 보강했습니다.

## 📋 Changes

- `Bookgolas App Store`와 `Bookgolas Widget App Store` profile을 fastlane `readonly` 모드로 다운로드
- Production workflow의 앱·위젯 provisioning profile GitHub secret 의존성 제거
- App Store Connect·RevenueCat 출시 체크리스트 현황 업데이트

## 🧠 Context & Background

프로덕션 Widget Extension용 provisioning profile secret이 없어 main 배포가 실패할 수 있었습니다. Apple Developer에 앱·위젯 profile을 생성하고, 기존 App Store Connect API key로 유효한 profile을 매 배포 시 직접 설치하도록 변경했습니다.

## ✅ How to Test

1. `ruby -c app/ios/fastlane/Fastfile` 실행
2. Production workflow YAML 문법 확인
3. feature → daily → dev 품질 게이트 확인
4. main 배포에서 앱·위젯 profile 다운로드 및 App Store Connect 업로드 확인

## 🧾 Screenshots or Videos (Optional)

해당 없음

## 🔗 Related Issues

- Related: #234

## 🙌 Additional Notes (Optional)

Apple Developer의 두 profile은 2026-12-30까지 유효합니다.