### PR TITLE
fix: sync widget build version

### DIFF
--- a/app/ios/fastlane/Fastfile
+++ b/app/ios/fastlane/Fastfile
@@ -1,5 +1,20 @@
 default_platform(:ios)
 
+def flutter_version_xcargs
+  config_path = File.expand_path("../Flutter/Generated.xcconfig", __dir__)
+  UI.user_error!("Missing Flutter generated build configuration") unless File.exist?(config_path)
+
+  config = File.read(config_path)
+  build_name = config[/^FLUTTER_BUILD_NAME=(.+)$/, 1]&.strip
+  build_number = config[/^FLUTTER_BUILD_NUMBER=(.+)$/, 1]&.strip
+
+  UI.user_error!("Invalid Flutter build name") unless build_name&.match?(/\A\d+\.\d+\.\d+\z/)
+  UI.user_error!("Invalid Flutter build number") unless build_number&.match?(/\A\d+\z/)
+
+  "FLUTTER_BUILD_NAME=#{build_name} FLUTTER_BUILD_NUMBER=#{build_number} " \
+    "MARKETING_VERSION=#{build_name} CURRENT_PROJECT_VERSION=#{build_number}"
+end
+
 platform :ios do
   desc "Build and upload to TestFlight (DEV)"
   lane :beta do
@@ -30,13 +45,15 @@ platform :ios do
     )
 
     archive_path = "./build/Runner.xcarchive"
+    version_xcargs = flutter_version_xcargs
 
     build_app(
       workspace: "Runner.xcworkspace",
       scheme: "dev",
       configuration: "Release-dev",
       skip_package_ipa: true,
-      archive_path: archive_path
+      archive_path: archive_path,
+      xcargs: version_xcargs
     )
 
     plist_path = "#{archive_path}/Products/Applications/Runner.app/Frameworks/App.framework/Info.plist"
@@ -116,11 +133,14 @@ platform :ios do
       targets: ["BookgolasWidgetExtension"]
     )
 
+    version_xcargs = flutter_version_xcargs
+
     build_app(
       workspace: "Runner.xcworkspace",
       scheme: "prod",
       configuration: "Release-prod",
       export_method: "app-store",
+      xcargs: version_xcargs,
       export_options: {
         provisioningProfiles: {
           "com.bookgolas.app" => ENV["PROVISIONING_PROFILE_NAME"] || "Bookgolas App Store",


### PR DESCRIPTION
TestFlight archive에서 Widget Extension 빌드 번호가 본 앱과 달라지는 문제를 수정합니다.

## 📋 Changes

- Flutter Generated.xcconfig에서 버전과 빌드 번호를 검증해 읽는 Fastlane 헬퍼 추가
- dev 및 prod archive에 동일한 버전 build setting을 모든 Xcode 타깃으로 전달
- Runner와 Widget Extension의 CFBundleVersion 동기화

## 🧠 Context & Background

- TestFlight 1.0.1 (28601) 업로드 로그에서 Widget Extension CFBundleVersion이 1이라는 경고를 확인했습니다.
- App Store 처리 및 심사 전에 본 앱과 extension의 빌드 번호가 반드시 일치하도록 보강합니다.

## ✅ How to Test

1. ruby -c app/ios/fastlane/Fastfile 실행
2. Xcode Release-dev build settings에 FLUTTER_BUILD_NUMBER=28601과 CURRENT_PROJECT_VERSION=28601 전달
3. Runner와 BookgolasWidgetExtension 모두 MARKETING_VERSION=1.0.1 확인
4. daily 병합 후 dev TestFlight 재배포 로그에서 CFBundleVersion 불일치 경고가 사라지는지 확인

## 🧾 Screenshots or Videos (Optional)

- 경고가 확인된 실행: https://github.com/byungsker/book-golas/actions/runs/29951835794

## 🔗 Related Issues

- Related: #234

## 🙌 Additional Notes (Optional)

- 프로덕션 release lane에도 동일한 동기화 로직을 적용했습니다.