### PR TITLE
docs: sync subscription review readiness

### DIFF
--- a/docs/guides/app-store-connect-iap-setup.md
+++ b/docs/guides/app-store-connect-iap-setup.md
@@ -70,7 +70,7 @@ RevenueCat의 Integrations → Webhooks에 환경별 구성을 추가합니다.
 - [x] App Store Connect 로그인 및 계약 상태 확인
 - [ ] 유료 앱 계약·세금·은행 정보 활성화
 - [x] 월간 $2.99·연간 $19.99 기준 가격과 전 지역 판매 설정 확인
-- [ ] `monthly`, `yearly` 메타데이터와 심사 스크린샷 완료
+- [x] `monthly`, `yearly` 메타데이터와 심사 스크린샷 완료
 - [ ] 두 상품을 제출할 앱 버전에 연결
 - [x] RevenueCat IAP Key 검증 완료
 - [ ] RevenueCat App Store Connect API Key 검증 완료

--- a/docs/guides/release-readiness.md
+++ b/docs/guides/release-readiness.md
@@ -36,7 +36,7 @@ Production workflow는 App Store Connect API key로 `Bookgolas App Store`와
 - [ ] 앱 버전, 개인정보, 연령 등급, 카테고리, 지원 URL 완료
 - [x] iPhone 필수 사이즈 스크린샷 완료
 - [x] 월간·연간 기준 가격과 전 지역 판매 설정 확인
-- [ ] 월간·연간 구독 메타데이터와 심사 스크린샷 완료
+- [x] 월간·연간 구독 메타데이터와 심사 스크린샷 완료
 - [ ] 앱 버전에 두 구독 연결
 - [x] RevenueCat 이메일 인증
 - [x] RevenueCat IAP key 검증 완료


### PR DESCRIPTION
App Store Connect의 구독 심사 준비 완료 상태를 dev 출시 문서에 반영합니다.

## 📋 Changes

- 월간·연간 구독 한·영 메타데이터 완료 상태 반영
- 월간·연간 App Review 스크린샷 완료 상태 반영

## 🧠 Context & Background

Apple API에서 두 구독 상품의 메타데이터와 심사 이미지 처리가 완료됐고 모두 READY_TO_SUBMIT 상태로 전환됐습니다.

## ✅ How to Test

1. 두 출시 가이드의 구독 메타데이터 체크 항목 확인
2. App Store Connect에서 monthly, yearly 상태 확인

## 🧾 Screenshots or Videos (Optional)

- App Review screenshot: 1290×2796

## 🔗 Related Issues

- BOK-374
- Related: #234
- #268

## 🙌 Additional Notes (Optional)

유료 앱 계약·세금·은행 활성화와 Sandbox 결제 검증은 아직 병합 전 출시 게이트입니다.
