### PR TITLE
docs: align production sandbox release flow

### DIFF
--- a/docs/guides/app-store-connect-iap-setup.md
+++ b/docs/guides/app-store-connect-iap-setup.md
@@ -58,6 +58,11 @@ RevenueCat의 Integrations → Webhooks에 환경별 구성을 추가합니다.
 
 ## Sandbox 필수 시나리오
 
+실제 `monthly`, `yearly` 상품은 `com.bookgolas.app`에 연결되어 있으므로
+프로덕션 번들의 TestFlight 빌드에서 검증해야 합니다. 프로덕션 빌드와 Supabase
+배포는 `main` CI에서만 수행하고, App Review 제출은 아래 시나리오가 모두 통과한
+뒤에 진행합니다.
+
 1. 무료 계정으로 paywall을 열어 월간·연간 가격을 확인합니다.
 2. 월간 구독 구매 후 Pro 기능과 entitlement가 즉시 활성화되는지 확인합니다.
 3. 앱 재실행·로그아웃·재로그인 후 권한이 유지되는지 확인합니다.

--- a/docs/guides/release-readiness.md
+++ b/docs/guides/release-readiness.md
@@ -53,9 +53,11 @@ Production workflow는 App Store Connect API key로 `Bookgolas App Store`와
 1. `feature/* → daily/YYYY-MM-DD` PR을 merge commit으로 합칩니다.
 2. `daily/YYYY-MM-DD → dev` PR을 merge commit으로 합칩니다.
 3. TestFlight와 개발 Supabase 배포가 성공할 때까지 수정합니다.
-4. Sandbox 테스트가 통과하면 `dev → main` PR을 merge commit으로 합칩니다.
-5. Production environment를 승인하고 운영 배포를 확인합니다.
-6. App Store Connect에서 빌드·구독을 선택하고 심사에 제출합니다.
-7. 승인 후 수동 출시 또는 예약 출시를 실행합니다.
+4. Apple 유료 앱 계약·세금·은행 정보와 외부 자격증명을 활성화합니다.
+5. `dev → main` PR을 merge commit으로 합치고 Production environment를 승인합니다.
+6. 운영 Supabase 배포와 `com.bookgolas.app` TestFlight 업로드를 확인합니다.
+7. 프로덕션 TestFlight 빌드에서 Sandbox 구매·복원·갱신·취소·만료를 검증합니다.
+8. App Store Connect에서 빌드·구독을 선택하고 심사에 제출합니다.
+9. 승인 후 수동 출시 또는 예약 출시를 실행합니다.
 
 최종 확인일: 2026-07-23


### PR DESCRIPTION
프로덕션 구독을 실제로 검증할 수 있도록 출시 게이트 순서를 dev 문서에 반영합니다.

## 📋 Changes

- 프로덕션 번들 TestFlight Sandbox 검증 조건 추가
- main 배포 이후 Sandbox 검증하도록 출시 순서 수정

## 🧠 Context & Background

개발 번들 TestFlight에서는 com.bookgolas.app의 실제 monthly, yearly 상품을 검증할 수 없습니다. 운영 배포 규칙을 유지하면서 순환 의존을 제거했습니다.

## ✅ How to Test

1. release-readiness 배포 순서 확인
2. IAP Sandbox 전제 조건 확인
3. main CI 전용 production workflow 확인

## 🧾 Screenshots or Videos (Optional)

- 해당 없음

## 🔗 Related Issues

- BOK-374
- Related: #234
- #272

## 🙌 Additional Notes (Optional)

최종 App Review 제출은 Sandbox 검증 이후 별도 승인으로 진행합니다.
