### PR TITLE
docs: confirm RevenueCat API credentials

### DIFF
--- a/docs/guides/app-store-connect-iap-setup.md
+++ b/docs/guides/app-store-connect-iap-setup.md
@@ -73,7 +73,7 @@ RevenueCat의 Integrations → Webhooks에 환경별 구성을 추가합니다.
 - [x] `monthly`, `yearly` 메타데이터와 심사 스크린샷 완료
 - [ ] 두 상품을 제출할 앱 버전에 연결
 - [x] RevenueCat IAP Key 검증 완료
-- [ ] RevenueCat App Store Connect API Key 검증 완료
+- [x] RevenueCat App Store Connect API Key 검증 완료
 - [x] Entitlement `byungskerslab/북골라스 Pro` 연결 확인
 - [x] Default offering의 두 패키지 확인
 - [x] Development·Production webhook 구성

--- a/docs/guides/release-readiness.md
+++ b/docs/guides/release-readiness.md
@@ -40,7 +40,7 @@ Production workflow는 App Store Connect API key로 `Bookgolas App Store`와
 - [ ] 앱 버전에 두 구독 연결
 - [x] RevenueCat 이메일 인증
 - [x] RevenueCat IAP key 검증 완료
-- [ ] RevenueCat App Store Connect API key 등록·검증 완료
+- [x] RevenueCat App Store Connect API key 등록·검증 완료
 - [x] RevenueCat Development·Production webhook 구성
 - [x] RevenueCat Development webhook 테스트 성공
 - [ ] RevenueCat Production webhook 테스트 성공


### PR DESCRIPTION
RevenueCat의 App Store Connect API 자격증명 등록 및 검증 완료 상태를 출시 문서에 반영합니다.

## 📋 Changes

- RevenueCat App Store Connect API 키 등록 완료 체크
- RevenueCat 자격증명 Valid credentials 검증 완료 체크

## 🧠 Context & Background

Bookgolas App Store 앱에 AuthKey_H49MTDVGLZ.p8, Key ID, Issuer ID를 등록했고 RevenueCat의 Valid credentials 상태를 확인했습니다.

## ✅ How to Test

1. RevenueCat 프로젝트 byungskerslab/북골라스의 App Store 앱 설정 열기
2. App Store Connect API 항목에서 Valid credentials 확인
3. 두 출시 가이드의 API key 체크 항목 확인

## 🧾 Screenshots or Videos (Optional)

- RevenueCat credential status: Valid credentials

## 🔗 Related Issues

- BOK-374
- Related: #234

## 🙌 Additional Notes (Optional)

Apple 유료 앱 계약·세금·은행 활성화와 Sandbox 구매 검증은 별도 출시 게이트로 남아 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release checklists to show that the RevenueCat App Store Connect API key has been registered and verified.
  * Marked the App Store Connect API key validation item as complete in setup and release-readiness guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->