### PR TITLE
docs: mark subscription metadata complete

### DIFF
--- a/docs/guides/app-store-connect-iap-setup.md
+++ b/docs/guides/app-store-connect-iap-setup.md
@@ -70,7 +70,7 @@ RevenueCat의 Integrations → Webhooks에 환경별 구성을 추가합니다.
 - [x] App Store Connect 로그인 및 계약 상태 확인
 - [ ] 유료 앱 계약·세금·은행 정보 활성화
 - [x] 월간 $2.99·연간 $19.99 기준 가격과 전 지역 판매 설정 확인
-- [ ] `monthly`, `yearly` 메타데이터와 심사 스크린샷 완료
+- [x] `monthly`, `yearly` 메타데이터와 심사 스크린샷 완료
 - [ ] 두 상품을 제출할 앱 버전에 연결
 - [x] RevenueCat IAP Key 검증 완료
 - [ ] RevenueCat App Store Connect API Key 검증 완료

--- a/docs/guides/release-readiness.md
+++ b/docs/guides/release-readiness.md
@@ -36,7 +36,7 @@ Production workflow는 App Store Connect API key로 `Bookgolas App Store`와
 - [ ] 앱 버전, 개인정보, 연령 등급, 카테고리, 지원 URL 완료
 - [x] iPhone 필수 사이즈 스크린샷 완료
 - [x] 월간·연간 기준 가격과 전 지역 판매 설정 확인
-- [ ] 월간·연간 구독 메타데이터와 심사 스크린샷 완료
+- [x] 월간·연간 구독 메타데이터와 심사 스크린샷 완료
 - [ ] 앱 버전에 두 구독 연결
 - [x] RevenueCat 이메일 인증
 - [x] RevenueCat IAP key 검증 완료


### PR DESCRIPTION
App Store Connect의 월간·연간 구독 메타데이터 완료 상태를 출시 문서에 반영합니다.

## 📋 Changes

- monthly, yearly 한·영 현지화 완료 체크
- 두 구독의 App Review 스크린샷 등록 완료 체크

## 🧠 Context & Background

App Store Connect API로 구독 상품 현지화, 구독 그룹 현지화, 1290×2796 심사 스크린샷 등록을 완료했고 두 상품 모두 READY_TO_SUBMIT 상태를 확인했습니다.

## ✅ How to Test

1. docs/guides/app-store-connect-iap-setup.md 체크리스트 확인
2. docs/guides/release-readiness.md 체크리스트 확인
3. App Store Connect에서 monthly, yearly 상태가 READY_TO_SUBMIT인지 확인

## 🧾 Screenshots or Videos (Optional)

- App Review screenshot: 1290×2796
- Monthly screenshot asset state: COMPLETE
- Yearly screenshot asset state: COMPLETE

## 🔗 Related Issues

- BOK-374
- Related: #234

## 🙌 Additional Notes (Optional)

유료 앱 계약·세금·은행 활성화와 Sandbox 결제 검증은 별도 출시 게이트로 남아 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the App Store and release readiness checklists to mark monthly and yearly subscription metadata as complete.
  * Marked review screenshot preparation as complete in both release checklists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->