### PR TITLE
chore: bootstrap target-version governance

### DIFF
--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "allowed_actor_prefixes": [
+    "codex"
+  ],
+  "delivery_units": {
+    "governance": {
+      "profile": "package-or-local",
+      "mode": "continuous",
+      "active_versions": [
+        "1.0.0"
+      ],
+      "target_version_source": ".byungskerlab/release-lines.json",
+      "production_branch": "dev",
+      "work_bases": [
+        "dev",
+        "main"
+      ],
+      "allowed_paths": [
+        ".byungskerlab/branch-policy.json",
+        ".byungskerlab/release-lines.json",
+        ".github/CODEOWNERS",
+        ".github/PULL_REQUEST_TEMPLATE.md",
+        ".github/scripts/validate_target_version_pr.py",
+        ".github/workflows/target-version-gate.yml",
+        ".github/workflows/quality.yml",
+        ".github/workflows/schema-check.yml",
+        "AGENTS.md",
+        "docs/product-roadmap.md"
+      ]
+    },
+    "mobile": {
+      "profile": "mobile-store",
+      "mode": "version-line",
+      "active_versions": [
+        "1.0.2"
+      ],
+      "target_version_source": ".byungskerlab/release-lines.json",
+      "production_branch": "main",
+      "allowed_paths": [
+        ".byungskerlab/release.yaml",
+        ".env.example",
+        ".github/workflows/daily-nudge.yml",
+        ".github/workflows/ios-production.yml",
+        ".github/workflows/ios-testflight.yml",
+        "README.md",
+        "app/**",
+        "docs/**",
+        "supabase/**"
+      ],
+      "sync_bases": [
+        "dev",
+        "version/mobile/1.0.2"
+      ]
+    },
+    "web": {
+      "profile": "web-release-train",
+      "mode": "version-line",
+      "active_versions": [],
+      "target_version_source": ".byungskerlab/release-lines.json",
+      "production_branch": "main",
+      "allowed_paths": [
+        "docs/**",
+        "web/**"
+      ]
+    },
+    "backend": {
+      "profile": "backend-service",
+      "mode": "continuous",
+      "active_versions": [],
+      "target_version_source": ".byungskerlab/release-lines.json",
+      "production_branch": "main",
+      "allowed_paths": [
+        ".github/workflows/deploy-edge-functions.yml",
+        "docs/**",
+        "supabase/**"
+      ]
+    }
+  }
+}

--- a/.byungskerlab/release-lines.json
+++ b/.byungskerlab/release-lines.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "delivery_units": {
+    "governance": {
+      "active_versions": [
+        "1.0.0"
+      ],
+      "evidence_refs": [
+        ".byungskerlab/branch-policy.json"
+      ],
+      "promotion_sources": {
+        "release": {},
+        "hotfix": {}
+      }
+    },
+    "mobile": {
+      "active_versions": [
+        "1.0.2"
+      ],
+      "evidence_refs": [
+        "docs/product-roadmap.md",
+        "app/pubspec.yaml"
+      ],
+      "promotion_sources": {
+        "release": {},
+        "hotfix": {}
+      }
+    },
+    "web": {
+      "active_versions": [],
+      "evidence_refs": [],
+      "promotion_sources": {
+        "release": {},
+        "hotfix": {}
+      }
+    },
+    "backend": {
+      "active_versions": [],
+      "evidence_refs": [],
+      "promotion_sources": {
+        "release": {},
+        "hotfix": {}
+      }
+    }
+  }
+}

