### PR TITLE
feat: improve reading progress share card

### DIFF
--- a/app/lib/data/services/book_share_service.dart
+++ b/app/lib/data/services/book_share_service.dart
@@ -14,32 +14,39 @@ import 'package:book_golas/ui/reading_chart/view_model/reading_chart_view_model.
 import 'package:book_golas/ui/reading_chart/widgets/reading_stats_share_card.dart';
 
 class BookShareService {
-  static Future<void> shareBookCard({
+  static Future<bool> shareBookCard({
     required BuildContext context,
     required Book book,
     required int highlightCount,
+    String? noteText,
+    bool useBookReviewFallback = true,
   }) async {
-    await _shareCard(
+    return _shareCard(
       context: context,
       filePrefix: 'bookgolas_share',
       subject: book.title,
       precache: () => _precacheBookCover(context, book.imageUrl),
-      child: BookShareCard(book: book, highlightCount: highlightCount),
+      child: BookShareCard(
+        book: book,
+        highlightCount: highlightCount,
+        noteText: noteText,
+        useBookReviewFallback: useBookReviewFallback,
+      ),
     );
   }
 
-  static Future<void> shareStatsCard({
+  static Future<bool> shareStatsCard({
     required BuildContext context,
     required ReadingChartViewModel vm,
   }) async {
-    await _shareCard(
+    return _shareCard(
       context: context,
       filePrefix: 'bookgolas_stats',
       child: ReadingStatsShareCard(vm: vm),
     );
   }
 
-  static Future<void> _shareCard({
+  static Future<bool> _shareCard({
     required BuildContext context,
     required String filePrefix,
     required Widget child,
@@ -48,17 +55,18 @@ class BookShareService {
   }) async {
     final repaintKey = GlobalKey();
     OverlayEntry? entry;
+    File? exportedFile;
 
     try {
       if (precache != null) {
         await precache();
       }
 
-      if (!context.mounted) return;
+      if (!context.mounted) return false;
       final mediaQuery = MediaQuery.of(context);
       final directionality = Directionality.of(context);
       final overlay = Overlay.maybeOf(context, rootOverlay: true);
-      if (overlay == null) return;
+      if (overlay == null) return false;
 
       entry = OverlayEntry(
         builder: (_) => Positioned(
@@ -90,23 +98,36 @@ class BookShareService {
         repaintKey: repaintKey,
         pixelRatio: _sharePixelRatio(mediaQuery),
       );
-      if (bytes == null) return;
+      if (bytes == null) return false;
 
       final dir = await getTemporaryDirectory();
       final file = File(
         '${dir.path}/${filePrefix}_${DateTime.now().millisecondsSinceEpoch}.png',
       );
+      exportedFile = file;
       await file.writeAsBytes(bytes, flush: true);
 
-      if (!context.mounted) return;
+      if (!context.mounted) return false;
+      final renderBox = context.findRenderObject() as RenderBox?;
+      final sharePositionOrigin = renderBox == null
+          ? const Rect.fromLTWH(0, 0, 1, 1)
+          : renderBox.localToGlobal(Offset.zero) & renderBox.size;
       await Share.shareXFiles(
         [XFile(file.path, mimeType: 'image/png')],
         subject: subject,
+        sharePositionOrigin: sharePositionOrigin,
       );
+      return true;
     } catch (e) {
       debugPrint('Failed to share card: $e');
+      return false;
     } finally {
       entry?.remove();
+      try {
+        await exportedFile?.delete();
+      } catch (e) {
+        debugPrint('Failed to remove temporary share image: $e');
+      }
     }
   }
 
@@ -126,6 +147,7 @@ class BookShareService {
   static Future<Uint8List?> _capturePngBytes({
     required GlobalKey repaintKey,
     required double pixelRatio,
+    int remainingPaintAttempts = 3,
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 80));
     await WidgetsBinding.instance.endOfFrame;
@@ -136,10 +158,12 @@ class BookShareService {
     if (boundary == null) return null;
 
     if (boundary.debugNeedsPaint) {
+      if (remainingPaintAttempts == 0) return null;
       await Future<void>.delayed(const Duration(milliseconds: 20));
       return _capturePngBytes(
         repaintKey: repaintKey,
         pixelRatio: pixelRatio,
+        remainingPaintAttempts: remainingPaintAttempts - 1,
       );
     }
 

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1707,11 +1707,62 @@
             "shareStartedOn": "Started {date}",
             "@shareStartedOn": {"description": "Short stat text for the reading start date on the book share card","placeholders": {"date": {}}},
 
-            "shareCompletedInDays": "Finished in {days} days",
+            "shareCompletedInDays": "{days, plural, =1 {Finished in 1 day} other {Finished in {days} days}}",
             "@shareCompletedInDays": {"description": "Short stat text for how many days it took to complete a book on the book share card","placeholders": {"days": {"type": "int"}}},
 
-            "shareHighlightCount": "{count} records",
+            "shareHighlightCount": "{count, plural, =0 {No records} =1 {1 record} other {{count} records}}",
             "@shareHighlightCount": {"description": "Short stat text for the number of highlights or records on the book share card","placeholders": {"count": {"type": "int"}}},
+
+            "shareDeadline": "Due {date}",
+            "@shareDeadline": {"description": "Deadline text shown on an in-progress book share card","placeholders": {"date": {}}},
+
+            "sharePlannedStart": "Starts {date}",
+            "@sharePlannedStart": {"description": "Planned start date shown on the book share card","placeholders": {"date": {}}},
+
+            "shareRetryCount": "Attempt {count}",
+            "@shareRetryCount": {"description": "Retry attempt count shown on the book share card","placeholders": {"count": {"type": "int"}}},
+
+            "shareCurrentPages": "{current} / {total}p",
+            "@shareCurrentPages": {"description": "Current and total pages shown on the book share card","placeholders": {"current": {"type": "int"}, "total": {"type": "int"}}},
+
+            "sharePages": "{pages}p",
+            "@sharePages": {"description": "Page count shown on the book share card","placeholders": {"pages": {"type": "int"}}},
+
+            "shareNoteHeading": "Notes from this book",
+            "@shareNoteHeading": {"description": "Heading for the selected note content on the book share card"},
+
+            "shareRemainingPages": "{pages}p left",
+            "@shareRemainingPages": {"description": "Remaining page count shown on an in-progress book share card","placeholders": {"pages": {"type": "int"}}},
+
+            "shareDaysLeft": "{days, plural, =0 {Due today} =1 {1 day left} other {{days} days left}}",
+            "@shareDaysLeft": {"description": "Days remaining until the reading deadline","placeholders": {"days": {"type": "int"}}},
+
+            "shareDaysOverdue": "{days, plural, =1 {1 day overdue} other {{days} days overdue}}",
+            "@shareDaysOverdue": {"description": "Days elapsed after the reading deadline","placeholders": {"days": {"type": "int"}}},
+
+            "shareComposerTitle": "Customize share card",
+            "@shareComposerTitle": {"description": "Title for the book share composition sheet"},
+
+            "shareComposerNotesTitle": "Choose from my notes",
+            "@shareComposerNotesTitle": {"description": "Section title for selecting notes in the book share composition sheet"},
+
+            "shareComposerNoNotes": "No saved notes yet. You can write one directly.",
+            "@shareComposerNoNotes": {"description": "Empty state when no notes are available for the share card"},
+
+            "shareComposerNoteLabel": "Note to share",
+            "@shareComposerNoteLabel": {"description": "Label for the editable note text used on the share card"},
+
+            "shareComposerNoteHint": "Write directly or edit your selected notes",
+            "@shareComposerNoteHint": {"description": "Hint for the editable note text used on the share card"},
+
+            "shareComposerPreviewLimit": "Up to the first 5 lines appear on the shared image.",
+            "@shareComposerPreviewLimit": {"description": "Preview guidance for the note line limit on the share card"},
+
+            "shareComposerCreateButton": "Create share image",
+            "@shareComposerCreateButton": {"description": "Button to generate the book share image"},
+
+            "shareComposerPage": "p. {page}",
+            "@shareComposerPage": {"description": "Page label for a note in the book share composition sheet","placeholders": {"page": {"type": "int"}}},
 
             "loginSocialGoogle": "Continue with Google",
             "@loginSocialGoogle": {"description": "Continue with Google button"},

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -3208,6 +3208,57 @@
          "shareHighlightCount": "{count} 기록",
          "@shareHighlightCount": {"description": "Short stat text for the number of highlights or records on the book share card","placeholders": {"count": {"type": "int"}}},
 
+         "shareDeadline": "마감 {date}",
+         "@shareDeadline": {"description": "Deadline text shown on an in-progress book share card","placeholders": {"date": {}}},
+
+         "sharePlannedStart": "{date} 시작 예정",
+         "@sharePlannedStart": {"description": "Planned start date shown on the book share card","placeholders": {"date": {}}},
+
+         "shareRetryCount": "{count}번째 도전",
+         "@shareRetryCount": {"description": "Retry attempt count shown on the book share card","placeholders": {"count": {"type": "int"}}},
+
+         "shareCurrentPages": "{current} / {total}쪽",
+         "@shareCurrentPages": {"description": "Current and total pages shown on the book share card","placeholders": {"current": {"type": "int"}, "total": {"type": "int"}}},
+
+         "sharePages": "{pages}쪽",
+         "@sharePages": {"description": "Page count shown on the book share card","placeholders": {"pages": {"type": "int"}}},
+
+         "shareNoteHeading": "이 책에서 남긴 기록",
+         "@shareNoteHeading": {"description": "Heading for the selected note content on the book share card"},
+
+         "shareRemainingPages": "{pages}쪽 남음",
+         "@shareRemainingPages": {"description": "Remaining page count shown on an in-progress book share card","placeholders": {"pages": {"type": "int"}}},
+
+         "shareDaysLeft": "{days}일 남음",
+         "@shareDaysLeft": {"description": "Days remaining until the reading deadline","placeholders": {"days": {"type": "int"}}},
+
+         "shareDaysOverdue": "{days}일 지남",
+         "@shareDaysOverdue": {"description": "Days elapsed after the reading deadline","placeholders": {"days": {"type": "int"}}},
+
+         "shareComposerTitle": "공유 카드 꾸미기",
+         "@shareComposerTitle": {"description": "Title for the book share composition sheet"},
+
+         "shareComposerNotesTitle": "내 기록에서 선택",
+         "@shareComposerNotesTitle": {"description": "Section title for selecting notes in the book share composition sheet"},
+
+         "shareComposerNoNotes": "저장된 기록이 없어 직접 입력할 수 있어요.",
+         "@shareComposerNoNotes": {"description": "Empty state when no notes are available for the share card"},
+
+         "shareComposerNoteLabel": "공유할 노트",
+         "@shareComposerNoteLabel": {"description": "Label for the editable note text used on the share card"},
+
+         "shareComposerNoteHint": "직접 입력하거나 기록을 편집해보세요",
+         "@shareComposerNoteHint": {"description": "Hint for the editable note text used on the share card"},
+
+         "shareComposerPreviewLimit": "공유 이미지에는 앞의 5줄까지 보여요.",
+         "@shareComposerPreviewLimit": {"description": "Preview guidance for the note line limit on the share card"},
+
+         "shareComposerCreateButton": "공유 이미지 만들기",
+         "@shareComposerCreateButton": {"description": "Button to generate the book share image"},
+
+         "shareComposerPage": "{page}쪽",
+         "@shareComposerPage": {"description": "Page label for a note in the book share composition sheet","placeholders": {"page": {"type": "int"}}},
+
          "loginSocialGoogle": "Google로 계속하기",
          "@loginSocialGoogle": {"description": "Continue with Google button"},
 

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -6773,6 +6773,108 @@ abstract class AppLocalizations {
   /// **'{count} 기록'**
   String shareHighlightCount(int count);
 
+  /// Deadline text shown on an in-progress book share card
+  ///
+  /// In ko, this message translates to:
+  /// **'마감 {date}'**
+  String shareDeadline(Object date);
+
+  /// Planned start date shown on the book share card
+  ///
+  /// In ko, this message translates to:
+  /// **'{date} 시작 예정'**
+  String sharePlannedStart(Object date);
+
+  /// Retry attempt count shown on the book share card
+  ///
+  /// In ko, this message translates to:
+  /// **'{count}번째 도전'**
+  String shareRetryCount(int count);
+
+  /// Current and total pages shown on the book share card
+  ///
+  /// In ko, this message translates to:
+  /// **'{current} / {total}쪽'**
+  String shareCurrentPages(int current, int total);
+
+  /// Page count shown on the book share card
+  ///
+  /// In ko, this message translates to:
+  /// **'{pages}쪽'**
+  String sharePages(int pages);
+
+  /// Heading for the selected note content on the book share card
+  ///
+  /// In ko, this message translates to:
+  /// **'이 책에서 남긴 기록'**
+  String get shareNoteHeading;
+
+  /// Remaining page count shown on an in-progress book share card
+  ///
+  /// In ko, this message translates to:
+  /// **'{pages}쪽 남음'**
+  String shareRemainingPages(int pages);
+
+  /// Days remaining until the reading deadline
+  ///
+  /// In ko, this message translates to:
+  /// **'{days}일 남음'**
+  String shareDaysLeft(int days);
+
+  /// Days elapsed after the reading deadline
+  ///
+  /// In ko, this message translates to:
+  /// **'{days}일 지남'**
+  String shareDaysOverdue(int days);
+
+  /// Title for the book share composition sheet
+  ///
+  /// In ko, this message translates to:
+  /// **'공유 카드 꾸미기'**
+  String get shareComposerTitle;
+
+  /// Section title for selecting notes in the book share composition sheet
+  ///
+  /// In ko, this message translates to:
+  /// **'내 기록에서 선택'**
+  String get shareComposerNotesTitle;
+
+  /// Empty state when no notes are available for the share card
+  ///
+  /// In ko, this message translates to:
+  /// **'저장된 기록이 없어 직접 입력할 수 있어요.'**
+  String get shareComposerNoNotes;
+
+  /// Label for the editable note text used on the share card
+  ///
+  /// In ko, this message translates to:
+  /// **'공유할 노트'**
+  String get shareComposerNoteLabel;
+
+  /// Hint for the editable note text used on the share card
+  ///
+  /// In ko, this message translates to:
+  /// **'직접 입력하거나 기록을 편집해보세요'**
+  String get shareComposerNoteHint;
+
+  /// Preview guidance for the note line limit on the share card
+  ///
+  /// In ko, this message translates to:
+  /// **'공유 이미지에는 앞의 5줄까지 보여요.'**
+  String get shareComposerPreviewLimit;
+
+  /// Button to generate the book share image
+  ///
+  /// In ko, this message translates to:
+  /// **'공유 이미지 만들기'**
+  String get shareComposerCreateButton;
+
+  /// Page label for a note in the book share composition sheet
+  ///
+  /// In ko, this message translates to:
+  /// **'{page}쪽'**
+  String shareComposerPage(int page);
+
   /// Continue with Google button
   ///
   /// In ko, this message translates to:

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -3709,12 +3709,110 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String shareCompletedInDays(int days) {
-    return 'Finished in $days days';
+    String _temp0 = intl.Intl.pluralLogic(
+      days,
+      locale: localeName,
+      other: 'Finished in $days days',
+      one: 'Finished in 1 day',
+    );
+    return '$_temp0';
   }
 
   @override
   String shareHighlightCount(int count) {
-    return '$count records';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count records',
+      one: '1 record',
+      zero: 'No records',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String shareDeadline(Object date) {
+    return 'Due $date';
+  }
+
+  @override
+  String sharePlannedStart(Object date) {
+    return 'Starts $date';
+  }
+
+  @override
+  String shareRetryCount(int count) {
+    return 'Attempt $count';
+  }
+
+  @override
+  String shareCurrentPages(int current, int total) {
+    return '$current / ${total}p';
+  }
+
+  @override
+  String sharePages(int pages) {
+    return '${pages}p';
+  }
+
+  @override
+  String get shareNoteHeading => 'Notes from this book';
+
+  @override
+  String shareRemainingPages(int pages) {
+    return '${pages}p left';
+  }
+
+  @override
+  String shareDaysLeft(int days) {
+    String _temp0 = intl.Intl.pluralLogic(
+      days,
+      locale: localeName,
+      other: '$days days left',
+      one: '1 day left',
+      zero: 'Due today',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String shareDaysOverdue(int days) {
+    String _temp0 = intl.Intl.pluralLogic(
+      days,
+      locale: localeName,
+      other: '$days days overdue',
+      one: '1 day overdue',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get shareComposerTitle => 'Customize share card';
+
+  @override
+  String get shareComposerNotesTitle => 'Choose from my notes';
+
+  @override
+  String get shareComposerNoNotes =>
+      'No saved notes yet. You can write one directly.';
+
+  @override
+  String get shareComposerNoteLabel => 'Note to share';
+
+  @override
+  String get shareComposerNoteHint =>
+      'Write directly or edit your selected notes';
+
+  @override
+  String get shareComposerPreviewLimit =>
+      'Up to the first 5 lines appear on the shared image.';
+
+  @override
+  String get shareComposerCreateButton => 'Create share image';
+
+  @override
+  String shareComposerPage(int page) {
+    return 'p. $page';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -3625,6 +3625,75 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String shareDeadline(Object date) {
+    return '마감 $date';
+  }
+
+  @override
+  String sharePlannedStart(Object date) {
+    return '$date 시작 예정';
+  }
+
+  @override
+  String shareRetryCount(int count) {
+    return '$count번째 도전';
+  }
+
+  @override
+  String shareCurrentPages(int current, int total) {
+    return '$current / $total쪽';
+  }
+
+  @override
+  String sharePages(int pages) {
+    return '$pages쪽';
+  }
+
+  @override
+  String get shareNoteHeading => '이 책에서 남긴 기록';
+
+  @override
+  String shareRemainingPages(int pages) {
+    return '$pages쪽 남음';
+  }
+
+  @override
+  String shareDaysLeft(int days) {
+    return '$days일 남음';
+  }
+
+  @override
+  String shareDaysOverdue(int days) {
+    return '$days일 지남';
+  }
+
+  @override
+  String get shareComposerTitle => '공유 카드 꾸미기';
+
+  @override
+  String get shareComposerNotesTitle => '내 기록에서 선택';
+
+  @override
+  String get shareComposerNoNotes => '저장된 기록이 없어 직접 입력할 수 있어요.';
+
+  @override
+  String get shareComposerNoteLabel => '공유할 노트';
+
+  @override
+  String get shareComposerNoteHint => '직접 입력하거나 기록을 편집해보세요';
+
+  @override
+  String get shareComposerPreviewLimit => '공유 이미지에는 앞의 5줄까지 보여요.';
+
+  @override
+  String get shareComposerCreateButton => '공유 이미지 만들기';
+
+  @override
+  String shareComposerPage(int page) {
+    return '$page쪽';
+  }
+
+  @override
   String get loginSocialGoogle => 'Google로 계속하기';
 
   @override

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -52,6 +52,7 @@ import 'package:book_golas/ui/book_detail/view_model/reading_timer_view_model.da
 import 'package:book_golas/ui/book_detail/widgets/reading_timer_modal.dart';
 import 'package:book_golas/ui/core/widgets/floating_timer_bar.dart';
 import 'package:book_golas/data/services/book_share_service.dart';
+import 'widgets/book_share_composer.dart';
 
 class BookDetailScreen extends StatelessWidget {
   final Book book;
@@ -305,16 +306,54 @@ class _BookDetailContentState extends State<_BookDetailContent>
                         color: isDark ? Colors.white : Colors.black,
                         size: 22,
                       ),
-                      onPressed: () {
+                      onPressed: () async {
                         final memorableVm =
                             context.read<MemorablePageViewModel>();
-                        final highlightCount =
-                            memorableVm.cachedImages?.length ?? 0;
-                        BookShareService.shareBookCard(
+                        final images = memorableVm.cachedImages ??
+                            await memorableVm.fetchBookImages();
+                        if (!context.mounted) return;
+                        final highlightCount = images.length;
+                        final notes = images
+                            .asMap()
+                            .entries
+                            .map((entry) {
+                              final image = entry.value;
+                              final text = (image['extracted_text'] ?? '')
+                                  .toString()
+                                  .trim();
+                              if (text.isEmpty) return null;
+                              return BookShareNote(
+                                id: image['id']?.toString() ??
+                                    'note-${entry.key}',
+                                text: text,
+                                pageNumber: image['page_number'] as int?,
+                              );
+                            })
+                            .whereType<BookShareNote>()
+                            .toList();
+                        final result = await showBookShareComposer(
+                          context: context,
+                          book: book,
+                          notes: notes,
+                        );
+                        if (!context.mounted || result == null) return;
+                        final didOpenShareSheet =
+                            await BookShareService.shareBookCard(
                           context: context,
                           book: book,
                           highlightCount: highlightCount,
+                          noteText: result.noteText,
+                          useBookReviewFallback: result.useBookReviewFallback,
                         );
+                        if (!didOpenShareSheet && context.mounted) {
+                          CustomSnackbar.show(
+                            context,
+                            message:
+                                AppLocalizations.of(context).shareBookCardError,
+                            type: BLabSnackbarType.error,
+                            bottomOffset: 32,
+                          );
+                        }
                       },
                     ),
                   ],

--- a/app/lib/ui/book_detail/widgets/book_share_card.dart
+++ b/app/lib/ui/book_detail/widgets/book_share_card.dart
@@ -1,6 +1,7 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'dart:math' as math;
+
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:intl/intl.dart';
 
 import 'package:book_golas/domain/models/book.dart';
@@ -10,22 +11,29 @@ import 'package:book_golas/ui/core/theme/design_system.dart';
 class BookShareCard extends StatelessWidget {
   final Book book;
   final int highlightCount;
+  final String? noteText;
+  final bool useBookReviewFallback;
 
-  static const double cardWidth = 400.0;
-  static const double cardHeight = 620.0;
+  static const double cardWidth = 400;
+  static const double cardHeight = 780;
+  static const double _coverWidth = 144;
+  static const double _coverHeight = 205;
+  static const double _horizontalInset = 28;
 
-  static const Color _bgTop = Color(0xFF1A1D24);
-  static const Color _bgBottom = Color(0xFF0D0F13);
-  static const Color _surfaceColor = Color(0xFF1E2128);
-  static const Color _textPrimary = Colors.white;
-  static const Color _textSecondary = Color(0xFFB0B4C0);
-  static const Color _textTertiary = Color(0xFF6B7280);
-  static const Color _dividerColor = Color(0xFF2A2D35);
+  static const Color _backgroundTop = BLabColors.elevatedDark;
+  static const Color _backgroundBottom = BLabColors.scaffoldDark;
+  static const Color _surface = BLabColors.surfaceDark;
+  static const Color _ink = BLabColors.textPrimaryDark;
+  static const Color _inkMuted = BLabColors.textSecondaryDark;
+  static const Color _inkSoft = BLabColors.textTertiaryDark;
+  static const Color _accent = BLabColors.primary;
 
   const BookShareCard({
     super.key,
     required this.book,
     this.highlightCount = 0,
+    this.noteText,
+    this.useBookReviewFallback = true,
   });
 
   @override
@@ -35,43 +43,65 @@ class BookShareCard extends StatelessWidget {
     return SizedBox(
       width: cardWidth,
       height: cardHeight,
-      child: Container(
+      child: DecoratedBox(
         decoration: const BoxDecoration(
           gradient: LinearGradient(
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
-            colors: [_bgTop, _bgBottom],
+            colors: [_backgroundTop, _backgroundBottom],
           ),
         ),
         child: Column(
           children: [
             const SizedBox(height: 28),
-            _buildCoverWithGlow(),
+            _buildCover(l10n),
             const SizedBox(height: 18),
             _buildStatusBadge(l10n),
-            const SizedBox(height: 10),
+            const SizedBox(height: 12),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 32),
-              child: _buildTitleAuthor(),
+              child: _buildTitleAndAuthor(),
             ),
-            const SizedBox(height: 16),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 28),
-              child: _buildMainContent(l10n),
-            ),
+            if (_hasNoteText) ...[
+              const SizedBox(height: 20),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: _horizontalInset,
+                ),
+                child: _buildNote(l10n),
+              ),
+            ],
+            if (book.status == BookStatus.reading.value) ...[
+              const SizedBox(height: 15),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: _horizontalInset,
+                ),
+                child: _buildReadingProgress(l10n),
+              ),
+            ],
             const Spacer(),
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 28),
-              child: _buildMiniStats(l10n),
+              padding: const EdgeInsets.symmetric(
+                horizontal: _horizontalInset,
+              ),
+              child: _buildMetadata(l10n),
+            ),
+            const SizedBox(height: 14),
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: _horizontalInset),
+              child: SizedBox(
+                height: 1,
+                child: ColoredBox(
+                  color: BLabColors.subtleDark,
+                ),
+              ),
             ),
             const SizedBox(height: 14),
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 28),
-              child: Container(height: 1, color: _dividerColor),
-            ),
-            const SizedBox(height: 14),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 28),
+              padding: const EdgeInsets.symmetric(
+                horizontal: _horizontalInset,
+              ),
               child: _buildFooter(l10n),
             ),
             const SizedBox(height: 20),
@@ -81,19 +111,20 @@ class BookShareCard extends StatelessWidget {
     );
   }
 
-  Widget _buildCoverWithGlow() {
-    final config = _statusConfig(null);
+  Widget _buildCover(AppLocalizations l10n) {
+    final config = _statusConfig(l10n);
+
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(10),
         boxShadow: [
           BoxShadow(
-            color: config.color.withValues(alpha: 0.15),
+            color: config.color.withValues(alpha: 0.18),
             blurRadius: 32,
             spreadRadius: 4,
           ),
           BoxShadow(
-            color: Colors.black.withValues(alpha: 0.4),
+            color: _backgroundBottom.withValues(alpha: 0.8),
             blurRadius: 20,
             offset: const Offset(0, 8),
           ),
@@ -101,12 +132,15 @@ class BookShareCard extends StatelessWidget {
       ),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(10),
-        child: book.imageUrl != null
+        child: book.imageUrl?.trim().isNotEmpty == true
             ? CachedNetworkImage(
-                imageUrl: book.imageUrl!,
-                width: 140,
-                height: 200,
+                imageUrl: book.imageUrl!.trim(),
+                width: _coverWidth,
+                height: _coverHeight,
                 fit: BoxFit.cover,
+                fadeInDuration: Duration.zero,
+                fadeOutDuration: Duration.zero,
+                placeholder: (_, __) => _buildCoverPlaceholder(),
                 errorWidget: (_, __, ___) => _buildCoverPlaceholder(),
               )
             : _buildCoverPlaceholder(),
@@ -115,42 +149,44 @@ class BookShareCard extends StatelessWidget {
   }
 
   Widget _buildCoverPlaceholder() {
-    return Container(
-      width: 140,
-      height: 200,
-      color: _surfaceColor,
-      child: const Icon(
-        CupertinoIcons.book_fill,
-        color: Color(0xFF4A4D55),
-        size: 40,
+    return const ColoredBox(
+      color: BLabColors.subtleDark,
+      child: SizedBox(
+        width: _coverWidth,
+        height: _coverHeight,
+        child: Icon(
+          CupertinoIcons.book_fill,
+          color: BLabColors.textTertiaryDark,
+          size: 40,
+        ),
       ),
     );
   }
 
-  Widget _buildStatusBadge(AppLocalizations? l10n) {
+  Widget _buildStatusBadge(AppLocalizations l10n) {
     final config = _statusConfig(l10n);
+
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
       decoration: BoxDecoration(
-        color: config.color.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(20),
+        color: config.color.withValues(alpha: 0.14),
+        borderRadius: BorderRadius.circular(22),
         border: Border.all(
-          color: config.color.withValues(alpha: 0.35),
-          width: 1,
+          color: config.color.withValues(alpha: 0.42),
         ),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(config.icon, size: 12, color: config.color),
-          const SizedBox(width: 5),
+          Icon(config.icon, size: 13, color: config.color),
+          const SizedBox(width: 6),
           Text(
             config.label,
-            style: TextStyle(
+            style: BLabTypography.caption.copyWith(
               color: config.color,
-              fontSize: 11,
+              fontSize: 12,
               fontWeight: FontWeight.w600,
-              letterSpacing: 0.3,
+              letterSpacing: 0.25,
             ),
           ),
         ],
@@ -158,221 +194,305 @@ class BookShareCard extends StatelessWidget {
     );
   }
 
-  Widget _buildTitleAuthor() {
+  Widget _buildTitleAndAuthor() {
     final subtitleParts = <String>[];
-    if (book.author != null) subtitleParts.add(book.author!);
-    if (book.genre != null) subtitleParts.add(book.genre!);
+    if (book.author?.trim().isNotEmpty == true) {
+      subtitleParts.add(book.author!.trim());
+    }
+    if (book.genre?.trim().isNotEmpty == true) {
+      subtitleParts.add(book.genre!.trim());
+    }
 
     return Column(
       children: [
         Text(
-          book.title,
-          style: const TextStyle(
-            color: _textPrimary,
-            fontSize: 18,
-            fontWeight: FontWeight.w700,
-            height: 1.3,
-          ),
+          _keepKoreanWordsTogether(book.title),
           textAlign: TextAlign.center,
           maxLines: 2,
           overflow: TextOverflow.ellipsis,
+          style: BLabTypography.title.copyWith(
+            color: _ink,
+            fontSize: 18,
+            height: 1.25,
+            fontWeight: FontWeight.w800,
+            letterSpacing: -0.25,
+          ),
         ),
         if (subtitleParts.isNotEmpty) ...[
           const SizedBox(height: 6),
           Text(
             subtitleParts.join(' · '),
-            style: const TextStyle(color: _textSecondary, fontSize: 13),
             textAlign: TextAlign.center,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
+            style: BLabTypography.label.copyWith(
+              color: _inkMuted,
+              fontSize: 13,
+              height: 1.3,
+            ),
           ),
         ],
       ],
     );
   }
 
-  Widget _buildMainContent(AppLocalizations? l10n) {
-    switch (book.status) {
-      case 'reading':
-        return _buildReadingProgress();
-      case 'completed':
-        return _buildCompletedContent();
-      default:
-        return const SizedBox.shrink();
-    }
-  }
-
-  Widget _buildReadingProgress() {
-    if (book.totalPages <= 0) return const SizedBox.shrink();
-
-    final progress = (book.currentPage / book.totalPages).clamp(0.0, 1.0);
-    final percent = (progress * 100).toStringAsFixed(0);
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-      decoration: BoxDecoration(
-        color: _surfaceColor,
-        borderRadius: BorderRadius.circular(14),
-      ),
-      child: Column(
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.baseline,
-            textBaseline: TextBaseline.alphabetic,
+  Widget _buildNote(AppLocalizations l10n) {
+    return SizedBox(
+      height: 154,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: _surface.withValues(alpha: 0.9),
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(
+            color: _accent.withValues(alpha: 0.2),
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 18, 16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                percent,
-                style: const TextStyle(
-                  color: _textPrimary,
-                  fontSize: 36,
-                  fontWeight: FontWeight.w800,
-                  height: 1.0,
+              Container(
+                width: 3,
+                height: 38,
+                decoration: BoxDecoration(
+                  color: _accent,
+                  borderRadius: BorderRadius.circular(2),
                 ),
               ),
-              const Text(
-                '%',
-                style: TextStyle(
-                  color: _textSecondary,
-                  fontSize: 18,
-                  fontWeight: FontWeight.w600,
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      l10n.shareNoteHeading,
+                      style: BLabTypography.caption.copyWith(
+                        color: _inkSoft,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                        letterSpacing: 0.6,
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    Expanded(
+                      child: Text(
+                        _resolvedNoteText!,
+                        maxLines: 5,
+                        overflow: TextOverflow.ellipsis,
+                        style: BLabTypography.label.copyWith(
+                          color: _inkMuted,
+                          fontSize: 13.5,
+                          height: 1.45,
+                          fontStyle: FontStyle.italic,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 12),
-          _buildGradientProgressBar(progress),
-          const SizedBox(height: 8),
-          Text(
-            '${book.currentPage} / ${book.totalPages}p',
-            style: const TextStyle(color: _textTertiary, fontSize: 12),
-          ),
-        ],
+        ),
       ),
     );
   }
 
-  Widget _buildGradientProgressBar(double progress) {
+  Widget _buildReadingProgress(AppLocalizations l10n) {
+    final progress = book.totalPages > 0
+        ? (book.currentPage / book.totalPages).clamp(0.0, 1.0)
+        : 0.0;
+    final percent = (progress * 100).round();
+    final remainingPages = math.max(book.totalPages - book.currentPage, 0);
+    final today = DateTime.now();
+    final todayDate = DateTime(today.year, today.month, today.day);
+    final deadlineDate = DateTime(
+      book.targetDate.year,
+      book.targetDate.month,
+      book.targetDate.day,
+    );
+    final daysUntilDeadline = deadlineDate.difference(todayDate).inDays;
+
     return SizedBox(
-      height: 8,
-      child: Stack(
-        children: [
-          Container(
-            decoration: BoxDecoration(
-              color: _dividerColor,
-              borderRadius: BorderRadius.circular(4),
-            ),
+      height: 146,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: _surface,
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 14, 24, 14),
+          child: Column(
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                textBaseline: TextBaseline.alphabetic,
+                children: [
+                  Text(
+                    '$percent',
+                    style: BLabTypography.title.copyWith(
+                      color: _ink,
+                      fontSize: 36,
+                      height: 1,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: -1,
+                    ),
+                  ),
+                  Text(
+                    '%',
+                    style: BLabTypography.title.copyWith(
+                      color: _inkMuted,
+                      fontSize: 18,
+                      height: 1,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              _buildProgressBar(progress),
+              const SizedBox(height: 9),
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      book.totalPages > 0
+                          ? l10n.shareCurrentPages(
+                              book.currentPage,
+                              book.totalPages,
+                            )
+                          : l10n.sharePages(book.currentPage),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: BLabTypography.caption.copyWith(
+                        color: _inkSoft,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Flexible(
+                    child: Text(
+                      l10n.shareDeadline(_formatLongDate(book.targetDate)),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.end,
+                      style: BLabTypography.caption.copyWith(
+                        color: daysUntilDeadline >= 0
+                            ? _inkMuted
+                            : BLabColors.errorLight,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const Spacer(),
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      l10n.shareRemainingPages(remainingPages),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: BLabTypography.caption.copyWith(
+                        color: _inkMuted,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Flexible(
+                    child: Text(
+                      daysUntilDeadline >= 0
+                          ? l10n.shareDaysLeft(daysUntilDeadline)
+                          : l10n.shareDaysOverdue(-daysUntilDeadline),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.end,
+                      style: BLabTypography.caption.copyWith(
+                        color: daysUntilDeadline >= 0
+                            ? _inkMuted
+                            : BLabColors.errorLight,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
           ),
-          FractionallySizedBox(
-            widthFactor: progress,
-            child: Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(4),
-                gradient: const LinearGradient(
-                  colors: [BLabColors.primary, Color(0xFF818CF8)],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildProgressBar(double progress) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(4),
+      child: SizedBox(
+        height: 8,
+        child: Stack(
+          children: [
+            const Positioned.fill(
+              child: ColoredBox(color: BLabColors.subtleDark),
+            ),
+            FractionallySizedBox(
+              widthFactor: progress,
+              child: const SizedBox.expand(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [BLabColors.primary, BLabColors.primaryLight],
+                    ),
+                  ),
                 ),
               ),
             ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildCompletedContent() {
-    final review = book.review ?? book.longReview;
-    return Column(
-      children: [
-        if (book.rating != null) ...[
-          _buildLargeStarRating(book.rating!),
-          const SizedBox(height: 12),
-        ],
-        if (review != null && review.trim().isNotEmpty)
-          _buildReviewSnippet(review.trim()),
-      ],
-    );
-  }
-
-  Widget _buildLargeStarRating(int rating) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: List.generate(5, (i) {
-        return Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 2),
-          child: Icon(
-            i < rating ? CupertinoIcons.star_fill : CupertinoIcons.star,
-            size: 22,
-            color: i < rating ? BLabColors.gold : _textTertiary,
-          ),
-        );
-      }),
-    );
-  }
-
-  Widget _buildReviewSnippet(String review) {
-    return Container(
-      padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        color: _surfaceColor,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: BLabColors.primary.withValues(alpha: 0.15),
+          ],
         ),
       ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Container(
-            width: 3,
-            height: 32,
-            decoration: BoxDecoration(
-              color: BLabColors.primary,
-              borderRadius: BorderRadius.circular(2),
-            ),
-          ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Text(
-              review,
-              style: const TextStyle(
-                color: _textSecondary,
-                fontSize: 13,
-                height: 1.5,
-                fontStyle: FontStyle.italic,
-              ),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-        ],
-      ),
     );
   }
 
-  Widget _buildMiniStats(AppLocalizations? l10n) {
+  Widget _buildMetadata(AppLocalizations l10n) {
     final stats = _buildStats(l10n);
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
+
+    return Wrap(
+      alignment: WrapAlignment.center,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      runSpacing: 4,
       children: stats.asMap().entries.map((entry) {
         final isLast = entry.key == stats.length - 1;
+        final stat = entry.value;
+
         return Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(entry.value.icon, style: const TextStyle(fontSize: 13)),
-            const SizedBox(width: 3),
+            Text(stat.icon, style: const TextStyle(fontSize: 13)),
+            const SizedBox(width: 4),
             Text(
-              entry.value.value,
-              style: const TextStyle(
-                color: _textSecondary,
+              stat.value,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: BLabTypography.label.copyWith(
+                color: _inkMuted,
                 fontSize: 12,
                 fontWeight: FontWeight.w500,
               ),
             ),
             if (!isLast) ...[
               const SizedBox(width: 8),
-              const Text(
+              Text(
                 '·',
-                style: TextStyle(color: _textTertiary, fontSize: 12),
+                style: BLabTypography.label.copyWith(
+                  color: _inkSoft,
+                  fontSize: 12,
+                ),
               ),
               const SizedBox(width: 8),
             ],
@@ -382,55 +502,76 @@ class BookShareCard extends StatelessWidget {
     );
   }
 
-  Widget _buildFooter(AppLocalizations? l10n) {
+  Widget _buildFooter(AppLocalizations l10n) {
     return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Row(
-          children: [
-            ClipRRect(
-              borderRadius: BorderRadius.circular(5),
-              child: Image.asset(
-                'assets/images/logo-bookgolas.png',
-                width: 22,
-                height: 22,
-                fit: BoxFit.cover,
-              ),
-            ),
-            const SizedBox(width: 7),
-            Text(
-              l10n?.shareBrandName ?? '북골라스',
-              style: const TextStyle(
-                color: _textSecondary,
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-                letterSpacing: 0.3,
-              ),
-            ),
-          ],
+        ClipRRect(
+          borderRadius: BorderRadius.circular(5),
+          child: Image.asset(
+            'assets/images/logo-bookgolas.png',
+            width: 22,
+            height: 22,
+            fit: BoxFit.cover,
+          ),
         ),
+        const SizedBox(width: 7),
         Text(
-          DateFormat('yyyy.MM.dd').format(DateTime.now()),
-          style: const TextStyle(color: _textTertiary, fontSize: 11),
+          l10n.shareBrandName,
+          style: BLabTypography.label.copyWith(
+            color: _inkMuted,
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0.3,
+          ),
+        ),
+        const Spacer(),
+        Text(
+          _formatLongDate(DateTime.now()),
+          style: BLabTypography.caption.copyWith(
+            color: _inkSoft,
+            fontSize: 11,
+          ),
         ),
       ],
     );
   }
 
-  List<_StatItem> _buildStats(AppLocalizations? l10n) {
+  bool get _hasNoteText => _resolvedNoteText != null;
+
+  String? get _resolvedNoteText {
+    final value = noteText?.trim();
+    if (value != null && value.isNotEmpty) return value;
+    if (!useBookReviewFallback) return null;
+    final review = book.review ?? book.longReview;
+    return review?.trim().isNotEmpty == true ? review!.trim() : null;
+  }
+
+  String _formatLongDate(DateTime date) {
+    return DateFormat('yyyy.MM.dd').format(date);
+  }
+
+  String _formatShortDate(DateTime date) {
+    return DateFormat('MM.dd').format(date);
+  }
+
+  String _keepKoreanWordsTogether(String value) {
+    return value.replaceAllMapped(
+      RegExp(r'[가-힣]{2,}'),
+      (match) => match.group(0)!.split('').join('\u2060'),
+    );
+  }
+
+  List<_StatItem> _buildStats(AppLocalizations l10n) {
     switch (book.status) {
       case 'reading':
         return [
           _StatItem(
             icon: '📅',
-            value: l10n?.shareStartedOn(
-                    DateFormat('MM.dd').format(book.startDate)) ??
-                '${DateFormat('MM.dd').format(book.startDate)} 시작',
+            value: l10n.shareStartedOn(_formatShortDate(book.startDate)),
           ),
           _StatItem(
             icon: '💡',
-            value: l10n?.shareHighlightCount(highlightCount) ??
-                '$highlightCount 기록',
+            value: l10n.shareHighlightCount(highlightCount),
           ),
         ];
       case 'completed':
@@ -440,81 +581,92 @@ class BookShareCard extends StatelessWidget {
         return [
           _StatItem(
             icon: '📅',
-            value: l10n?.shareCompletedInDays(readDays) ?? '$readDays일 완독',
+            value: l10n.shareCompletedInDays(readDays),
           ),
           _StatItem(
             icon: '📄',
-            value: book.totalPages > 0 ? '${book.totalPages}p' : '-',
+            value: book.totalPages > 0 ? l10n.sharePages(book.totalPages) : '-',
           ),
           _StatItem(
             icon: '💡',
-            value: l10n?.shareHighlightCount(highlightCount) ??
-                '$highlightCount 기록',
+            value: l10n.shareHighlightCount(highlightCount),
           ),
         ];
       case 'planned':
         return [
           _StatItem(
             icon: '📅',
-            value: DateFormat(
-              'MM.dd',
-            ).format(book.plannedStartDate ?? book.startDate),
+            value: l10n.sharePlannedStart(
+              _formatShortDate(book.plannedStartDate ?? book.startDate),
+            ),
           ),
           _StatItem(icon: '🏷️', value: book.genre ?? '-'),
           _StatItem(
             icon: '📄',
-            value: book.totalPages > 0 ? '${book.totalPages}p' : '-',
+            value: book.totalPages > 0 ? l10n.sharePages(book.totalPages) : '-',
           ),
         ];
       case 'will_retry':
         return [
-          _StatItem(icon: '🔁', value: '${book.attemptCount}번째 도전'),
+          _StatItem(
+            icon: '🔁',
+            value: l10n.shareRetryCount(book.attemptCount),
+          ),
           _StatItem(icon: '🏷️', value: book.genre ?? '-'),
           _StatItem(
             icon: '📄',
-            value: book.totalPages > 0 ? '${book.totalPages}p' : '-',
+            value: book.totalPages > 0 ? l10n.sharePages(book.totalPages) : '-',
           ),
         ];
       default:
         return [
-          _StatItem(icon: '📖', value: '${book.currentPage}p'),
-          _StatItem(icon: '📄', value: '${book.totalPages}p'),
-          _StatItem(icon: '💡', value: '$highlightCount 기록'),
+          _StatItem(
+            icon: '📖',
+            value: l10n.sharePages(book.currentPage),
+          ),
+          _StatItem(
+            icon: '📄',
+            value: l10n.sharePages(book.totalPages),
+          ),
+          _StatItem(
+            icon: '💡',
+            value: l10n.shareHighlightCount(highlightCount),
+          ),
         ];
     }
   }
 
-  _StatusConfig _statusConfig(AppLocalizations? l10n) {
+  _StatusConfig _statusConfig(AppLocalizations l10n) {
     switch (book.status) {
       case 'reading':
         return _StatusConfig(
-          label: l10n?.shareStatusReading ?? '독서 중',
+          label: l10n.shareStatusReading,
           icon: CupertinoIcons.book,
-          color: BLabColors.primary,
+          color: _accent,
         );
       case 'completed':
         return _StatusConfig(
-          label: l10n?.shareStatusCompleted ?? '완독',
+          label: l10n.shareStatusCompleted,
           icon: CupertinoIcons.checkmark_circle_fill,
           color: BLabColors.success,
         );
       case 'planned':
         return _StatusConfig(
-          label: l10n?.shareStatusPlanned ?? '읽을 예정',
+          label: l10n.shareStatusPlanned,
           icon: CupertinoIcons.bookmark_fill,
           color: BLabColors.warning,
         );
       case 'will_retry':
         return _StatusConfig(
-          label: l10n?.shareStatusWillRetry ?? '다시 도전',
+          label: l10n.shareStatusWillRetry,
           icon: CupertinoIcons.arrow_2_circlepath,
           color: BLabColors.purple,
         );
       default:
         return _StatusConfig(
-          label: l10n?.shareStatusReading ?? '독서 중',
+          label: l10n.shareStatusReading,
           icon: CupertinoIcons.book,
-          color: BLabColors.primary,
+          color: _accent,
         );
     }
   }
@@ -524,6 +676,7 @@ class _StatusConfig {
   final String label;
   final IconData icon;
   final Color color;
+
   const _StatusConfig({
     required this.label,
     required this.icon,
@@ -534,5 +687,9 @@ class _StatusConfig {
 class _StatItem {
   final String icon;
   final String value;
-  const _StatItem({required this.icon, required this.value});
+
+  const _StatItem({
+    required this.icon,
+    required this.value,
+  });
 }

--- a/app/lib/ui/book_detail/widgets/book_share_composer.dart
+++ b/app/lib/ui/book_detail/widgets/book_share_composer.dart
@@ -1,0 +1,351 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/core/theme/design_system.dart';
+import 'package:book_golas/ui/core/widgets/liquid_glass_button.dart';
+import 'package:book_golas/ui/core/widgets/liquid_glass_card.dart';
+import 'package:book_golas/ui/core/widgets/liquid_glass_text_field.dart';
+
+class BookShareNote {
+  final String id;
+  final String text;
+  final int? pageNumber;
+
+  const BookShareNote({
+    required this.id,
+    required this.text,
+    this.pageNumber,
+  });
+}
+
+class BookShareComposerResult {
+  final String? noteText;
+  final bool useBookReviewFallback;
+
+  const BookShareComposerResult({
+    this.noteText,
+    this.useBookReviewFallback = false,
+  });
+}
+
+Future<BookShareComposerResult?> showBookShareComposer({
+  required BuildContext context,
+  required Book book,
+  required List<BookShareNote> notes,
+}) {
+  return showModalBottomSheet<BookShareComposerResult>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    useSafeArea: true,
+    builder: (_) => _BookShareComposerSheet(book: book, notes: notes),
+  );
+}
+
+class _BookShareComposerSheet extends StatefulWidget {
+  final Book book;
+  final List<BookShareNote> notes;
+
+  const _BookShareComposerSheet({
+    required this.book,
+    required this.notes,
+  });
+
+  @override
+  State<_BookShareComposerSheet> createState() =>
+      _BookShareComposerSheetState();
+}
+
+class _BookShareComposerSheetState extends State<_BookShareComposerSheet> {
+  late final TextEditingController _noteController;
+  final Set<String> _selectedNoteIds = <String>{};
+  bool _isApplyingSelection = false;
+  bool _hasManualEdits = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedNoteIds.addAll(widget.notes.take(2).map((note) => note.id));
+    _noteController = TextEditingController(text: _selectedNotesText);
+    _noteController.addListener(_handleNoteTextChanged);
+  }
+
+  @override
+  void dispose() {
+    _noteController.removeListener(_handleNoteTextChanged);
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  String get _selectedNotesText {
+    return widget.notes
+        .where((note) => _selectedNoteIds.contains(note.id))
+        .map((note) => note.text.trim())
+        .where((text) => text.isNotEmpty)
+        .join('\n\n');
+  }
+
+  void _handleNoteTextChanged() {
+    if (!_isApplyingSelection) {
+      _hasManualEdits = true;
+    }
+  }
+
+  void _replaceNoteText(String text) {
+    _isApplyingSelection = true;
+    _noteController.value = TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+    _isApplyingSelection = false;
+  }
+
+  void _toggleNote(BookShareNote note) {
+    final wasSelected = _selectedNoteIds.contains(note.id);
+    setState(() {
+      if (wasSelected) {
+        _selectedNoteIds.remove(note.id);
+      } else {
+        _selectedNoteIds.add(note.id);
+      }
+
+      if (!_hasManualEdits) {
+        _replaceNoteText(_selectedNotesText);
+      } else if (!wasSelected) {
+        final selectedText = note.text.trim();
+        final currentText = _noteController.text.trimRight();
+        final paragraphs = currentText
+            .split('\n\n')
+            .map((text) => text.trim())
+            .where((text) => text.isNotEmpty);
+        if (selectedText.isNotEmpty && !paragraphs.contains(selectedText)) {
+          _replaceNoteText(
+            currentText.isEmpty
+                ? selectedText
+                : '$currentText\n\n$selectedText',
+          );
+        }
+      }
+    });
+  }
+
+  void _submit() {
+    final text = _noteController.text.trim();
+    Navigator.of(context).pop(
+      BookShareComposerResult(
+        noteText: text.isEmpty ? null : text,
+        useBookReviewFallback: false,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surfaceColor =
+        isDark ? BLabColors.surfaceDark : BLabColors.surfaceLight;
+    final textColor =
+        isDark ? BLabColors.textPrimaryDark : BLabColors.textPrimaryLight;
+    final secondaryColor =
+        isDark ? BLabColors.textSecondaryDark : BLabColors.textSecondaryLight;
+
+    return Container(
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.sizeOf(context).height * 0.88,
+      ),
+      padding: EdgeInsets.fromLTRB(
+        20,
+        16,
+        20,
+        20 + MediaQuery.viewInsetsOf(context).bottom,
+      ),
+      decoration: BoxDecoration(
+        color: surfaceColor,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: secondaryColor.withValues(alpha: 0.4),
+                borderRadius: BorderRadius.circular(4),
+              ),
+            ),
+          ),
+          const SizedBox(height: 18),
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  l10n.shareComposerTitle,
+                  style: BLabTypography.title.copyWith(
+                    color: textColor,
+                    fontSize: 20,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              IconButton(
+                tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
+                onPressed: () => Navigator.of(context).pop(),
+                icon: Icon(CupertinoIcons.xmark, color: secondaryColor),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            widget.book.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: BLabTypography.caption.copyWith(color: secondaryColor),
+          ),
+          const SizedBox(height: 18),
+          Text(
+            l10n.shareComposerNotesTitle,
+            style: BLabTypography.label.copyWith(
+              color: textColor,
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 10),
+          if (widget.notes.isEmpty)
+            BLabCard(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  Icon(CupertinoIcons.info, color: secondaryColor, size: 18),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      l10n.shareComposerNoNotes,
+                      style: BLabTypography.caption
+                          .copyWith(color: secondaryColor),
+                    ),
+                  ),
+                ],
+              ),
+            )
+          else
+            Flexible(
+              child: SingleChildScrollView(
+                child: Column(
+                  children: widget.notes.map(_buildNoteOption).toList(),
+                ),
+              ),
+            ),
+          const SizedBox(height: 16),
+          BLabTextField(
+            controller: _noteController,
+            label: l10n.shareComposerNoteLabel,
+            hintText: l10n.shareComposerNoteHint,
+            maxLines: 4,
+          ),
+          const SizedBox(height: 6),
+          Text(
+            l10n.shareComposerPreviewLimit,
+            style: BLabTypography.caption.copyWith(color: secondaryColor),
+          ),
+          const SizedBox(height: 16),
+          BLabButton(
+            text: l10n.shareComposerCreateButton,
+            icon: CupertinoIcons.share,
+            isFullWidth: true,
+            onPressed: _submit,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNoteOption(BookShareNote note) {
+    final l10n = AppLocalizations.of(context);
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final selected = _selectedNoteIds.contains(note.id);
+    final borderColor = selected
+        ? BLabColors.primary
+        : (isDark
+            ? BLabColors.textPrimaryDark.withValues(alpha: 0.12)
+            : BLabColors.textPrimaryLight.withValues(alpha: 0.1));
+    final textColor =
+        isDark ? BLabColors.textPrimaryDark : BLabColors.textPrimaryLight;
+    final secondaryColor = isDark
+        ? BLabColors.textPrimaryDark.withValues(alpha: 0.62)
+        : BLabColors.textPrimaryLight.withValues(alpha: 0.58);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Semantics(
+        container: true,
+        button: true,
+        toggled: selected,
+        label: note.text,
+        child: InkWell(
+          onTap: () => _toggleNote(note),
+          borderRadius: BorderRadius.circular(14),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 160),
+            padding: const EdgeInsets.all(14),
+            decoration: BoxDecoration(
+              color: selected
+                  ? BLabColors.primary.withValues(alpha: 0.12)
+                  : (isDark
+                      ? BLabColors.textPrimaryDark.withValues(alpha: 0.06)
+                      : BLabColors.textPrimaryLight.withValues(alpha: 0.04)),
+              borderRadius: BorderRadius.circular(14),
+              border:
+                  Border.all(color: borderColor, width: selected ? 1.3 : 0.7),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(
+                  selected
+                      ? CupertinoIcons.checkmark_circle_fill
+                      : CupertinoIcons.circle,
+                  color: selected ? BLabColors.primary : secondaryColor,
+                  size: 20,
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        note.text,
+                        maxLines: 3,
+                        overflow: TextOverflow.ellipsis,
+                        style: BLabTypography.label.copyWith(
+                          color: textColor,
+                          fontSize: 14,
+                          height: 1.4,
+                        ),
+                      ),
+                      if (note.pageNumber != null) ...[
+                        const SizedBox(height: 6),
+                        Text(
+                          l10n.shareComposerPage(note.pageNumber!),
+                          style: BLabTypography.caption.copyWith(
+                            color: secondaryColor,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ui/core/theme/app_typography.dart
+++ b/app/lib/ui/core/theme/app_typography.dart
@@ -1,5 +1,34 @@
 import 'package:flutter/material.dart';
 
+class BLabTypography {
+  BLabTypography._();
+
+  static const TextStyle title = TextStyle(
+    fontSize: 20,
+    height: 1.35,
+    letterSpacing: -0.2,
+    fontWeight: FontWeight.w600,
+  );
+
+  static const TextStyle bodyStrong = TextStyle(
+    fontSize: 16,
+    height: 1.5,
+    fontWeight: FontWeight.w600,
+  );
+
+  static const TextStyle label = TextStyle(
+    fontSize: 14,
+    height: 1.4,
+    fontWeight: FontWeight.w500,
+  );
+
+  static const TextStyle caption = TextStyle(
+    fontSize: 13,
+    height: 1.45,
+    fontWeight: FontWeight.w500,
+  );
+}
+
 class AppTypography {
   AppTypography._();
 

--- a/app/test/ui/book_detail/widgets/book_share_card_test.dart
+++ b/app/test/ui/book_detail/widgets/book_share_card_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -10,6 +11,10 @@ void main() {
     testWidgets('renders localized english share content', (
       WidgetTester tester,
     ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(500, 900);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPhysicalSize);
       final book = Book(
         id: 'book-1',
         title: 'Atomic Habits',
@@ -24,19 +29,41 @@ void main() {
       await tester.pumpWidget(
         _buildTestApp(
           locale: const Locale('en'),
-          child: BookShareCard(book: book, highlightCount: 7),
+          child: BookShareCard(
+            book: book,
+            highlightCount: 7,
+            noteText: 'Small habits compound into remarkable results.',
+          ),
         ),
       );
 
       expect(find.text('Reading'), findsOneWidget);
+      expect(find.text('50'), findsOneWidget);
+      expect(find.text('%'), findsOneWidget);
+      expect(find.text('Due 2026.03.31'), findsOneWidget);
+      expect(find.text('Notes from this book'), findsOneWidget);
+      expect(find.text('120p left'), findsOneWidget);
+      expect(find.textContaining('days overdue'), findsOneWidget);
       expect(find.text('Started 03.01'), findsOneWidget);
       expect(find.text('7 records'), findsOneWidget);
+      expect(
+        find.text('Small habits compound into remarkable results.'),
+        findsOneWidget,
+      );
       expect(find.text('Bookgolas'), findsOneWidget);
+      expect(
+        tester.getSize(find.byType(BookShareCard)),
+        const Size(BookShareCard.cardWidth, BookShareCard.cardHeight),
+      );
     });
 
     testWidgets('renders localized korean completion content', (
       WidgetTester tester,
     ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(500, 900);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPhysicalSize);
       final book = Book(
         id: 'book-2',
         title: '아주 작은 습관의 힘',
@@ -53,7 +80,11 @@ void main() {
       await tester.pumpWidget(
         _buildTestApp(
           locale: const Locale('ko'),
-          child: BookShareCard(book: book, highlightCount: 12),
+          child: BookShareCard(
+            book: book,
+            highlightCount: 12,
+            noteText: '작은 습관이 큰 변화를 만든다는 점이 인상적이었다.',
+          ),
         ),
       );
 
@@ -61,6 +92,143 @@ void main() {
       expect(find.text('5일 완독'), findsOneWidget);
       expect(find.text('12 기록'), findsOneWidget);
       expect(find.text('북골라스'), findsOneWidget);
+      expect(find.text('이 책에서 남긴 기록'), findsOneWidget);
+      expect(find.byIcon(CupertinoIcons.star_fill), findsNothing);
+    });
+
+    testWidgets('pluralizes singular english share metadata', (
+      WidgetTester tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(500, 900);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPhysicalSize);
+      final book = Book(
+        id: 'book-singular',
+        title: 'Deep Work',
+        startDate: DateTime(2026, 3, 1),
+        targetDate: DateTime(2026, 3, 31),
+        updatedAt: DateTime(2026, 3, 1),
+        totalPages: 304,
+        status: BookStatus.completed.value,
+      );
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          locale: const Locale('en'),
+          child: BookShareCard(book: book, highlightCount: 1),
+        ),
+      );
+
+      expect(find.text('Finished in 1 day'), findsOneWidget);
+      expect(find.text('1 record'), findsOneWidget);
+    });
+
+    testWidgets('omits the note panel when a reading share has no note', (
+      WidgetTester tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(500, 900);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPhysicalSize);
+      final book = Book(
+        id: 'book-no-note',
+        title: 'Deep Work',
+        startDate: DateTime(2026, 3, 1),
+        targetDate: DateTime(2026, 3, 31),
+        currentPage: 12,
+        totalPages: 320,
+        status: BookStatus.reading.value,
+      );
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          locale: const Locale('en'),
+          child: BookShareCard(book: book),
+        ),
+      );
+
+      expect(find.text('Notes from this book'), findsNothing);
+      expect(find.text('4'), findsOneWidget);
+      expect(find.text('%'), findsOneWidget);
+      expect(find.text('12 / 320p'), findsOneWidget);
+    });
+
+    testWidgets('honors an explicit empty note instead of restoring a review', (
+      WidgetTester tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(500, 900);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPhysicalSize);
+      final book = Book(
+        id: 'book-empty-note',
+        title: 'Essentialism',
+        startDate: DateTime(2026, 3, 1),
+        targetDate: DateTime(2026, 3, 31),
+        currentPage: 80,
+        totalPages: 240,
+        status: BookStatus.reading.value,
+        review: 'This review should not be reinserted.',
+      );
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          locale: const Locale('en'),
+          child: BookShareCard(
+            book: book,
+            useBookReviewFallback: false,
+          ),
+        ),
+      );
+
+      expect(find.text('Notes from this book'), findsNothing);
+      expect(find.text('This review should not be reinserted.'), findsNothing);
+    });
+
+    testWidgets('renders localized planned and retry metadata', (
+      WidgetTester tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(500, 900);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPhysicalSize);
+      final plannedBook = Book(
+        id: 'planned-book',
+        title: 'The Creative Act',
+        author: 'Rick Rubin',
+        startDate: DateTime(2026, 4, 1),
+        targetDate: DateTime(2026, 5, 1),
+        plannedStartDate: DateTime(2026, 4, 1),
+        totalPages: 300,
+        genre: 'Creativity',
+        status: BookStatus.planned.value,
+      );
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          locale: const Locale('en'),
+          child: BookShareCard(book: plannedBook),
+        ),
+      );
+
+      expect(find.text('Starts 04.01'), findsOneWidget);
+      expect(find.text('Creativity'), findsOneWidget);
+      expect(find.text('300p'), findsOneWidget);
+      expect(find.text('📅'), findsOneWidget);
+      expect(find.text('🏷️'), findsOneWidget);
+
+      final retryBook = plannedBook.copyWith(
+        status: BookStatus.willRetry.value,
+        attemptCount: 2,
+      );
+      await tester.pumpWidget(
+        _buildTestApp(
+          locale: const Locale('en'),
+          child: BookShareCard(book: retryBook),
+        ),
+      );
+      expect(find.text('Attempt 2'), findsOneWidget);
     });
   });
 }

--- a/app/test/ui/book_detail/widgets/book_share_composer_test.dart
+++ b/app/test/ui/book_detail/widgets/book_share_composer_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_detail/widgets/book_share_composer.dart';
+
+void main() {
+  testWidgets('merges selected notes and returns editable share text', (
+    WidgetTester tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(500, 900);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+    BookShareComposerResult? result;
+    final book = Book(
+      id: 'book-1',
+      title: 'Atomic Habits',
+      startDate: DateTime(2026, 3, 1),
+      targetDate: DateTime(2026, 3, 31),
+      totalPages: 240,
+      status: BookStatus.reading.value,
+    );
+    final notes = [
+      const BookShareNote(id: 'note-1', text: '첫 번째 기록', pageNumber: 12),
+      const BookShareNote(id: 'note-2', text: '두 번째 기록', pageNumber: 44),
+      const BookShareNote(id: 'note-3', text: '세 번째 기록', pageNumber: 88),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('ko'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () async {
+                  result = await showBookShareComposer(
+                    context: context,
+                    book: book,
+                    notes: notes,
+                  );
+                },
+                child: const Text('open'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('공유 카드 꾸미기'), findsOneWidget);
+    var textField = tester.widget<TextField>(find.byType(TextField).last);
+    expect(textField.controller!.text, '첫 번째 기록\n\n두 번째 기록');
+
+    await tester.tap(find.text('세 번째 기록'));
+    await tester.pump();
+    textField = tester.widget<TextField>(find.byType(TextField).last);
+    expect(
+      textField.controller!.text,
+      '첫 번째 기록\n\n두 번째 기록\n\n세 번째 기록',
+    );
+
+    await tester.enterText(find.byType(TextField).last, '직접 다듬은 문장');
+    await tester.tap(find.text('세 번째 기록'));
+    await tester.pump();
+    textField = tester.widget<TextField>(find.byType(TextField).last);
+    expect(textField.controller!.text, '직접 다듬은 문장');
+
+    await tester.tap(find.text('세 번째 기록'));
+    await tester.pump();
+    textField = tester.widget<TextField>(find.byType(TextField).last);
+    expect(textField.controller!.text, '직접 다듬은 문장\n\n세 번째 기록');
+
+    await tester.tap(find.text('공유 이미지 만들기'));
+    await tester.pumpAndSettle();
+
+    expect(result?.noteText, '직접 다듬은 문장\n\n세 번째 기록');
+  });
+
+  testWidgets('keeps a large note list usable with large text', (
+    WidgetTester tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(500, 900);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+    final book = Book(
+      id: 'book-large',
+      title: 'Atomic Habits',
+      startDate: DateTime(2026, 3, 1),
+      targetDate: DateTime(2026, 3, 31),
+      totalPages: 240,
+      status: BookStatus.reading.value,
+    );
+    final notes = List.generate(
+      12,
+      (index) => BookShareNote(
+        id: 'note-$index',
+        text: '긴 독서 기록 ${index + 1} — 다음 행동을 더 분명하게 만든다.',
+        pageNumber: index + 1,
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('ko'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        builder: (context, child) {
+          return MediaQuery(
+            data: MediaQuery.of(context).copyWith(
+              textScaler: const TextScaler.linear(2),
+            ),
+            child: child!,
+          );
+        },
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () => showBookShareComposer(
+                  context: context,
+                  book: book,
+                  notes: notes,
+                ),
+                child: const Text('open'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('공유 카드 꾸미기'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('marks an intentionally empty note as a deliberate omission', (
+    WidgetTester tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(500, 900);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+    BookShareComposerResult? result;
+    final book = Book(
+      id: 'book-clear',
+      title: 'Essentialism',
+      startDate: DateTime(2026, 3, 1),
+      targetDate: DateTime(2026, 3, 31),
+      totalPages: 240,
+      status: BookStatus.reading.value,
+      review: 'Existing review must not return.',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return ElevatedButton(
+                onPressed: () async {
+                  result = await showBookShareComposer(
+                    context: context,
+                    book: book,
+                    notes: const [
+                      BookShareNote(id: 'note-1', text: 'A note'),
+                    ],
+                  );
+                },
+                child: const Text('open'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).last, '');
+    await tester.tap(find.text('Create share image'));
+    await tester.pumpAndSettle();
+
+    expect(result?.noteText, isNull);
+    expect(result?.useBookReviewFallback, isFalse);
+  });
+}

--- a/docs/design/book-share-card-art-direction.md
+++ b/docs/design/book-share-card-art-direction.md
@@ -1,0 +1,81 @@
+# Bookgolas 독서 현황 공유 카드 — 아트 디렉션 패킷
+
+## Surface job
+
+- Audience: 책을 읽으며 짧은 메모와 진도를 남기는 성인 독자
+- Moment: 한 권을 읽는 중 발견한 생각을 피드에 남기는 순간
+- Platforms: Instagram Stories, Threads, LinkedIn의 세로형 공유 이미지
+- Desired feeling: “이 책을 읽고 이런 생각을 했다”는 조용한 자부심과 호기심
+- User action: 이미지의 문장을 읽고 책과 기록 방식에 관심을 갖는다
+- Product relationship: Bookgolas는 광고 배너가 아니라 기록의 출처로만 작게 드러난다
+
+## Evidence and benchmarks
+
+| Reference | Useful signal | Deliberate rejection |
+| --- | --- | --- |
+| [Goodreads Year in Books](https://www.goodreads.com/book/show/208216246-goodreads-year-in-books-2024) | 공유를 유도하는 개인 성취 서사와 강한 한 문장 | 읽는 중인 책에 과한 축하·게임화는 맞지 않음 |
+| [Bookmory](https://bookmory.net/) | 진도, 시작일, 기록 수를 한눈에 보여주는 실용 정보 | 대시보드형 카드와 작은 지표 나열은 피함 |
+| [Bookshelf quote card](https://getbookshelf.com/) | 인용문을 중심으로 책과 저자를 편집물처럼 보여줌 | 배경 선택 UI처럼 보이는 장식적 커스터마이징은 제외 |
+
+## Three visual directions
+
+### A. Night bookmark — restored after owner visual review
+
+큰 표지를 세로 화면의 첫 장면으로 두고, 사용자의 노트를 편집 잡지의 pull
+quote로 강조한다. 깊은 잉크색 바탕, 밝은 활자, Blab blue 한 줄만 사용한다.
+
+- Composition: centered cover hero → status → title/author → quote panel →
+  progress panel → metadata
+- Type: 큰 제목보다 노트 문장이 먼저 읽히는 editorial hierarchy
+- Feeling: 몰입, 조용한 취향, 기록하는 사람의 관찰력
+- Share reason: “이 책에서 이런 생각을 했다”를 바로 전달
+
+상태별 의미는 텍스트와 아이콘으로 전달한다. 읽는 중은 Blab blue를 사용하고,
+완독·예정·재독 배지는 각 상태의 semantic color를 보조적으로 사용한다.
+
+### B. Margin note
+
+표지를 배경처럼 크게 깔고 한쪽 여백에 노트와 진행률을 주석처럼 배치한다.
+
+- Composition: full-bleed cover → translucent reading note → vertical progress
+- Feeling: 책의 여백에 직접 메모한 듯한 개인성
+- Rejected: 표지 이미지가 네트워크에서 늦게 오거나 긴 제목이 들어오면 가독성이
+  급격히 흔들리고, 콘텐츠보다 이미지 효과가 앞설 위험이 크다.
+
+### C. Reading receipt
+
+도서관 대출 영수증처럼 한 권의 읽기 기록을 시간·페이지·마감일로 정리한다.
+
+- Composition: receipt header → title → monospaced progress table → note footer
+- Feeling: 수집하고 축적하는 독서 습관
+- Rejected: 기능적이지만 독서자의 생각보다 관리 데이터가 주인공이 되며,
+  Bookgolas를 생산성 도구처럼 보이게 한다.
+
+## Selection rationale
+
+A안을 선택한다. 4:5 압축안은 피드 호환성은 높았지만 표지의 존재감과 독서
+기록의 여유가 줄어들었다. 소유자 시각 검토에 따라 이전 세로형 구도를 기준안으로
+복원하고, 이후에 추가된 노트 선택·직접 입력, 마감일, 남은 페이지와 남은 기간
+기능은 유지한다. B안은 표지 의존성이 크고, C안은 기능적이지만 현재 제품의
+독서 인사이트 서사와 거리가 있다.
+
+## Implementation contract
+
+- Canvas: 400×780 logical pixels, share export 1200×2340 at 3×
+- Safe area: 28 horizontal, 20 minimum vertical
+- Fixed export locale: render ko-KR and en-US separately; never mix labels
+- Real content: cover URL, title, author, selected notes, current/total pages,
+  deadline, start date, record count
+- Edge states: no cover, no note, long title, long note, overdue, completed,
+  planned, 2× text scaling
+- Brand: `북골라스`/`Bookgolas` only as a quiet source line; no CTA or ad copy
+- Accessibility: contrast-first typography, state icon + label, note selection
+  semantics in the composer
+
+## Open checks
+
+- [ ] selected direction rendered in ko-KR and en-US
+- [x] feed thumbnail and full-size visual check
+- [ ] 2× text scaling and long-title reflow check
+- [ ] independent conformance review
+- [ ] independent aesthetic/share-worthiness review

--- a/docs/design/book-share-card.md
+++ b/docs/design/book-share-card.md
@@ -1,0 +1,87 @@
+# Bookgolas 독서 현황 공유 카드 디자인
+
+## 디자인 판정
+
+상태: 초기 세로형 Night Bookmark 기준안 복원, 독립 디자인 게이트 검토 중
+
+상세 아트 디렉션과 대안 방향 비교는 [book-share-card-art-direction.md](book-share-card-art-direction.md)에 기록한다.
+
+목표는 앱을 모르는 독서자가 이미지를 2초 안에 이해하고, 기록의 내용에 관심을 가진 뒤 Bookgolas를 자연스럽게 발견하게 하는 것이다. 카드는 광고 배너가 아니라 개인 독서 기록의 편집물처럼 보여야 한다.
+
+## 독서자 관점의 정보 우선순위
+
+1. 이 책에서 무엇을 생각했는가 — 선택한 노트
+2. 어떤 책을 읽고 있는가 — 표지, 제목, 저자
+3. 어디까지 읽었는가 — 퍼센트, 진행 바, 현재/전체 페이지
+4. 언제까지 읽을 것인가 — 마감일과 남은 일수
+5. 어떤 기록을 쌓았는가 — 시작일과 기록 수
+6. 어디에서 기록했는가 — 최소한의 Bookgolas 브랜드 노출
+
+별점은 읽는 중 상태에서 의미가 없으므로 노출하지 않는다.
+
+## 레이아웃 계약
+
+- 기본 공유 비율: 400×780 세로 카드. 표지와 노트가 충분한 호흡을 갖는 초기
+  기준안을 유지하며, 피드 게시 시에는 플랫폼별 배경 여백 또는 크롭 미리보기를
+  확인한다.
+- 안전 여백: 모든 콘텐츠는 좌우 28dp, 상하 최소 20dp 안에 둔다.
+- 읽는 중 상태의 순서: 표지/상태 → 제목/저자 → 노트 → 진행률 → 시작일/기록 수 → 브랜드.
+- 노트는 최대 5줄을 우선 노출하고, 여러 기록을 합칠 때 문단 사이에 빈 줄을 유지한다.
+- 진행률은 숫자만으로 판단하지 않도록 퍼센트와 진행 바를 함께 제공한다.
+- 마감 초과는 경고 색상과 명시적인 기간 텍스트로 표현한다.
+
+## 시각 언어
+
+- `BLabColors.elevatedDark`에서 `scaffoldDark`로 이어지는 잉크색 배경으로
+  피드에서 표지와 노트의 존재감을 만든다.
+- Blab primary(`#5B7FFF`)는 진행 상태와 노트 인용부호를 위한 단일 강조색으로 사용한다.
+- 본문은 `BLabColors.textPrimaryDark`, 보조 정보는 `BLabColors.textSecondaryDark`와
+  `BLabColors.textTertiaryDark`로 위계를 만든다.
+- 기준안의 짧은 메타데이터에는 달력·전구 등 익숙한 이모지를 장식적으로
+  사용하되, 의미는 항상 현지화된 텍스트로 함께 전달한다.
+- 제목은 강한 대비의 한 단계, 메타 정보는 두 단계 낮은 대비, 보조 정보는 세 단계 낮은 대비로 구분한다.
+- 브랜드는 하단에 작게 배치하고, 별도 광고 문구나 다운로드 유도 문구는 넣지 않는다.
+
+## 상태·예외 계약
+
+- reading + note: 노트가 진행률보다 먼저 나온다.
+- reading + no note: 노트 패널을 생략하고 진행률을 먼저 보여준다.
+- total pages가 0: 퍼센트는 0%, 페이지 표기는 현재 페이지만 보여준다.
+- deadline이 지난 경우: `days overdue`/`일 지남`을 경고 색상으로 보여준다.
+- completed: 노트/리뷰를 핵심 기록으로 보여주고 별점은 표시하지 않는다.
+- 긴 제목·저자·노트: 제목 2줄, 저자 1줄, 노트 5줄에서 말줄임한다.
+- cover 오류/누락: 동일한 비율의 책 아이콘 플레이스홀더를 사용한다.
+
+## 접근성·현지화
+
+- 한국어와 영어 ARB에 모든 사용자 노출 문구를 함께 등록한다.
+- 색상만으로 상태를 구분하지 않고 상태 텍스트와 아이콘을 함께 사용한다.
+- 공유 이미지의 텍스트 대비를 우선하고, 원문 노트가 잘리지 않도록
+  선택/편집 단계에서 미리 안내한다. 외부 SNS에서의 대체 텍스트 입력은
+  게시 단계의 후속 접근성 과제로 남긴다.
+- 날짜, 페이지 단위, 남은 기간은 locale에 맞게 포맷한다.
+
+## 검증 체크
+
+- [x] 복원한 세로형 실제 렌더에서 표지·노트·진행률·브랜드가 모두 안전
+  영역에 들어온다. (실제 iPhone Simulator 캡처 PNG 1200×2340 확인)
+- [x] reading, no-note, completed, planned, retry, Korean, English의 문자열·상태 분기를 위젯 테스트로 검증했다. (시각 검증과 별도)
+- [x] 긴 콘텐츠에서 가로 overflow가 없는 composer 동작을 검증했다. (대형 텍스트·12개 노트 테스트 포함)
+- [x] 카드 캡처와 실제 share_plus 공유 파일의 비율이 일치한다.
+  (BookShareService의 3× 캡처 정책과 400×780 카드 비율 검증)
+- [ ] 2× 텍스트 스케일과 긴 제목 reflow를 실제 렌더로 확인한다.
+- [ ] 독립 디자인 conformance 리뷰를 통과한다.
+- [ ] 독립 aesthetic/share-worthiness 리뷰를 통과한다.
+
+최신 실기기 비율 렌더 증거:
+
+- `/Users/byungskersmacbook/.codex/visualizations/2026/07/25/019f96b9-0294-7082-9991-ec571545f852/book-share-card-restored-2026-07-26.png`
+- `/Users/byungskersmacbook/.codex/visualizations/2026/07/25/019f96b9-0294-7082-9991-ec571545f852/book-share-card-dark-editorial-final.png`
+- `/Users/byungskersmacbook/.codex/visualizations/2026/07/25/019f96b9-0294-7082-9991-ec571545f852/book-share-card-dark-editorial-thumbnail.png`
+
+이전 기준선 렌더:
+
+- `/Users/byungskersmacbook/.codex/visualizations/2026/07/25/019f96b9-0294-7082-9991-ec571545f852/book-share-card-editorial-ko.png`
+- `/Users/byungskersmacbook/.codex/visualizations/2026/07/25/019f96b9-0294-7082-9991-ec571545f852/book-share-card-editorial-en.png`
+- `/Users/byungskersmacbook/.codex/visualizations/2026/07/25/019f96b9-0294-7082-9991-ec571545f852/book-share-card-native-share.png`
+- `/Users/byungskersmacbook/.codex/visualizations/2026/07/25/019f96b9-0294-7082-9991-ec571545f852/book-share-native-share-sheet.png`


### PR DESCRIPTION
승인된 세로형 독서 현황 공유 카드 디자인을 복원하고 노트 선택·직접 편집 기능을 완성합니다.

## 📋 Changes

- 400×780 세로형 공유 카드와 표지·노트·진행률·마감 정보 복원
- 저장 노트 다중 선택, 문단 개행 유지, 직접 편집 기능 추가
- 공유 실패 처리와 한국어·영어 현지화 보강
- 위젯 테스트와 디자인 아트 디렉션 문서 추가

## 🧠 Context & Background

독서 중인 사용자가 자신의 생각과 현재 독서 상태를 자연스럽게 SNS에 공유할 수 있도록, 소유자가 승인한 이전 세로형 디자인을 기준안으로 확정했습니다.

## ✅ How to Test

1. 책 상세 화면에서 공유 버튼을 누릅니다.
2. 저장한 노트를 하나 이상 선택하거나 직접 편집합니다.
3. 생성된 이미지에서 표지, 노트, 진행률, 마감일, 남은 페이지와 기간을 확인합니다.
4. `flutter test test/ui/book_detail/widgets/book_share_card_test.dart test/ui/book_detail/widgets/book_share_composer_test.dart`
5. 관련 공유 카드 파일을 대상으로 `flutter analyze`를 실행합니다.

## 🧾 Screenshots or Videos (Optional)

- 실제 iOS 렌더를 소유자에게 공유해 시각 검토를 완료했습니다.

## 🔗 Related Issues

- Related: BYU-000

## 🙌 Additional Notes (Optional)

- 원격 배포 또는 App Store 출시는 이 PR 범위에 포함하지 않습니다.
- 작업 트리의 다른 미완료 변경은 이 커밋에 포함하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a share-card composer for selecting, editing, and previewing up to two book notes before sharing.
  * Redesigned book share cards with reading progress, deadlines, retry status, page counts, notes, and localized metadata.
  * Added English and Korean translations for the new sharing experience, including pluralized messages.
  * Share results now indicate whether sharing succeeded.

* **Bug Fixes**
  * Improved share-image positioning, rendering retries, and temporary-file cleanup.
  * Added safeguards for sharing when required rendering context is unavailable.

* **Tests**
  * Expanded coverage for composer interactions, localization, card layouts, notes, and reading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->