### PR TITLE
docs: update subscription release status

### DIFF
--- a/docs/guides/app-store-connect-iap-setup.md
+++ b/docs/guides/app-store-connect-iap-setup.md
@@ -69,9 +69,10 @@ RevenueCat의 Integrations → Webhooks에 환경별 구성을 추가합니다.
 
 - [x] App Store Connect 로그인 및 계약 상태 확인
 - [ ] 유료 앱 계약·세금·은행 정보 활성화
+- [x] 월간 $2.99·연간 $19.99 기준 가격과 전 지역 판매 설정 확인
 - [ ] `monthly`, `yearly` 메타데이터와 심사 스크린샷 완료
 - [ ] 두 상품을 제출할 앱 버전에 연결
-- [ ] RevenueCat IAP Key 검증 완료
+- [x] RevenueCat IAP Key 검증 완료
 - [ ] RevenueCat App Store Connect API Key 검증 완료
 - [x] Entitlement `byungskerslab/북골라스 Pro` 연결 확인
 - [x] Default offering의 두 패키지 확인

--- a/docs/guides/release-readiness.md
+++ b/docs/guides/release-readiness.md
@@ -35,10 +35,11 @@ Production workflow는 App Store Connect API key로 `Bookgolas App Store`와
 - [ ] 유료 앱 계약·한국 세금·미국 세금·은행 정보 활성화
 - [ ] 앱 버전, 개인정보, 연령 등급, 카테고리, 지원 URL 완료
 - [x] iPhone 필수 사이즈 스크린샷 완료
+- [x] 월간·연간 기준 가격과 전 지역 판매 설정 확인
 - [ ] 월간·연간 구독 메타데이터와 심사 스크린샷 완료
 - [ ] 앱 버전에 두 구독 연결
 - [x] RevenueCat 이메일 인증
-- [ ] RevenueCat IAP key 검증 완료
+- [x] RevenueCat IAP key 검증 완료
 - [ ] RevenueCat App Store Connect API key 등록·검증 완료
 - [x] RevenueCat Development·Production webhook 구성
 - [x] RevenueCat Development webhook 테스트 성공


### PR DESCRIPTION
RevenueCat IAP key와 App Store 구독 가격·판매 지역 검증 결과를 출시 체크리스트에 반영했습니다.

## 📋 Changes

- RevenueCat IAP key 검증 완료 표시
- 월간 $2.99·연간 $19.99 기준 가격 확인 기록
- 두 상품의 전 지역 판매 설정 확인 기록

## 🧠 Context & Background

외부 콘솔의 실제 상태와 저장소 출시 런북을 일치시키기 위한 문서 업데이트입니다.

## ✅ How to Test

1. RevenueCat 앱 설정에서 IAP key가 Valid credentials인지 확인
2. App Store Connect에서 월간 ₩4,400 / 연간 ₩33,000 가격 확인
3. 두 상품의 판매 지역이 전체 지역인지 확인

## 🧾 Screenshots or Videos (Optional)

해당 없음

## 🔗 Related Issues

- Related: #234

## 🙌 Additional Notes (Optional)

App Store Connect API key와 심사용 스크린샷은 아직 미완료입니다.