--- a/.byungskerlab/release-lines.json
+++ b/.byungskerlab/release-lines.json
@@ -18,8 +18,7 @@
         "1.0.2"
       ],
       "evidence_refs": [
-        "docs/product-roadmap.md",
-        "app/pubspec.yaml"
+        "docs/product-roadmap.md"
       ],
       "promotion_sources": {
         "release": {},

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+/.byungskerlab/branch-policy.json @byungsker
+/.byungskerlab/release-lines.json @byungsker
+/.github/CODEOWNERS @byungsker
+/.github/PULL_REQUEST_TEMPLATE.md @byungsker
+/.github/scripts/validate_target_version_pr.py @byungsker
+/.github/workflows/target-version-gate.yml @byungsker
+/AGENTS.md @byungsker

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+<!-- 아래 세 값은 브랜치, base, release source와 정확히 일치해야 합니다. -->
+Target-Delivery-Unit:
+Target-Version:
+Delivery-Profile:
+Promotion-Source-SHA:
+
 > 이번 PR의 목적을 한 문장으로 요약해주세요.
 
 ## 📋 Changes
@@ -12,6 +18,8 @@
 ## ✅ How to Test
 
 > 테스트 방법을 단계별로 작성해주세요.
+
+- [ ] 타깃 버전 원본, branch, base, PR metadata가 모두 일치한다.
 
 ## 🧾 Screenshots or Videos (Optional)
 

--- a/.github/scripts/validate_target_version_pr.py
+++ b/.github/scripts/validate_target_version_pr.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Fail-closed validation of branch, base, PR metadata, and active version."""
+
+from __future__ import annotations
+
+import base64
+import fnmatch
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+
+SEMVER = r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+WORK_RE = re.compile(
+    rf"^(?P<type>feature|fix|chore|refactor|docs|ci|migration|sync)/"
+    rf"(?P<unit>[a-z0-9][a-z0-9-]*)/(?P<version>{SEMVER})/"
+    r"(?P<scope>[A-Za-z0-9][A-Za-z0-9._-]*)$"
+)
+PROMOTION_RE = re.compile(
+    rf"^(?P<type>release|hotfix)/"
+    rf"(?P<unit>[a-z0-9][a-z0-9-]*)/(?P<version>{SEMVER})$"
+)
+METADATA_KEYS = (
+    "Target-Delivery-Unit",
+    "Target-Version",
+    "Delivery-Profile",
+)
+
+
+class PolicyError(ValueError):
+    pass
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    try:
+        config = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        raise PolicyError(f"cannot load policy config {path}: {exc}") from exc
+    if config.get("schema_version") != 1:
+        raise PolicyError("policy config schema_version must be 1")
+    if not isinstance(config.get("delivery_units"), dict):
+        raise PolicyError("policy config delivery_units must be an object")
+    return config
+
+
+def load_release_registry(path: Path) -> dict[str, Any]:
+    try:
+        registry = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as exc:
+        raise PolicyError(f"cannot load release registry {path}: {exc}") from exc
+    if registry.get("schema_version") != 1:
+        raise PolicyError("release registry schema_version must be 1")
+    if not isinstance(registry.get("delivery_units"), dict):
+        raise PolicyError("release registry delivery_units must be an object")
+    return registry
+
+
+def read_metadata(body: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for key in METADATA_KEYS:
+        values = re.findall(
+            rf"(?mi)^[ \t]*{re.escape(key)}[ \t]*:[ \t]*(\S.*?)[ \t]*$",
+            body,
+        )
+        if len(values) != 1:
+            raise PolicyError(
+                f"{key} must appear exactly once with a value; found {len(values)}"
+            )
+        result[key] = values[0].strip()
+    return result
+
+
+def read_changed_files(encoded: str) -> list[str]:
+    if not encoded:
+        raise PolicyError("missing changed-file evidence")
+    try:
+        files = json.loads(base64.b64decode(encoded, validate=True))
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise PolicyError("changed-file evidence is malformed") from exc
+    if not isinstance(files, list) or not files or not all(
+        isinstance(path, str) and path for path in files
+    ):
+        raise PolicyError("changed-file evidence must be a non-empty string array")
+    return files
+
+
+def single_metadata(body: str, key: str) -> str:
+    values = re.findall(
+        rf"(?mi)^[ \t]*{re.escape(key)}[ \t]*:[ \t]*(\S.*?)[ \t]*$",
+        body,
+    )
+    if len(values) != 1:
+        raise PolicyError(f"{key} must appear exactly once; found {len(values)}")
+    return values[0].strip()
+
+
+def validate(
+    config: dict[str, Any],
+    head: str,
+    base: str,
+    body: str,
+    changed_files: list[str],
+    release_registry: dict[str, Any],
+    ancestry_checker: Callable[[str], bool] | None = None,
+) -> str:
+    metadata = read_metadata(body)
+    for actor in config.get("allowed_actor_prefixes", ["codex"]):
+        marker = f"{actor}/"
+        if head.startswith(marker):
+            head = head[len(marker) :]
+            break
+
+    branch = WORK_RE.fullmatch(head)
+    promotion = PROMOTION_RE.fullmatch(head)
+    parsed = branch or promotion
+    if parsed is None:
+        raise PolicyError(
+            "head must be [codex/]<type>/<unit>/<x.y.z>/<scope> or "
+            "[codex/](release|hotfix)/<unit>/<x.y.z>"
+        )
+
+    branch_type = parsed.group("type")
+    unit = parsed.group("unit")
+    version = parsed.group("version")
+    policy = config["delivery_units"].get(unit)
+    if not isinstance(policy, dict):
+        raise PolicyError(f"unknown delivery unit: {unit}")
+    profile = policy.get("profile")
+    mode = policy.get("mode")
+    active = policy.get("active_versions")
+    version_source = policy.get("target_version_source")
+    if mode not in {"version-line", "continuous"}:
+        raise PolicyError(f"invalid mode for {unit}: {mode!r}")
+    if not isinstance(active, list) or version not in active:
+        raise PolicyError(
+            f"target version {version} is not active for {unit}; active={active!r}"
+        )
+    if (
+        not isinstance(version_source, str)
+        or not version_source.strip()
+        or version_source.lower().startswith("pending")
+    ):
+        raise PolicyError(
+            f"delivery unit {unit} has no authoritative target_version_source"
+        )
+    registry_unit = release_registry["delivery_units"].get(unit)
+    if not isinstance(registry_unit, dict):
+        raise PolicyError(f"release registry has no delivery unit {unit}")
+    registry_versions = registry_unit.get("active_versions")
+    if registry_versions != active:
+        raise PolicyError(
+            f"active version source mismatch for {unit}: "
+            f"policy={active!r}, registry={registry_versions!r}"
+        )
+    allowed_paths = policy.get("allowed_paths")
+    if not isinstance(allowed_paths, list) or not allowed_paths:
+        raise PolicyError(f"delivery unit {unit} has no allowed_paths policy")
+    invalid_paths = [
+        path
+        for path in changed_files
+        if path.startswith("/")
+        or ".." in Path(path).parts
+        or not any(fnmatch.fnmatchcase(path, pattern) for pattern in allowed_paths)
+    ]
+    if invalid_paths:
+        raise PolicyError(
+            f"changed paths are outside delivery unit {unit}: "
+            + ", ".join(invalid_paths[:5])
+        )
+
+    expected = {
+        "Target-Delivery-Unit": unit,
+        "Target-Version": version,
+        "Delivery-Profile": profile,
+    }
+    for key, value in expected.items():
+        if metadata[key] != value:
+            raise PolicyError(
+                f"{key} mismatch: observed {metadata[key]!r}, expected {value!r}"
+            )
+
+    production = policy.get("production_branch", "main")
+    if promotion:
+        promotion_sources = registry_unit.get("promotion_sources")
+        source = (
+            promotion_sources.get(branch_type, {}).get(version)
+            if isinstance(promotion_sources, dict)
+            else None
+        )
+        if not isinstance(source, dict):
+            raise PolicyError(
+                f"no approved {branch_type} promotion source for {unit} {version}"
+            )
+        source_branch = source.get("branch")
+        source_sha = source.get("sha")
+        if (
+            not isinstance(source_branch, str)
+            or not source_branch
+            or not isinstance(source_sha, str)
+            or re.fullmatch(r"[0-9a-f]{40}", source_sha) is None
+        ):
+            raise PolicyError(f"approved {branch_type} source is malformed")
+        observed_source_sha = single_metadata(body, "Promotion-Source-SHA")
+        if observed_source_sha != source_sha:
+            raise PolicyError(
+                "Promotion-Source-SHA mismatch: "
+                f"observed {observed_source_sha!r}, expected {source_sha!r}"
+            )
+        if ancestry_checker is None or not ancestry_checker(source_sha):
+            raise PolicyError(
+                f"promotion head is not a descendant of {source_branch} "
+                f"at {source_sha}"
+            )
+        if base != production:
+            raise PolicyError(
+                f"{branch_type} base mismatch: observed {base!r}, expected {production!r}"
+            )
+    elif branch_type == "sync":
+        allowed = policy.get("sync_bases", ["dev", f"version/{unit}/{version}"])
+        if base not in allowed:
+            raise PolicyError(
+                f"sync base mismatch: observed {base!r}, expected one of {allowed!r}"
+            )
+    elif mode == "continuous":
+        work_bases = policy.get("work_bases", [production])
+        if base not in work_bases:
+            raise PolicyError(
+                f"continuous base mismatch: observed {base!r}, "
+                f"expected one of {work_bases!r}"
+            )
+    else:
+        version_base = f"version/{unit}/{version}"
+        release_base = f"release/{unit}/{version}"
+        integration_prefix = f"integration/{unit}/{version}/"
+        allowed = base == version_base
+        allowed = allowed or (branch_type == "fix" and base == release_base)
+        allowed = allowed or base.startswith(integration_prefix)
+        if not allowed:
+            raise PolicyError(
+                f"version-line base mismatch: observed {base!r}, "
+                f"expected {version_base!r}"
+            )
+
+    return (
+        f"target-version gate passed: unit={unit} profile={profile} "
+        f"version={version}"
+    )
+
+
+def github_ancestry_checker(source_sha: str) -> bool:
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    head_sha = os.environ.get("PR_HEAD_SHA", "")
+    token = os.environ.get("GH_TOKEN", "")
+    if (
+        re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository) is None
+        or re.fullmatch(r"[0-9a-f]{40}", head_sha) is None
+        or not token
+    ):
+        return False
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repository}/compare/{source_sha}...{head_sha}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            payload = json.load(response)
+    except (OSError, ValueError):
+        return False
+    return (
+        payload.get("status") in {"ahead", "identical"}
+        and payload.get("merge_base_commit", {}).get("sha") == source_sha
+    )
+
+
+def main() -> int:
+    try:
+        config = load_config(Path(".byungskerlab/branch-policy.json"))
+        sources = {
+            unit.get("target_version_source")
+            for unit in config["delivery_units"].values()
+            if isinstance(unit, dict)
+        }
+        if len(sources) != 1:
+            raise PolicyError("all delivery units must use one release registry")
+        source_path = next(iter(sources))
+        if not isinstance(source_path, str):
+            raise PolicyError("release registry path is missing")
+        result = validate(
+            config,
+            os.environ["PR_HEAD_REF"],
+            os.environ["PR_BASE_REF"],
+            os.environ.get("PR_BODY", ""),
+            read_changed_files(os.environ.get("PR_CHANGED_FILES_B64", "")),
+            load_release_registry(Path(source_path)),
+            github_ancestry_checker,
+        )
+    except (KeyError, PolicyError) as exc:
+        print(f"target-version gate failed: {exc}", file=sys.stderr)
+        return 1
+    print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - main
       - dev
-      - 'daily/**'
+      - 'version/**'
+      - 'release/**'
 
 concurrency:
   group: quality-${{ github.event.pull_request.number }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -50,34 +50,15 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Detect web changes
-        id: web-changes
-        working-directory: .
-        run: |
-          if git diff --quiet \
-            "${{ github.event.pull_request.base.sha }}" \
-            "${{ github.event.pull_request.head.sha }}" \
-            -- web; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
       - uses: actions/setup-node@v4
-        if: steps.web-changes.outputs.changed == 'true'
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: web/package-lock.json
-      - if: steps.web-changes.outputs.changed == 'true'
-        run: npm ci
-      - if: steps.web-changes.outputs.changed == 'true'
-        run: npm audit --audit-level=high
-      - if: steps.web-changes.outputs.changed == 'true'
-        run: npm run lint
-      - if: steps.web-changes.outputs.changed == 'true'
-        run: npm run build
+      - run: npm ci
+      - run: npm audit --audit-level=high
+      - run: npm run lint
+      - run: npm run build
 
   edge-functions:
     name: Edge Function Type Check

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -50,15 +50,34 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect web changes
+        id: web-changes
+        working-directory: .
+        run: |
+          if git diff --quiet \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}" \
+            -- web; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/setup-node@v4
+        if: steps.web-changes.outputs.changed == 'true'
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: web/package-lock.json
-      - run: npm ci
-      - run: npm audit --audit-level=high
-      - run: npm run lint
-      - run: npm run build
+      - if: steps.web-changes.outputs.changed == 'true'
+        run: npm ci
+      - if: steps.web-changes.outputs.changed == 'true'
+        run: npm audit --audit-level=high
+      - if: steps.web-changes.outputs.changed == 'true'
+        run: npm run lint
+      - if: steps.web-changes.outputs.changed == 'true'
+        run: npm run build
 
   edge-functions:
     name: Edge Function Type Check

--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - main
       - dev
-      - 'daily/**'
+      - 'version/**'
+      - 'release/**'
     paths:
       - 'supabase/migrations/**'
       - 'supabase/functions/**'

--- a/.github/workflows/target-version-gate.yml
+++ b/.github/workflows/target-version-gate.yml
@@ -1,0 +1,48 @@
+name: Target Version Gate
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  target-version-contract:
+    name: Target Version Contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out trusted default-branch policy
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Read changed paths without checking out PR code
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          changed_files_b64="$(
+            gh api \
+              --paginate \
+              --slurp \
+              "repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" |
+              jq -c '[.[][] | .filename]' |
+              openssl base64 -A
+          )"
+          test -n "$changed_files_b64"
+          echo "PR_CHANGED_FILES_B64=$changed_files_b64" >> "$GITHUB_ENV"
+
+      - name: Validate target version, branch, base, and PR metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: python3 .github/scripts/validate_target_version_pr.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,10 +150,10 @@ UI (lib/ui/) → ViewModel → Repository → Service
   `.byungskerlab/release-lines.json`과 전역 Target Delivery Contract를
   따른다.
 - 기계 검증 가능한 활성 버전 원본은 `release-lines.json`이며, 현재
-  승인된 모바일 타깃 `1.0.2`의 근거는 `docs/product-roadmap.md`와
-  `app/pubspec.yaml`이다. 웹 또는 독립 backend는 승인된 다음 버전이
-  아직 없으므로 버전 원본과 active version을 먼저 갱신하기 전에는
-  브랜치나 PR을 만들 수 없다.
+  승인된 모바일 타깃 `1.0.2`의 근거는 `docs/product-roadmap.md`이다.
+  현재 앱 매니페스트 버전은 후속 모바일 작업에서 타깃 버전에 맞춘다.
+  웹 또는 독립 backend는 승인된 다음 버전이 아직 없으므로 버전 원본과
+  active version을 먼저 갱신하기 전에는 브랜치나 PR을 만들 수 없다.
 - active version을 여는 정책 변경은 byungsker 검토가 필요한
   `chore/governance/1.0.0/<scope>` PR로만 수행한다.
 - `daily/*`는 사용하지 않는다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,176 +132,70 @@ UI (lib/ui/) → ViewModel → Repository → Service
 
 ## Git Workflow
 
-### Branch Strategy
+브랜치 생성, PR, release/hotfix, 역반영과 브랜치 정리는 전역
+`engineering-team` 하네스의 `references/branch-strategy.md`를 따른다.
+이 문서에서는 Bookgolas의 배포 프로필과 저장소 고유 규칙만 정의한다.
 
-```
-main (Production)
- │
- └── dev (TestFlight)
-      │
-      └── daily/YYYY-MM-DD (일별 작업 그룹화 - 직접 커밋 금지!)
-           │
-           ├── feature/BYU-XXX-task-name (실제 작업 브랜치)
-           ├── feature/BYU-YYY-another-task
-           └── fix/BYU-ZZZ-bug-fix
-```
+### Delivery Profiles
 
-**브랜치 역할:**
+| Surface | Profile |
+| --- | --- |
+| `app/` iOS/Android 앱 | `mobile-store` |
+| `web/` Next.js Admin | `web-release-train` |
+| `supabase/` Functions 및 DB | 모바일 결합 시 `mobile-store`, 독립 배포 시 `backend-service` |
 
-| 브랜치 | 용도 | 직접 커밋 |
-|--------|------|----------|
-| `main` | Production 릴리즈 | ❌ 금지 |
-| `dev` | 개발 통합 브랜치 | ❌ 금지 |
-| `daily/YYYY-MM-DD` | 일별 작업 그룹화 (머지 타겟) | ❌ 금지 |
-| `feature/BYU-XXX-*` | **실제 코드 작업** | ✅ 허용 |
+### Repository-Specific Rules
 
-### Daily Workflow
-
-⚠️ **중요: `daily` 브랜치에 직접 커밋하지 마라. 반드시 `feature/BYU-XXX` 브랜치를 만들어서 작업해라.**
-
-```
-1. 작업 시작
-   ├── daily/YYYY-MM-DD 브랜치가 없으면 dev에서 생성
-   └── daily 브랜치에서 feature/BYU-XXX 브랜치 생성 ← 여기서 작업!
-
-2. 이슈별 작업 (각 이슈마다 반복)
-   ├── feature/BYU-XXX 브랜치에서 코드 작성 및 커밋
-   ├── 작업 완료 시 feature/BYU-XXX → daily PR 생성 및 머지
-   └── 다음 이슈는 daily에서 새로운 feature/BYU-YYY 브랜치 생성
-
-3. 일일 작업 완료
-   └── daily → dev PR 생성 → 머지 → TestFlight 자동 배포
-
-4. 버전 릴리즈
-   └── dev → main PR 생성 (버전 태그: v1.x.x) → 머지 → App Store 배포
-```
-
-### PR 생성 규칙 (CRITICAL - BLOCKING)
-
-**허용되는 PR 방향:**
-
-| From | To | 허용 |
-|------|-----|------|
-| `feature/BYU-XXX` | `daily/YYYY-MM-DD` | ✅ 허용 |
-| `daily/YYYY-MM-DD` | `dev` | ✅ 허용 |
-| `dev` | `main` | ✅ 허용 (릴리즈 시) |
-| `feature/BYU-XXX` | `dev` | ❌ **절대 금지** |
-| `feature/BYU-XXX` | `main` | ❌ **절대 금지** |
-| `daily/YYYY-MM-DD` | `main` | ❌ **절대 금지** |
-
-**daily 브랜치가 remote에 없을 때:**
-
-```bash
-# ❌ 잘못된 대응: dev에 직접 PR 생성
-gh pr create --base dev  # 절대 금지!
-
-# ✅ 올바른 대응: daily 브랜치 생성 후 push
-git checkout dev
-git pull origin dev
-git checkout -b daily/$(date +%Y-%m-%d)
-git push -u origin daily/$(date +%Y-%m-%d)
-# 그 후 feature → daily PR 생성
-```
-
-**PR 생성 전 필수 체크리스트:**
-
-1. [ ] `--base`가 `daily/YYYY-MM-DD` 형식인가? (feature PR의 경우)
-2. [ ] daily 브랜치가 remote에 존재하는가? 없으면 생성 먼저!
-3. [ ] `--base dev` 또는 `--base main`을 사용하고 있지 않은가?
-
-**위반 시 = BLOCKED. 작업 중단하고 올바른 절차로 재진행.**
-
-### 브랜치 생성 예시
-
-```bash
-# 1. daily 브랜치 생성 (없으면)
-git checkout dev
-git pull origin dev
-git checkout -b daily/2025-01-07
-
-# 2. 이슈 작업용 feature 브랜치 생성
-git checkout daily/2025-01-07
-git checkout -b feature/BYU-225-fix-network-error
-
-# 3. 작업 및 커밋 (feature 브랜치에서!)
-# ... 코드 작성 ...
-git add .
-git commit -m "fix: 네트워크 오류 수정 (BYU-225)"
-
-# 4. feature → daily PR 생성 및 머지
-git push origin feature/BYU-225-fix-network-error
-gh pr create --base daily/2025-01-07 --head feature/BYU-225-fix-network-error
-
-# 5. 다음 이슈는 daily에서 새 브랜치
-git checkout daily/2025-01-07
-git pull origin daily/2025-01-07
-git checkout -b feature/BYU-248-tab-cycling
-```
-
-### Commit Rules
-
-- 반드시 gh를 **byungsker** 계정으로 커밋, 푸시, PR을 진행해야해.
-- 커밋 메세지는 영문 컨벤셔널 커밋으로 해야해. (단, description은 한글 불릿 포인트로 작성.)
-- 맥락 별로 커밋을 만들며 진행해야해.
-
-### Merge Rules
-
-- PR 머지 시 반드시 **"Create a merge commit"** 방식으로 머지해라.
-- ❌ "Squash and merge" 사용 금지
-- ❌ "Rebase and merge" 사용 금지
-- `gh pr merge` 사용 시: `gh pr merge --merge` (기본값이 merge commit)
-
-### PR Template
-
-PR 생성 시 아래 템플릿을 사용해. (인용문은 지우고 해당 내용을 작성)
-
-```markdown
-> 이번 PR의 목적을 한 문장으로 요약해주세요.
->
-> - 예: 사용자가 프로필 정보를 수정할 수 있는 기능을 추가했습니다.
-
-## 📋 Changes
-
-> 주요 변경사항을 bullet로 정리해주세요.
->
-> - 예:
->   - `UserProfileEdit.tsx` 컴포넌트 추가
->   - `/api/user/profile` PUT 엔드포인트 연결
->   - Validation 로직 추가
-
-## 🧠 Context & Background
-
-> 이 변경이 필요한 이유를 설명해주세요.
-> 관련된 이슈나 문서 링크를 첨부해도 좋아요.
->
-> - 예: 유저 피드백에 따라 프로필 수정 기능이 필요했습니다. (#45)
-
-## ✅ How to Test
-
-> 테스트 방법을 단계별로 작성해주세요.
->
-> - 예:
->   1. `/profile/edit` 페이지로 이동
->   2. 이름 수정 후 저장 클릭
->   3. 수정 내용이 DB에 반영되는지 확인
-
-## 🧾 Screenshots or Videos (Optional)
-
-> UI 변경이 있을 경우, Before / After 이미지를 첨부해주세요.
-> 또는 Loom, GitHub Video를 추가해도 좋아요.
-
-## 🔗 Related Issues
-
-> 연관된 이슈를 연결해주세요.
->
-> - 예:
->   - Closes: #123
->   - Related: #456
-
-## 🙌 Additional Notes (Optional)
-
-> 기타 참고사항, TODO, 리뷰어에게 요청사항 등을 작성해주세요. - 예: 스타일 관련 부분은 별도 PR로 분리 예정입니다.
-```
+- 모든 브랜치와 PR은 `.byungskerlab/branch-policy.json`,
+  `.byungskerlab/release-lines.json`과 전역 Target Delivery Contract를
+  따른다.
+- 기계 검증 가능한 활성 버전 원본은 `release-lines.json`이며, 현재
+  승인된 모바일 타깃 `1.0.2`의 근거는 `docs/product-roadmap.md`와
+  `app/pubspec.yaml`이다. 웹 또는 독립 backend는 승인된 다음 버전이
+  아직 없으므로 버전 원본과 active version을 먼저 갱신하기 전에는
+  브랜치나 PR을 만들 수 없다.
+- active version을 여는 정책 변경은 byungsker 검토가 필요한
+  `chore/governance/1.0.0/<scope>` PR로만 수행한다.
+- `daily/*`는 사용하지 않는다.
+- 모바일 작업과 모바일에 결합된 backend 작업은 승인된 `dev`에서 연
+  `version/mobile/x.y.z`에서 분기하고 같은 version line으로 PR한다.
+- `web/`은 승인된 버전마다 운영 `main`에서
+  `version/web/x.y.z`를 열고 같은 버전 작업만 받은 뒤
+  `release/web/x.y.z` QA를 거쳐 `main`으로 승격한다.
+- 현재 `ios-testflight.yml`과 `ios-production.yml`이 Supabase migration과
+  Functions 배포를 함께 수행한다. 이 결합을 제거하기 전까지 자동
+  Supabase 배포는 `mobile-store` 흐름을 따른다.
+- Functions만 독립 배포할 때는 검증된 커밋과 명시적 배포 권한을
+  확인하고 수동 `deploy-edge-functions.yml`을 사용한다.
+- `integration/<unit>/x.y.z/<purpose>`는 같은 버전의 여러 검토 완료
+  작업 조합 검증에만 사용하며 직접 커밋, 새 작업의 기반, promotion
+  source로 사용하지 않는다.
+- 작업 브랜치는
+  `[codex/]<type>/<delivery-unit>/<x.y.z>/<issue-or-scope>` 형식이다.
+- PR 본문에는 `Target-Delivery-Unit`, `Target-Version`,
+  `Delivery-Profile`을 정확히 한 번씩 기록한다.
+- release 또는 hotfix 승격 PR은 governance 변경으로
+  `.byungskerlab/release-lines.json`에 승인된 source branch와 정확한
+  40자리 source SHA를 먼저 등록한다. PR의 `Promotion-Source-SHA`가
+  registry 및 실제 commit ancestry와 일치하지 않으면 반려한다.
+- 브랜치·worktree·commit·push·PR 생성/수정/리뷰/승인/merge를 수행하는
+  모든 Engineering Team 에이전트가 타깃 버전을 독립 확인한다.
+- branch, base, PR metadata, issue, roadmap, policy config 중 하나라도
+  빠지거나 다르면 `REQUEST_CHANGES`로 반려하고 Git 작업을 진행하지 않는다.
+- release 또는 hotfix source branch/SHA나 ancestry를 검증할 수 없어도
+  `REQUEST_CHANGES`로 반려한다.
+- `.github/workflows/target-version-gate.yml`은 이 규칙을 fail-closed로
+  검사한다. required check가 없거나 skipped/neutral/failing이면 merge
+  승인으로 간주하지 않는다.
+- 기존 비준수 활성 브랜치는 그대로 PR하지 않는다. 올바른 version
+  line에서 새 브랜치를 만들고 필요한 커밋만 안전하게 옮긴다.
+- 커밋 제목은 영문 Conventional Commit을 사용하고, 본문 설명은 한글
+  불릿으로 작성한다.
+- 이 저장소의 PR은 전역 기본값을 강화해 항상 merge commit으로
+  병합한다. squash와 rebase merge는 사용하지 않는다.
+- PR 설명에는 목적, 주요 변경, 배경, 검증 방법과 관련 이슈를 포함한다.
+- 브랜치 생성, 커밋, push, PR, merge, tag, 출시와 배포는 각각 사용자
+  권한 범위 안에서만 수행한다.
 
 ## Critical Rules
 
@@ -443,15 +337,17 @@ supabase functions deploy <function-name>
 supabase secrets set OPENAI_API_KEY=sk-...
 ```
 
-### Deployment Flow
+### Environment Promotion
 
-```
-1. 로컬 개발 → supabase-dev 프로젝트
-2. feature → daily → dev 머지 → TestFlight (supabase-dev)
-3. dev → main 머지 → Production (supabase prod) ← CI가 prod 환경변수 주입
-```
-
-**WARNING**: Production Supabase에 직접 migration이나 function 배포하지 마라. main 브랜치 CI를 통해서만 배포해라.
+- 로컬 개발은 `supabase-dev`만 사용한다.
+- `dev`의 iOS TestFlight 워크플로는 Dev migration과 Functions 배포를
+  함께 수행한다.
+- `main`의 iOS Production 워크플로는 Production migration과 Functions
+  배포를 App Store 빌드와 함께 수행한다.
+- Functions 단독 배포는 수동 워크플로를 사용하며 Production 대상은
+  별도 명시적 권한이 필요하다.
+- Production Supabase에 로컬에서 직접 migration이나 Functions를
+  배포하지 않는다.
 
 ### Database Migration Guidelines (CRITICAL)
 
@@ -485,26 +381,12 @@ supabase migration new add_user_preferences
 
 #### Migration Workflow
 
-```
-1. 마이그레이션 파일 생성 (CLI 필수!)
-   └── supabase migration new add_new_column
-   └── 생성된 파일: supabase/migrations/20260125123456_add_new_column.sql
-
-2. SQL 작성
-   └── 생성된 파일에 SQL 작성
-
-3. Dev DB에 적용 (로컬에서)
-   └── supabase link --project-ref reoiqefoymdsqzpbouxi
-   └── supabase db push
-
-4. 코드 작성 및 테스트
-
-5. feature → daily → dev 머지
-   └── CI가 자동으로 Dev DB에 마이그레이션 적용 (이미 적용된 경우 스킵)
-
-6. dev → main 머지 (Production 배포)
-   └── CI가 자동으로 Prod DB에 마이그레이션 적용
-```
+1. Supabase CLI로 migration 파일을 생성한다.
+2. SQL을 작성하고 Dev DB에서 적용·검증한다.
+3. 코드와 migration 검사를 함께 통과시킨다.
+4. 위 Git Workflow와 현재 CI 결합 규칙에 따라 동일한 검증 변경을
+   승격한다.
+5. Production 적용은 CI와 사용자 승인 경계를 거친다.
 
 #### MCP 대안: 읽기 전용 사용
 

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -1,0 +1,61 @@
+# Bookgolas Product Roadmap
+
+Last updated: 2026-07-25
+
+## Priority order
+
+Bookgolas follows this release order:
+
+1. Ship the next patch release: **1.0.2**.
+2. Prepare and validate the Android / Google Play release.
+3. Publish the Android release to Google Play after the test and policy gates pass.
+
+## P0 — 1.0.2 patch release
+
+The existing [1.0.2 release plan](./guides/release-1.0.2-plan.md) remains the
+source of truth for the patch scope and release blockers. The patch is not
+complete until the outstanding stability, privacy, metadata, and platform
+verification items are closed with evidence.
+
+Exit gate:
+
+- iOS and Android behavior is verified for the supported feature matrix.
+- The release build is reproducible and signed through the approved release
+  path.
+- Store metadata, privacy disclosures, review notes, and release evidence match
+  the shipped binary.
+- byungsker explicitly approves the external release action.
+
+## P1 — Android / Google Play readiness
+
+- Confirm `com.bookgolas.app` as the Android application ID and register it in
+  the authorized Google Play account.
+- Verify Firebase Android configuration, release keystore ownership, and
+  secret-safe CI or local build configuration.
+- Produce and inspect a signed Android App Bundle (`.aab`).
+- Run Android device and regression checks, including the camera flow called out
+  in the 1.0.2 release audit.
+- Prepare Google Play store listing, privacy policy, Data safety, content
+  declarations, screenshots, and reviewer access instructions.
+
+Readiness gate: no Google Play public release is attempted while package
+identity, signing, Android runtime behavior, or policy metadata remains
+unverified.
+
+## P2 — Google Play launch
+
+- Upload the signed AAB to internal testing.
+- Move to closed testing when the internal smoke test passes.
+- Complete any Google Play account-specific tester and production-access
+  requirements.
+- Submit the production release for review only after the launch packet is
+  complete and byungsker gives explicit publication authority.
+- Verify the public listing, install, sign-in, core reading flow, analytics,
+  support entrypoint, and rollback/hold criteria after approval.
+
+## Current evidence and unknowns
+
+- iOS release state is connected in the Company Control Plane.
+- Google Play public listing is not yet connected or released.
+- Android signing readiness, Play Console app registration, and final Android
+  runtime evidence require verification during P1.


### PR DESCRIPTION
Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local

## 목적

북골라스의 `daily/*` 흐름을 버전 라인 전략으로 교체하고, 잘못된 타겟
버전·전달 단위·브랜치·PR metadata를 자동 반려합니다.

## 주요 변경

- 모바일 활성 버전 `1.0.2`와 governance 버전 `1.0.0` 등록
- `daily/*` 대신 `version/*`와 `release/*`에 품질·스키마 검사 연결
- `pull_request_target` 기반 read-only `Target Version Contract` 추가
- CODEOWNERS와 PR metadata 계약 추가
- 모바일·웹·백엔드 프로파일과 release/hotfix ancestry 검증 문서화

## 검증

- 정책·release registry JSON 파싱
- GitHub Actions YAML 파싱
- 실제 PR 변경 파일 목록으로 governance validator 통과
- governance가 제품 코드를 포함하는 오류 케이스 반려 확인
- `git diff --check`
- Flutter Analyze and Test 통과
- Web Audit, Lint, and Build 통과
- Edge Function Type Check 통과
- Vercel 통과

## Bootstrap 주의

trusted workflow는 이 PR이 `dev`에 병합된 다음 PR부터 실행됩니다.
병합 후 `main`, `dev`와 version/release 브랜치 보호에
`Target Version Contract`를 required check로 연결해야 합니다.
