### PR TITLE
fix: preserve existing App Store release version

### DIFF
--- a/app/ios/fastlane/Fastfile
+++ b/app/ios/fastlane/Fastfile
@@ -155,6 +155,7 @@ platform :ios do
       api_key: api_key,
       skip_metadata: true,
       skip_screenshots: true,
+      skip_app_version_update: true,
       precheck_include_in_app_purchases: false,
       submit_for_review: false,
       automatic_release: false


### PR DESCRIPTION
App Store Connect에 생성된 릴리즈 버전을 CI가 재생성하지 않도록 배포 설정을 통합합니다.

## 📋 Changes

- 기존 App Store 버전 업데이트 건너뛰기
- IPA 업로드 전용 배포 흐름 적용

## 🧠 Context & Background

- 1.0.1 심사 초안이 이미 존재해 중복 버전 생성 요청이 실패함

## ✅ How to Test

1. Fastfile Ruby 문법 검사
2. main 배포 워크플로에서 IPA 업로드 확인

## 🧾 Screenshots or Videos (Optional)

- 해당 없음

## 🔗 Related Issues

- 해당 없음

## 🙌 Additional Notes (Optional)

- 기존 메타데이터와 심사 초안은 유지됩니다.