### PR TITLE
fix: upload builds to the existing App Store version

### DIFF
--- a/app/ios/fastlane/Fastfile
+++ b/app/ios/fastlane/Fastfile
@@ -155,6 +155,7 @@ platform :ios do
       api_key: api_key,
       skip_metadata: true,
       skip_screenshots: true,
+      skip_app_version_update: true,
       precheck_include_in_app_purchases: false,
       submit_for_review: false,
       automatic_release: false


### PR DESCRIPTION
App Store Connect에 이미 생성된 1.0.1 버전을 유지하면서 프로덕션 빌드만 업로드하도록 수정합니다.

## 📋 Changes

- `upload_to_app_store`에서 앱 버전 생성·수정을 건너뜀
- 기존 App Store Connect 메타데이터와 심사 초안을 보존

## 🧠 Context & Background

- Fastlane이 이미 존재하는 1.0.1 버전을 다시 생성하려다 Apple API에서 거절됨

## ✅ How to Test

1. Fastfile Ruby 문법 검사
2. main 배포 워크플로에서 IPA 업로드 성공 확인
3. App Store Connect에서 빌드가 1.0.1에 연결 가능한지 확인

## 🧾 Screenshots or Videos (Optional)

- 해당 없음

## 🔗 Related Issues

- 해당 없음

## 🙌 Additional Notes (Optional)

- 메타데이터 및 심사 제출은 기존처럼 수동으로 유지합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * App Store uploads now preserve the existing app version instead of updating it automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->