### PR TITLE
docs: sync RevenueCat credential readiness

### DIFF
--- a/docs/guides/app-store-connect-iap-setup.md
+++ b/docs/guides/app-store-connect-iap-setup.md
@@ -73,7 +73,7 @@ RevenueCat의 Integrations → Webhooks에 환경별 구성을 추가합니다.
 - [x] `monthly`, `yearly` 메타데이터와 심사 스크린샷 완료
 - [ ] 두 상품을 제출할 앱 버전에 연결
 - [x] RevenueCat IAP Key 검증 완료
-- [ ] RevenueCat App Store Connect API Key 검증 완료
+- [x] RevenueCat App Store Connect API Key 검증 완료
 - [x] Entitlement `byungskerslab/북골라스 Pro` 연결 확인
 - [x] Default offering의 두 패키지 확인
 - [x] Development·Production webhook 구성

--- a/docs/guides/release-readiness.md
+++ b/docs/guides/release-readiness.md
@@ -40,7 +40,7 @@ Production workflow는 App Store Connect API key로 `Bookgolas App Store`와
 - [ ] 앱 버전에 두 구독 연결
 - [x] RevenueCat 이메일 인증
 - [x] RevenueCat IAP key 검증 완료
-- [ ] RevenueCat App Store Connect API key 등록·검증 완료
+- [x] RevenueCat App Store Connect API key 등록·검증 완료
 - [x] RevenueCat Development·Production webhook 구성
 - [x] RevenueCat Development webhook 테스트 성공
 - [ ] RevenueCat Production webhook 테스트 성공


### PR DESCRIPTION
RevenueCat의 Apple API 자격증명 검증 완료 상태를 dev 출시 문서에 반영합니다.

## 📋 Changes

- App Store Connect API 키 등록 완료 상태 반영
- RevenueCat Valid credentials 검증 완료 상태 반영

## 🧠 Context & Background

프로덕션 App Store 앱에 필요한 Apple API 키 연결이 완료되어 출시 체크리스트를 최신화합니다.

## ✅ How to Test

1. 두 출시 가이드의 RevenueCat API key 체크 확인
2. RevenueCat App Store Connect API 항목의 Valid credentials 확인

## 🧾 Screenshots or Videos (Optional)

- RevenueCat credential status: Valid credentials

## 🔗 Related Issues

- BOK-374
- Related: #234
- #270

## 🙌 Additional Notes (Optional)

Sandbox 결제 검증과 Apple Business 활성화는 아직 병합 전 출시 게이트입니다.
