### PR TITLE
chore: integrate localized subscription pricing

### DIFF
--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -962,6 +962,9 @@
            "subscriptionUpgradeTitle": "Upgrade to Pro",
            "@subscriptionUpgradeTitle": {"description": "Upgrade to Pro title"},
 
+           "subscriptionPopular": "POPULAR",
+           "@subscriptionPopular": {"description": "Popular subscription badge"},
+
            "subscriptionMonthly": "Monthly",
            "@subscriptionMonthly": {"description": "Monthly subscription"},
 

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2493,6 +2493,9 @@
         "subscriptionUpgradeTitle": "Pro로 업그레이드",
         "@subscriptionUpgradeTitle": {"description": "Upgrade to Pro title"},
 
+        "subscriptionPopular": "인기",
+        "@subscriptionPopular": {"description": "Popular subscription badge"},
+
         "subscriptionMonthly": "월간 구독",
         "@subscriptionMonthly": {"description": "Monthly subscription"},
 

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -4144,6 +4144,12 @@ abstract class AppLocalizations {
   /// **'Pro로 업그레이드'**
   String get subscriptionUpgradeTitle;
 
+  /// Popular subscription badge
+  ///
+  /// In ko, this message translates to:
+  /// **'인기'**
+  String get subscriptionPopular;
+
   /// Monthly subscription
   ///
   /// In ko, this message translates to:

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -2271,6 +2271,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get subscriptionUpgradeTitle => 'Upgrade to Pro';
 
   @override
+  String get subscriptionPopular => 'POPULAR';
+
+  @override
   String get subscriptionMonthly => 'Monthly';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -2201,6 +2201,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get subscriptionUpgradeTitle => 'Pro로 업그레이드';
 
   @override
+  String get subscriptionPopular => '인기';
+
+  @override
   String get subscriptionMonthly => '월간 구독';
 
   @override

--- a/app/lib/ui/subscription/widgets/subscription_screen.dart
+++ b/app/lib/ui/subscription/widgets/subscription_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+
 import 'package:provider/provider.dart';
+
 import 'package:book_golas/l10n/app_localizations.dart';
-import 'package:book_golas/ui/subscription/view_model/subscription_view_model.dart';
 import 'package:book_golas/ui/core/widgets/custom_snackbar.dart';
+import 'package:book_golas/ui/subscription/view_model/subscription_view_model.dart';
 
 /// Subscription management screen.
 ///
@@ -131,6 +133,12 @@ class SubscriptionScreen extends StatelessWidget {
     SubscriptionViewModel viewModel,
     AppLocalizations l10n,
   ) {
+    final currentOffering = viewModel.offerings?.current;
+    final monthlyPrice = currentOffering?.monthly?.storeProduct.priceString ??
+        l10n.subscriptionMonthlyPrice;
+    final yearlyPrice = currentOffering?.annual?.storeProduct.priceString ??
+        l10n.subscriptionYearlyPrice;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -144,26 +152,31 @@ class SubscriptionScreen extends StatelessWidget {
         const SizedBox(height: 12),
         _PricingButton(
           title: l10n.subscriptionMonthly,
-          price: l10n.subscriptionMonthlyPrice,
+          price: monthlyPrice,
           period: l10n.subscriptionPerMonth,
+          popularLabel: l10n.subscriptionPopular,
           isPopular: true,
           onTap: () async {
             final success = await viewModel.showPaywall(context);
             if (!success && context.mounted) {
-              CustomSnackbar.show(context, message: l10n.subscriptionUnavailable, type: BLabSnackbarType.info);
+              CustomSnackbar.show(context,
+                  message: l10n.subscriptionUnavailable,
+                  type: BLabSnackbarType.info);
             }
           },
         ),
         const SizedBox(height: 10),
         _PricingButton(
           title: l10n.subscriptionYearly,
-          price: l10n.subscriptionYearlyPrice,
+          price: yearlyPrice,
           period: l10n.subscriptionPerYear,
           savings: l10n.subscriptionYearlySavings,
           onTap: () async {
             final success = await viewModel.showPaywall(context);
             if (!success && context.mounted) {
-              CustomSnackbar.show(context, message: l10n.subscriptionUnavailable, type: BLabSnackbarType.info);
+              CustomSnackbar.show(context,
+                  message: l10n.subscriptionUnavailable,
+                  type: BLabSnackbarType.info);
             }
           },
         ),
@@ -236,14 +249,13 @@ class SubscriptionScreen extends StatelessWidget {
           onTap: () async {
             final success = await viewModel.restorePurchases();
             if (context.mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(
-                    success
-                        ? l10n.subscriptionRestoreSuccess
-                        : l10n.subscriptionRestoreFailed,
-                  ),
-                ),
+              CustomSnackbar.show(
+                context,
+                message: success
+                    ? l10n.subscriptionRestoreSuccess
+                    : l10n.subscriptionRestoreFailed,
+                type:
+                    success ? BLabSnackbarType.success : BLabSnackbarType.error,
               );
             }
           },
@@ -264,6 +276,7 @@ class _PricingButton extends StatelessWidget {
   final String title;
   final String price;
   final String period;
+  final String? popularLabel;
   final String? savings;
   final bool isPopular;
   final VoidCallback onTap;
@@ -272,6 +285,7 @@ class _PricingButton extends StatelessWidget {
     required this.title,
     required this.price,
     required this.period,
+    this.popularLabel,
     this.savings,
     this.isPopular = false,
     required this.onTap,
@@ -296,35 +310,44 @@ class _PricingButton extends StatelessWidget {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Row(
-              children: [
-                if (isPopular)
-                  Container(
-                    margin: const EdgeInsets.only(right: 8),
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).primaryColor,
-                      borderRadius: BorderRadius.circular(4),
+            Expanded(
+              child: Row(
+                children: [
+                  if (isPopular && popularLabel != null)
+                    Container(
+                      margin: const EdgeInsets.only(right: 8),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 4,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).primaryColor,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      child: Text(
+                        popularLabel!,
+                        style: TextStyle(
+                          fontSize: 10,
+                          fontWeight: FontWeight.bold,
+                          color: Theme.of(context).colorScheme.onPrimary,
+                        ),
+                      ),
                     ),
+                  Flexible(
                     child: Text(
-                      'POPULAR',
-                      style: TextStyle(
-                        fontSize: 10,
-                        fontWeight: FontWeight.bold,
-                        color: Theme.of(context).colorScheme.onPrimary,
+                      title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w500,
                       ),
                     ),
                   ),
-                Text(
-                  title,
-                  style: const TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-              ],
+                ],
+              ),
             ),
+            const SizedBox(width: 8),
             Row(
               crossAxisAlignment: CrossAxisAlignment.baseline,
               textBaseline: TextBaseline.alphabetic,

--- a/app/test/ui/subscription/subscription_screen_test.dart
+++ b/app/test/ui/subscription/subscription_screen_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:book_golas/data/services/subscription_service.dart';
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/subscription/view_model/subscription_view_model.dart';
+import 'package:book_golas/ui/subscription/widgets/subscription_screen.dart';
+
+void main() {
+  testWidgets('renders English subscription pricing without overflow',
+      (tester) async {
+    tester.view.physicalSize = const Size(430, 932);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => SubscriptionViewModel(SubscriptionService()),
+        child: const MaterialApp(
+          locale: Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: SubscriptionScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('POPULAR'), findsOneWidget);
+    expect(find.text(r'US$2.99'), findsOneWidget);
+    expect(find.text(r'US$19.99'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
구독 화면의 StoreKit 현지화 가격과 다국어 레이아웃 수정사항을 dev에 통합합니다.

## 📋 Changes

- RevenueCat offering의 지역별 가격 표시
- 월간 인기 배지 한국어·영어 지원
- 구매 복원 결과 공통 스낵바 적용
- 430×932 영문 레이아웃 회귀 테스트 추가

## 🧠 Context & Background

App Store 심사 전 가격 표시와 영문 레이아웃을 실제 상품 구성에 맞추기 위한 daily 통합입니다.

## ✅ How to Test

1. Quality Gates 전체 통과 확인
2. daily → dev 병합 후 TestFlight 업로드 확인
3. Sandbox에서 월간·연간 현지화 가격 확인

## 🧾 Screenshots or Videos (Optional)

실제 Sandbox 상품 활성화 후 심사용 화면을 캡처합니다.

## 🔗 Related Issues

- Related: #234
- Related: #262

## 🙌 Additional Notes (Optional)

App Store 가격은 월 $2.99 / 연 $19.99 기준으로 이미 설정돼 있습니다.