### PR TITLE
fix: unblock App Store build upload

### DIFF
--- a/app/ios/fastlane/Fastfile
+++ b/app/ios/fastlane/Fastfile
@@ -155,6 +155,7 @@ platform :ios do
       api_key: api_key,
       skip_metadata: true,
       skip_screenshots: true,
+      skip_app_version_update: true,
       precheck_include_in_app_purchases: false,
       submit_for_review: false,
       automatic_release: false


### PR DESCRIPTION
기존 App Store Connect 1.0.1 릴리즈 초안을 보존하면서 프로덕션 IPA를 업로드할 수 있도록 배포 흐름을 수정합니다.

## 📋 Changes

- Fastlane의 중복 App Store 버전 생성 방지
- 기존 1.0.1 메타데이터·심사 초안 유지
- IPA 업로드만 수행

## 🧠 Context & Background

- Apple API가 이미 사용 중인 1.0.1 버전의 재생성을 거절해 프로덕션 업로드가 중단됨

## ✅ How to Test

1. Fastfile Ruby 문법 검사 완료
2. main 머지 후 프로덕션 빌드·App Store 업로드 확인
3. App Store Connect에서 새 빌드를 1.0.1에 연결

## 🧾 Screenshots or Videos (Optional)

- 해당 없음

## 🔗 Related Issues

- 해당 없음

## 🙌 Additional Notes (Optional)

- 심사 제출은 빌드 처리 완료 후 App Store Connect에서 진행합니다.