### PR TITLE
fix: move external API secrets behind authenticated proxies

### DIFF
--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.109.1
 
       - name: Link to Production Project
         run: |
@@ -38,13 +38,20 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
-      - name: Configure RevenueCat Webhook Secret
+      - name: Configure Edge Function Secrets
         run: |
           test -n "$REVENUECAT_WEBHOOK_AUTH_KEY"
-          supabase secrets set REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY"
+          test -n "$ALADIN_TTB_KEY"
+          test -n "$GOOGLE_CLOUD_VISION_API_KEY"
+          supabase secrets set \
+            REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY" \
+            ALADIN_TTB_KEY="$ALADIN_TTB_KEY" \
+            GOOGLE_CLOUD_VISION_API_KEY="$GOOGLE_CLOUD_VISION_API_KEY"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           REVENUECAT_WEBHOOK_AUTH_KEY: ${{ secrets.REVENUECAT_WEBHOOK_AUTH_KEY_PROD }}
+          ALADIN_TTB_KEY: ${{ secrets.ALADIN_TTB_KEY }}
+          GOOGLE_CLOUD_VISION_API_KEY: ${{ secrets.GOOGLE_CLOUD_VISION_API_KEY }}
 
       - name: Reconcile legacy production migration history
         run: |
@@ -177,16 +184,6 @@ jobs:
           cd app/ios
           bundle exec pod install --repo-update
 
-      - name: Create .env file
-        run: |
-          cd app
-          echo "ALADIN_TTB_KEY=${{ secrets.ALADIN_TTB_KEY }}" >> .env
-          echo "SUPABASE_URL_PROD=${{ secrets.SUPABASE_URL_PROD }}" >> .env
-          echo "SUPABASE_ANON_KEY_PROD=${{ secrets.SUPABASE_ANON_KEY_PROD }}" >> .env
-          echo "GOOGLE_CLOUD_VISION_API_KEY=${{ secrets.GOOGLE_CLOUD_VISION_API_KEY }}" >> .env
-          echo "REVENUECAT_PUBLIC_KEY=${{ secrets.REVENUECAT_PUBLIC_KEY }}" >> .env
-          echo "ENVIRONMENT=production" >> .env
-
       - name: Install Certificate
         env:
           CERTIFICATE_P12_BASE64: ${{ secrets.CERTIFICATE_P12_BASE64 }}
@@ -212,11 +209,27 @@ jobs:
       - name: Build Flutter iOS
         env:
           PAID_SUBSCRIPTIONS_ENABLED: ${{ vars.PAID_SUBSCRIPTIONS_ENABLED_PROD || 'false' }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL_PROD }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY_PROD }}
+          REVENUECAT_PUBLIC_KEY: ${{ secrets.REVENUECAT_PUBLIC_KEY }}
+          GOOGLE_SERVER_CLIENT_ID: ${{ secrets.GOOGLE_SERVER_CLIENT_ID }}
         run: |
           cd app
           BUILD_NAME=$(grep '^version:' pubspec.yaml | sed -E 's/version: ([0-9]+\.[0-9]+\.[0-9]+)\+.*/\1/')
           BUILD_NUMBER=$(( (${{ github.run_number }} + 135) * 100 + ${{ github.run_attempt }} ))
-          flutter build ios --flavor prod -t lib/main_prod.dart --release --no-codesign --build-name=$BUILD_NAME --build-number=$BUILD_NUMBER --dart-define=PAID_SUBSCRIPTIONS_ENABLED=$PAID_SUBSCRIPTIONS_ENABLED
+          flutter build ios \
+            --flavor prod \
+            -t lib/main_prod.dart \
+            --release \
+            --no-codesign \
+            --build-name="$BUILD_NAME" \
+            --build-number="$BUILD_NUMBER" \
+            --dart-define=PAID_SUBSCRIPTIONS_ENABLED="$PAID_SUBSCRIPTIONS_ENABLED" \
+            --dart-define=ENVIRONMENT=production \
+            --dart-define=SUPABASE_URL="$SUPABASE_URL" \
+            --dart-define=SUPABASE_ANON_KEY="$SUPABASE_ANON_KEY" \
+            --dart-define=REVENUECAT_PUBLIC_KEY="$REVENUECAT_PUBLIC_KEY" \
+            --dart-define=GOOGLE_SERVER_CLIENT_ID="$GOOGLE_SERVER_CLIENT_ID"
 
       - name: Build and Upload to App Store
         env:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - dev
+      - 'version/mobile/**'
+      - 'release/mobile/**'
     # web 전용 / 문서 전용 변경 시 iOS 빌드 트리거 안 함
     paths-ignore:
       - 'web/**'
@@ -25,7 +27,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.109.1
 
       - name: Link to Dev Project
         run: |
@@ -33,14 +35,21 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
-      - name: Configure RevenueCat Webhook Secret
+      - name: Configure Edge Function Secrets
         id: revenuecat-secret
         run: |
           test -n "$REVENUECAT_WEBHOOK_AUTH_KEY"
-          supabase secrets set REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY"
+          test -n "$ALADIN_TTB_KEY"
+          test -n "$GOOGLE_CLOUD_VISION_API_KEY"
+          supabase secrets set \
+            REVENUECAT_WEBHOOK_AUTH_KEY="$REVENUECAT_WEBHOOK_AUTH_KEY" \
+            ALADIN_TTB_KEY="$ALADIN_TTB_KEY" \
+            GOOGLE_CLOUD_VISION_API_KEY="$GOOGLE_CLOUD_VISION_API_KEY"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           REVENUECAT_WEBHOOK_AUTH_KEY: ${{ secrets.REVENUECAT_WEBHOOK_AUTH_KEY_DEV }}
+          ALADIN_TTB_KEY: ${{ secrets.ALADIN_TTB_KEY }}
+          GOOGLE_CLOUD_VISION_API_KEY: ${{ secrets.GOOGLE_CLOUD_VISION_API_KEY }}
 
       - name: Repair migration history (orphan remote migrations)
         run: |
@@ -166,16 +175,6 @@ jobs:
           cd app/ios
           bundle exec pod install --repo-update
 
-      - name: Create .env file
-        run: |
-          cd app
-          echo "ALADIN_TTB_KEY=${{ secrets.ALADIN_TTB_KEY }}" >> .env
-          echo "SUPABASE_URL_DEV=${{ secrets.SUPABASE_URL_DEV }}" >> .env
-          echo "SUPABASE_ANON_KEY_DEV=${{ secrets.SUPABASE_ANON_KEY_DEV }}" >> .env
-          echo "GOOGLE_CLOUD_VISION_API_KEY=${{ secrets.GOOGLE_CLOUD_VISION_API_KEY }}" >> .env
-          echo "REVENUECAT_PUBLIC_KEY=${{ secrets.REVENUECAT_PUBLIC_KEY }}" >> .env
-          echo "ENVIRONMENT=development" >> .env
-
       - name: Install Certificate and Provisioning Profiles
         id: install-cert
         env:
@@ -232,11 +231,27 @@ jobs:
       - name: Build Flutter iOS
         env:
           PAID_SUBSCRIPTIONS_ENABLED: ${{ vars.PAID_SUBSCRIPTIONS_ENABLED_DEV || 'false' }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL_DEV }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY_DEV }}
+          REVENUECAT_PUBLIC_KEY: ${{ secrets.REVENUECAT_PUBLIC_KEY }}
+          GOOGLE_SERVER_CLIENT_ID: ${{ secrets.GOOGLE_SERVER_CLIENT_ID }}
         run: |
           cd app
           BUILD_NAME=$(grep '^version:' pubspec.yaml | sed -E 's/version: ([0-9]+\.[0-9]+\.[0-9]+)\+.*/\1/')
           BUILD_NUMBER=$(( (${{ github.run_number }} + 135) * 100 + ${{ github.run_attempt }} ))
-          flutter build ios --flavor dev -t lib/main_dev.dart --release --no-codesign --build-name=$BUILD_NAME --build-number=$BUILD_NUMBER --dart-define=PAID_SUBSCRIPTIONS_ENABLED=$PAID_SUBSCRIPTIONS_ENABLED
+          flutter build ios \
+            --flavor dev \
+            -t lib/main_dev.dart \
+            --release \
+            --no-codesign \
+            --build-name="$BUILD_NAME" \
+            --build-number="$BUILD_NUMBER" \
+            --dart-define=PAID_SUBSCRIPTIONS_ENABLED="$PAID_SUBSCRIPTIONS_ENABLED" \
+            --dart-define=ENVIRONMENT=development \
+            --dart-define=SUPABASE_URL="$SUPABASE_URL" \
+            --dart-define=SUPABASE_ANON_KEY="$SUPABASE_ANON_KEY" \
+            --dart-define=REVENUECAT_PUBLIC_KEY="$REVENUECAT_PUBLIC_KEY" \
+            --dart-define=GOOGLE_SERVER_CLIENT_ID="$GOOGLE_SERVER_CLIENT_ID"
 
       - name: Build and Upload to TestFlight
         env:

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -140,6 +140,8 @@ PODS:
   - RevenueCat (5.55.2)
   - RevenueCatUI (5.55.2):
     - RevenueCat (= 5.55.2)
+  - share_plus (0.0.1):
+    - Flutter
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -174,6 +176,7 @@ DEPENDENCIES:
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - purchases_flutter (from `.symlinks/plugins/purchases_flutter/ios`)
   - purchases_ui_flutter (from `.symlinks/plugins/purchases_ui_flutter/ios`)
+  - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sign_in_with_apple (from `.symlinks/plugins/sign_in_with_apple/ios`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
@@ -241,6 +244,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/purchases_flutter/ios"
   purchases_ui_flutter:
     :path: ".symlinks/plugins/purchases_ui_flutter/ios"
+  share_plus:
+    :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sign_in_with_apple:
@@ -291,6 +296,7 @@ SPEC CHECKSUMS:
   PurchasesHybridCommonUI: ad685a661cc19fb45f1d7448f5890b399e177e14
   RevenueCat: b5605778017c179315e60b8921ed158b3428688c
   RevenueCatUI: ee8109669a5abf52df099788a0f961abdd2b5b09
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0

--- a/app/lib/config/app_config.dart
+++ b/app/lib/config/app_config.dart
@@ -1,70 +1,50 @@
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-
 class AppConfig {
-  static String get aladinApiKey => dotenv.env['ALADIN_TTB_KEY'] ?? '';
+  static const String _supabaseUrlOverride = String.fromEnvironment(
+    'SUPABASE_URL_OVERRIDE',
+  );
+  static const String environment = String.fromEnvironment(
+    'ENVIRONMENT',
+    defaultValue: 'development',
+  );
+  static const String _supabaseUrl = String.fromEnvironment('SUPABASE_URL');
+  static const String _supabaseAnonKey = String.fromEnvironment(
+    'SUPABASE_ANON_KEY',
+  );
+  static const String googleBooksApiKey = String.fromEnvironment(
+    'GOOGLE_BOOKS_API_KEY',
+  );
+  static const String revenueCatPublicKey = String.fromEnvironment(
+    'REVENUECAT_PUBLIC_KEY',
+  );
+  static const String googleServerClientId = String.fromEnvironment(
+    'GOOGLE_SERVER_CLIENT_ID',
+  );
+  static const String naverClientId = '';
+  static const String naverClientSecret = '';
 
-  static String get environment => dotenv.env['ENVIRONMENT'] ?? 'development';
-
-  static String get aladinBaseUrl =>
-      'http://www.aladin.co.kr/ttb/api/ItemSearch.aspx';
-
-  // Supabase 설정 (환경별 분기)
   static String get supabaseUrl {
-    if (isProduction) {
-      return dotenv.env['SUPABASE_URL_PROD'] ??
-          dotenv.env['SUPABASE_URL'] ??
-          'https://enyxrgxixrnoazzgqyyd.supabase.co';
+    if (_supabaseUrlOverride.isNotEmpty) {
+      return _supabaseUrlOverride;
     }
-    return dotenv.env['SUPABASE_URL_DEV'] ??
-        dotenv.env['SUPABASE_URL'] ??
-        'https://reoiqefoymdsqzpbouxi.supabase.co';
+    if (_supabaseUrl.isNotEmpty) {
+      return _supabaseUrl;
+    }
+    return isProduction
+        ? 'https://enyxrgxixrnoazzgqyyd.supabase.co'
+        : 'https://reoiqefoymdsqzpbouxi.supabase.co';
   }
 
-  static String get supabaseAnonKey {
-    if (isProduction) {
-      return dotenv.env['SUPABASE_ANON_KEY_PROD'] ??
-          dotenv.env['SUPABASE_ANON_KEY'] ??
-          '';
-    }
-    return dotenv.env['SUPABASE_ANON_KEY_DEV'] ??
-        dotenv.env['SUPABASE_ANON_KEY'] ??
-        '';
-  }
-
-  // Google Books API 설정
-  static String get googleBooksApiKey =>
-      dotenv.env['GOOGLE_BOOKS_API_KEY'] ?? '';
-
-  // Google Cloud Vision API 설정
-  static String get googleCloudVisionApiKey =>
-      dotenv.env['GOOGLE_CLOUD_VISION_API_KEY'] ?? '';
-
-  // Naver Books API 설정
-  static String get naverClientId => dotenv.env['NAVER_CLIENT_ID'] ?? '';
-  static String get naverClientSecret =>
-      dotenv.env['NAVER_CLIENT_SECRET'] ?? '';
-
-  // RevenueCat 설정
-  static String get revenueCatPublicKey =>
-      dotenv.env['REVENUECAT_PUBLIC_KEY'] ?? '';
-
+  static String get supabaseAnonKey => _supabaseAnonKey;
   static const int maxSearchResults = 10;
   static const String apiVersion = '20131101';
 
   static bool get isProduction => environment == 'production';
   static bool get isDevelopment => environment == 'development';
 
-  static void validateApiKeys() {
-    if (aladinApiKey.isEmpty) {
-      throw Exception(
-          'ALADIN_TTB_KEY is required but not found in environment variables');
-    }
+  static void validateRuntimeConfig() {
     if (supabaseAnonKey.isEmpty) {
       throw Exception(
           'SUPABASE_ANON_KEY is required but not properly configured');
     }
   }
-
-  static bool get hasGoogleCloudVisionApiKey =>
-      googleCloudVisionApiKey.isNotEmpty;
 }

--- a/app/lib/data/services/aladin_api_service.dart
+++ b/app/lib/data/services/aladin_api_service.dart
@@ -1,7 +1,5 @@
-import 'dart:convert';
-
 import 'package:flutter/foundation.dart';
-import 'package:http/http.dart' as http;
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:book_golas/config/app_config.dart';
 import 'package:book_golas/domain/models/book.dart';
@@ -9,10 +7,10 @@ import 'package:book_golas/ui/core/utils/isbn_validator.dart';
 import 'package:book_golas/utils/html_utils.dart';
 
 class AladinApiService {
+  static SupabaseClient get _supabase => Supabase.instance.client;
+
   static Future<List<BookSearchResult>> searchBooks(String query) async {
     if (query.trim().isEmpty) return [];
-
-    AppConfig.validateApiKeys();
 
     try {
       final cleanedQuery = IsbnValidator.cleanISBN(query);
@@ -21,81 +19,40 @@ class AladinApiService {
         return result != null ? [result] : [];
       }
 
-      final searchUri = Uri.parse(AppConfig.aladinBaseUrl).replace(
-        queryParameters: {
-          'ttbkey': AppConfig.aladinApiKey,
-          'Query': query,
-          'QueryType': 'Title',
-          'MaxResults': AppConfig.maxSearchResults.toString(),
-          'start': '1',
-          'SearchTarget': 'Book',
-          'output': 'js',
-          'Version': AppConfig.apiVersion,
-          'Cover': 'Big',
-        },
+      final data = await _invoke(
+        action: 'search',
+        query: query,
+        maxResults: AppConfig.maxSearchResults,
       );
+      final items = _items(data);
+      final books = <BookSearchResult>[];
 
-      final searchResponse = await http.get(searchUri);
-
-      if (searchResponse.statusCode == 200) {
-        final searchData = json.decode(searchResponse.body);
-        final List<dynamic> searchItems = searchData['item'] ?? [];
-
-        List<BookSearchResult> detailedBooks = [];
-
-        for (var item in searchItems.take(5)) {
-          final isbn13 = item['isbn13'];
-          if (isbn13 != null && isbn13.toString().isNotEmpty) {
-            final detailedBook = await lookupByISBN(isbn13.toString());
-            if (detailedBook != null) {
-              detailedBooks.add(detailedBook);
-            } else {
-              detailedBooks.add(BookSearchResult.fromJson(item));
-            }
-          } else {
-            detailedBooks.add(BookSearchResult.fromJson(item));
-          }
+      for (final item in items.take(5)) {
+        final isbn = item['isbn13']?.toString();
+        if (isbn != null && isbn.isNotEmpty) {
+          final detailed = await lookupByISBN(isbn);
+          books.add(detailed ?? BookSearchResult.fromJson(item));
+        } else {
+          books.add(BookSearchResult.fromJson(item));
         }
-
-        return detailedBooks;
-      } else {
-        throw Exception('Failed to load books: ${searchResponse.statusCode}');
       }
-    } catch (e) {
-      debugPrint('Error searching books: $e');
+
+      return books;
+    } catch (error) {
+      debugPrint('Error searching books: $error');
       return [];
     }
   }
 
   static Future<BookSearchResult?> lookupByISBN(String isbn) async {
     try {
-      final lookupUri =
-          Uri.parse('http://www.aladin.co.kr/ttb/api/ItemLookUp.aspx').replace(
-        queryParameters: {
-          'ttbkey': AppConfig.aladinApiKey,
-          'itemIdType': 'ISBN13',
-          'ItemId': isbn,
-          'output': 'js',
-          'Version': AppConfig.apiVersion,
-          'OptResult': 'ebookList,usedList,reviewList',
-          'Cover': 'Big',
-        },
-      );
-
-      final response = await http.get(lookupUri);
-
-      if (response.statusCode == 200) {
-        final jsonData = json.decode(response.body);
-
-        final List<dynamic> items = jsonData['item'] ?? [];
-        if (items.isNotEmpty) {
-          return BookSearchResult.fromJson(items[0]);
-        }
-      }
-    } catch (e) {
-      // 에러 발생 시 null 반환
+      final data = await _invoke(action: 'lookup', isbn: isbn);
+      final items = _items(data);
+      return items.isEmpty ? null : BookSearchResult.fromJson(items.first);
+    } catch (error) {
+      debugPrint('Failed to look up Aladin book: $error');
+      return null;
     }
-    return null;
   }
 
   static Future<BookSearchResult?> searchByTitle(
@@ -103,39 +60,109 @@ class AladinApiService {
     String? author,
   ) async {
     try {
-      AppConfig.validateApiKeys();
-
       final cleanTitle = _cleanTitle(title);
       final cleanAuthor = _cleanAuthor(author);
       final query =
-          cleanAuthor != null ? '$cleanTitle $cleanAuthor' : cleanTitle;
-
-      debugPrint('📕 [Aladin] searchByTitle query="$query"');
-
-      var result = await _searchAladin(query);
-
+          cleanAuthor == null ? cleanTitle : '$cleanTitle $cleanAuthor';
+      var result = await _searchFirst(query);
       if (result == null && cleanAuthor != null) {
-        debugPrint('📕 [Aladin] searchByTitle fallback: 제목만으로 재검색');
-        result = await _searchAladin(cleanTitle);
+        result = await _searchFirst(cleanTitle);
       }
-
       return result;
-    } catch (e) {
-      debugPrint('📕 [Aladin] searchByTitle ERROR: $e');
+    } catch (error) {
+      debugPrint('Failed to search Aladin title: $error');
+      return null;
     }
-    return null;
+  }
+
+  static Future<String?> fetchDescriptionByTitle(String title) async {
+    try {
+      final data = await _invoke(
+        action: 'search',
+        query: title,
+        maxResults: 1,
+      );
+      return _description(_items(data));
+    } catch (error) {
+      debugPrint('Failed to fetch Aladin description by title: $error');
+      return null;
+    }
+  }
+
+  static Future<String?> fetchDescription(String isbn13) async {
+    try {
+      final data = await _invoke(action: 'lookup', isbn: isbn13);
+      return _description(_items(data));
+    } catch (error) {
+      debugPrint('Failed to fetch Aladin description: $error');
+      return null;
+    }
+  }
+
+  static Future<BookSearchResult?> _searchFirst(String query) async {
+    final data = await _invoke(
+      action: 'search',
+      query: query,
+      maxResults: 1,
+    );
+    final items = _items(data);
+    if (items.isEmpty) return null;
+
+    final isbn = items.first['isbn13']?.toString();
+    if (isbn != null && isbn.isNotEmpty) {
+      final detailed = await lookupByISBN(isbn);
+      if (detailed != null) return detailed;
+    }
+    return BookSearchResult.fromJson(items.first);
+  }
+
+  static Future<Map<String, dynamic>> _invoke({
+    required String action,
+    String? query,
+    String? isbn,
+    int? maxResults,
+  }) async {
+    final response = await _supabase.functions.invoke(
+      'aladin-books',
+      body: {
+        'action': action,
+        if (query != null) 'query': query,
+        if (isbn != null) 'isbn': isbn,
+        if (maxResults != null) 'maxResults': maxResults,
+      },
+    );
+
+    if (response.status != 200 || response.data is! Map) {
+      throw StateError('Aladin proxy request failed');
+    }
+    return Map<String, dynamic>.from(response.data as Map);
+  }
+
+  static List<Map<String, dynamic>> _items(Map<String, dynamic> data) {
+    final rawItems = data['item'];
+    if (rawItems is! List) return [];
+    return rawItems
+        .whereType<Map>()
+        .map((item) => Map<String, dynamic>.from(item))
+        .toList();
+  }
+
+  static String? _description(List<Map<String, dynamic>> items) {
+    if (items.isEmpty) return null;
+    final description = items.first['description']?.toString();
+    if (description == null || description.isEmpty) return null;
+    return stripAndDecodeHtml(description);
   }
 
   static String _cleanTitle(String title) {
     var cleaned = title.split(' - ').first.trim();
     cleaned = cleaned.split(' : ').first.trim();
-    cleaned = cleaned.split('(').first.trim();
-    return cleaned;
+    return cleaned.split('(').first.trim();
   }
 
   static String? _cleanAuthor(String? author) {
     if (author == null || author.isEmpty) return null;
-    var cleaned = author
+    final cleaned = author
         .replaceAll(RegExp(r'\s*\(지은이\)'), '')
         .replaceAll(RegExp(r'\s*\(옮긴이\)'), '')
         .replaceAll(RegExp(r'\s*\(글\)'), '')
@@ -143,117 +170,10 @@ class AladinApiService {
         .replaceAll(RegExp(r'\s*\(저\)'), '')
         .replaceAll(RegExp(r'\s*\(역\)'), '')
         .replaceAll(RegExp(r'\s*\(편\)'), '')
+        .trim()
+        .split(',')
+        .first
         .trim();
-    final firstAuthor = cleaned.split(',').first.trim();
-    return firstAuthor.isEmpty ? null : firstAuthor;
-  }
-
-  static Future<BookSearchResult?> _searchAladin(String query) async {
-    final searchUri =
-        Uri.parse(AppConfig.aladinBaseUrl).replace(queryParameters: {
-      'ttbkey': AppConfig.aladinApiKey,
-      'Query': query,
-      'QueryType': 'Title',
-      'MaxResults': '1',
-      'start': '1',
-      'SearchTarget': 'Book',
-      'output': 'js',
-      'Version': AppConfig.apiVersion,
-      'Cover': 'Big',
-    });
-
-    final response = await http.get(searchUri).timeout(
-          const Duration(seconds: 5),
-        );
-
-    if (response.statusCode == 200) {
-      final data = json.decode(response.body);
-      final List<dynamic> items = data['item'] ?? [];
-      if (items.isNotEmpty) {
-        final isbn13 = items[0]['isbn13']?.toString();
-        if (isbn13 != null && isbn13.isNotEmpty) {
-          final detailed = await lookupByISBN(isbn13);
-          if (detailed != null) return detailed;
-        }
-        return BookSearchResult.fromJson(items[0]);
-      }
-    }
-    return null;
-  }
-
-  static Future<String?> fetchDescriptionByTitle(String title) async {
-    debugPrint('📕 [Aladin] fetchDescriptionByTitle title="$title"');
-    try {
-      final uri = Uri.parse(AppConfig.aladinBaseUrl).replace(
-        queryParameters: {
-          'ttbkey': AppConfig.aladinApiKey,
-          'Query': title,
-          'QueryType': 'Title',
-          'MaxResults': '1',
-          'start': '1',
-          'SearchTarget': 'Book',
-          'output': 'js',
-          'Version': AppConfig.apiVersion,
-        },
-      );
-
-      final response = await http.get(uri).timeout(const Duration(seconds: 5));
-      debugPrint('📕 [Aladin] title search status=${response.statusCode}');
-
-      if (response.statusCode == 200) {
-        final jsonData = json.decode(response.body);
-        final List<dynamic> items = jsonData['item'] ?? [];
-        debugPrint('📕 [Aladin] title search items=${items.length}');
-        if (items.isNotEmpty) {
-          final description = items[0]['description'] as String?;
-          debugPrint(
-            '📕 [Aladin] title search desc=${description != null ? "${description.length}자" : "null"}',
-          );
-          if (description != null && description.isNotEmpty) {
-            return stripAndDecodeHtml(description);
-          }
-        }
-      }
-    } catch (e) {
-      debugPrint('📕 [Aladin] title search ERROR: $e');
-    }
-    return null;
-  }
-
-  static Future<String?> fetchDescription(String isbn13) async {
-    debugPrint('📕 [Aladin] fetchDescription isbn=$isbn13');
-    try {
-      final uri =
-          Uri.parse('http://www.aladin.co.kr/ttb/api/ItemLookUp.aspx').replace(
-        queryParameters: {
-          'ttbkey': AppConfig.aladinApiKey,
-          'itemIdType': 'ISBN13',
-          'ItemId': isbn13,
-          'output': 'js',
-          'Version': AppConfig.apiVersion,
-        },
-      );
-
-      final response = await http.get(uri).timeout(const Duration(seconds: 5));
-      debugPrint('📕 [Aladin] status=${response.statusCode}');
-
-      if (response.statusCode == 200) {
-        final jsonData = json.decode(response.body);
-        final List<dynamic> items = jsonData['item'] ?? [];
-        debugPrint('📕 [Aladin] items=${items.length}');
-        if (items.isNotEmpty) {
-          final description = items[0]['description'] as String?;
-          debugPrint(
-            '📕 [Aladin] desc=${description != null ? "${description.length}자" : "null"}',
-          );
-          if (description != null && description.isNotEmpty) {
-            return stripAndDecodeHtml(description);
-          }
-        }
-      }
-    } catch (e) {
-      debugPrint('📕 [Aladin] ERROR: $e');
-    }
-    return null;
+    return cleaned.isEmpty ? null : cleaned;
   }
 }

--- a/app/lib/data/services/auth_service.dart
+++ b/app/lib/data/services/auth_service.dart
@@ -4,11 +4,11 @@ import 'dart:math';
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import 'package:book_golas/config/app_config.dart';
 import 'package:book_golas/data/services/subscription_service.dart';
 import 'package:book_golas/domain/models/user_model.dart';
 
@@ -20,10 +20,12 @@ class AuthService {
   UserModel? get currentUser => _currentUser;
 
   AuthService()
-    : _googleSignIn = GoogleSignIn(
-        scopes: ['email', 'profile'],
-        serverClientId: dotenv.env['GOOGLE_SERVER_CLIENT_ID'],
-      ) {
+      : _googleSignIn = GoogleSignIn(
+          scopes: ['email', 'profile'],
+          serverClientId: AppConfig.googleServerClientId.isEmpty
+              ? null
+              : AppConfig.googleServerClientId,
+        ) {
     _init();
   }
 
@@ -162,8 +164,7 @@ class AuthService {
           if (fullName.isNotEmpty) {
             await _supabase
                 .from('users')
-                .update({'nickname': fullName})
-                .eq('id', response.user!.id);
+                .update({'nickname': fullName}).eq('id', response.user!.id);
           }
         }
       }
@@ -281,11 +282,8 @@ class AuthService {
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) return null;
 
-    final data = await _supabase
-        .from('users')
-        .select()
-        .eq('id', userId)
-        .maybeSingle();
+    final data =
+        await _supabase.from('users').select().eq('id', userId).maybeSingle();
 
     if (data == null) {
       final email = _supabase.auth.currentUser?.email ?? '';
@@ -298,11 +296,8 @@ class AuthService {
         'revenuecat_user_id': userId,
       });
 
-      final newData = await _supabase
-          .from('users')
-          .select()
-          .eq('id', userId)
-          .single();
+      final newData =
+          await _supabase.from('users').select().eq('id', userId).single();
       _currentUser = UserModel.fromJson(newData);
     } else {
       _currentUser = UserModel.fromJson(data);
@@ -316,8 +311,7 @@ class AuthService {
     if (userId == null) return;
     await _supabase
         .from('users')
-        .update({'nickname': nickname})
-        .eq('id', userId);
+        .update({'nickname': nickname}).eq('id', userId);
     await fetchCurrentUser();
   }
 
@@ -328,7 +322,7 @@ class AuthService {
     }
 
     final filePath = '$userId/avatar.png';
-    debugPrint('🖼️ [Avatar] Uploading to: $filePath');
+    debugPrint('🖼️ [Avatar] Upload started');
 
     await _supabase.storage
         .from('avatars')
@@ -337,12 +331,10 @@ class AuthService {
 
     final baseUrl = _supabase.storage.from('avatars').getPublicUrl(filePath);
     final urlWithBust = '$baseUrl?ts=${DateTime.now().millisecondsSinceEpoch}';
-    debugPrint('🖼️ [Avatar] URL: $urlWithBust');
 
     await _supabase
         .from('users')
-        .update({'avatar_url': urlWithBust})
-        .eq('id', userId);
+        .update({'avatar_url': urlWithBust}).eq('id', userId);
     debugPrint('🖼️ [Avatar] Updated users table');
 
     await _supabase.auth.updateUser(
@@ -354,8 +346,13 @@ class AuthService {
   }
 
   Future<UserModel?> getCurrentUser() async {
-    final user = await _supabase.auth.getUser();
-    _currentUser = UserModel.fromUser(user.user!);
+    final response = await _supabase.auth.getUser();
+    final user = response.user;
+    if (user == null) {
+      _currentUser = null;
+      return null;
+    }
+    _currentUser = UserModel.fromUser(user);
     return _currentUser;
   }
 

--- a/app/lib/data/services/google_vision_ocr_service.dart
+++ b/app/lib/data/services/google_vision_ocr_service.dart
@@ -2,8 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
-
-import 'package:book_golas/config/app_config.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class GoogleVisionOcrService {
   static final GoogleVisionOcrService _instance =
@@ -11,141 +10,47 @@ class GoogleVisionOcrService {
   factory GoogleVisionOcrService() => _instance;
   GoogleVisionOcrService._internal();
 
-  static const String _baseUrl =
-      'https://vision.googleapis.com/v1/images:annotate';
+  static const int _maxImageBytes = 8 * 1024 * 1024;
+  SupabaseClient get _supabase => Supabase.instance.client;
 
   Future<String?> extractTextFromImageUrl(String imageUrl) async {
-    if (!AppConfig.hasGoogleCloudVisionApiKey) {
-      debugPrint('🔴 OCR: API 키가 설정되지 않았습니다.');
-      return null;
-    }
-
     try {
-      final response = await http.get(Uri.parse(imageUrl));
+      final response = await http
+          .get(Uri.parse(imageUrl))
+          .timeout(const Duration(seconds: 10));
       if (response.statusCode != 200) {
-        debugPrint('🔴 OCR: 이미지 다운로드 실패 - ${response.statusCode}');
+        debugPrint('OCR image download failed: ${response.statusCode}');
         return null;
       }
 
       return await extractTextFromBytes(response.bodyBytes);
-    } catch (e) {
-      debugPrint('🔴 OCR: 이미지 다운로드 에러 - $e');
+    } catch (error) {
+      debugPrint('OCR image download failed: $error');
       return null;
     }
   }
 
   Future<String?> extractTextFromBytes(Uint8List imageBytes) async {
-    if (!AppConfig.hasGoogleCloudVisionApiKey) {
-      debugPrint('🔴 OCR: API 키가 설정되지 않았습니다.');
+    if (imageBytes.isEmpty || imageBytes.length > _maxImageBytes) {
+      debugPrint('OCR image size is invalid');
       return null;
     }
 
-    final apiKey = AppConfig.googleCloudVisionApiKey;
-    final maskedKey = apiKey.length > 8
-        ? '${apiKey.substring(0, 4)}...${apiKey.substring(apiKey.length - 4)}'
-        : '****';
-    debugPrint('🟡 OCR: API 키 확인 - $maskedKey (길이: ${apiKey.length})');
-    debugPrint('🟡 OCR: 텍스트 추출 시작 (이미지 크기: ${imageBytes.length} bytes)');
-
     try {
-      final base64Image = base64Encode(imageBytes);
-      debugPrint('🟡 OCR: Base64 인코딩 완료 (길이: ${base64Image.length})');
-
-      final requestBody = {
-        'requests': [
-          {
-            'image': {
-              'content': base64Image,
-            },
-            'features': [
-              {
-                'type': 'DOCUMENT_TEXT_DETECTION',
-                'maxResults': 1,
-              },
-            ],
-            'imageContext': {
-              'languageHints': ['ko', 'en'],
-            },
-          },
-        ],
-      };
-
-      debugPrint('🟡 OCR: API 호출 중...');
-      final response = await http.post(
-        Uri.parse('$_baseUrl?key=${AppConfig.googleCloudVisionApiKey}'),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: jsonEncode(requestBody),
+      final response = await _supabase.functions.invoke(
+        'vision-ocr',
+        body: {'imageBase64': base64Encode(imageBytes)},
       );
-
-      debugPrint('🟡 OCR: API 응답 코드 - ${response.statusCode}');
-      debugPrint('🟡 OCR: API 응답 헤더 - ${response.headers}');
-
-      if (response.statusCode != 200) {
-        debugPrint('🔴 OCR: API 에러 (상태코드: ${response.statusCode})');
-        debugPrint('🔴 OCR: API 에러 응답 본문 - ${response.body}');
-
-        try {
-          final errorJson = jsonDecode(response.body) as Map<String, dynamic>;
-          final error = errorJson['error'] as Map<String, dynamic>?;
-          if (error != null) {
-            debugPrint('🔴 OCR: 에러 코드 - ${error['code']}');
-            debugPrint('🔴 OCR: 에러 메시지 - ${error['message']}');
-            debugPrint('🔴 OCR: 에러 상태 - ${error['status']}');
-          }
-        } catch (_) {}
+      if (response.status != 200 || response.data is! Map) {
+        debugPrint('OCR request failed');
         return null;
       }
 
-      final jsonResponse = jsonDecode(response.body) as Map<String, dynamic>;
-      final responses = jsonResponse['responses'] as List<dynamic>?;
-
-      if (responses == null || responses.isEmpty) {
-        debugPrint('🔴 OCR: 응답이 비어있습니다.');
-        return null;
-      }
-
-      final firstResponse = responses[0] as Map<String, dynamic>;
-
-      // 에러 체크
-      if (firstResponse.containsKey('error')) {
-        debugPrint('🔴 OCR: API 에러 - ${firstResponse['error']}');
-        return null;
-      }
-
-      final fullTextAnnotation =
-          firstResponse['fullTextAnnotation'] as Map<String, dynamic>?;
-
-      if (fullTextAnnotation != null) {
-        final structuredText =
-            _extractFromFullTextAnnotation(fullTextAnnotation);
-        if (structuredText.isNotEmpty) {
-          debugPrint(
-              '🟢 OCR: 구조화된 텍스트 추출 성공 (길이: ${structuredText.length})');
-          return _cleanupExtractedText(structuredText);
-        }
-      }
-
-      final textAnnotations =
-          firstResponse['textAnnotations'] as List<dynamic>?;
-
-      if (textAnnotations == null || textAnnotations.isEmpty) {
-        debugPrint('🟠 OCR: 텍스트가 감지되지 않았습니다.');
-        return null;
-      }
-
-      final fullText = textAnnotations[0]['description'] as String?;
-
-      if (fullText == null || fullText.isEmpty) {
-        debugPrint('🟠 OCR: 추출된 텍스트가 비어있습니다.');
-        return null;
-      }
-
-      debugPrint('🟢 OCR: 텍스트 추출 성공 - fallback (길이: ${fullText.length})');
-      return _cleanupExtractedText(fullText);
-    } catch (e) {
-      debugPrint('🔴 OCR: 예외 발생 - $e');
+      final data = Map<String, dynamic>.from(response.data as Map);
+      final text = data['text']?.toString() ?? '';
+      return text.isEmpty ? null : _cleanupExtractedText(text);
+    } catch (error) {
+      debugPrint('OCR request failed: $error');
       return null;
     }
   }
@@ -165,90 +70,13 @@ class GoogleVisionOcrService {
     return cleaned;
   }
 
-  String _extractFromFullTextAnnotation(Map<String, dynamic> annotation) {
-    final pages = annotation['pages'] as List<dynamic>?;
-    if (pages == null || pages.isEmpty) {
-      return annotation['text'] as String? ?? '';
-    }
-
-    final paragraphs = <String>[];
-
-    for (final page in pages) {
-      final blocks =
-          (page as Map<String, dynamic>)['blocks'] as List<dynamic>?;
-      if (blocks == null) continue;
-
-      for (final block in blocks) {
-        final blockMap = block as Map<String, dynamic>;
-        final blockType = blockMap['blockType'] as String?;
-        if (blockType != null && blockType != 'TEXT') continue;
-
-        final blockParagraphs =
-            blockMap['paragraphs'] as List<dynamic>?;
-        if (blockParagraphs == null) continue;
-
-        for (final paragraph in blockParagraphs) {
-          final words =
-              (paragraph as Map<String, dynamic>)['words'] as List<dynamic>?;
-          if (words == null) continue;
-
-          final text = _buildParagraphText(words);
-          if (text.isNotEmpty) {
-            paragraphs.add(text);
-          }
-        }
-      }
-    }
-
-    if (paragraphs.isEmpty) {
-      return annotation['text'] as String? ?? '';
-    }
-
-    return paragraphs.join('\n\n');
-  }
-
-  String _buildParagraphText(List<dynamic> words) {
-    final buffer = StringBuffer();
-
-    for (final word in words) {
-      final symbols =
-          (word as Map<String, dynamic>)['symbols'] as List<dynamic>?;
-      if (symbols == null) continue;
-
-      for (final symbol in symbols) {
-        final symbolMap = symbol as Map<String, dynamic>;
-        final text = symbolMap['text'] as String?;
-        if (text != null) {
-          buffer.write(text);
-        }
-
-        final property =
-            symbolMap['property'] as Map<String, dynamic>?;
-        final detectedBreak =
-            property?['detectedBreak'] as Map<String, dynamic>?;
-        if (detectedBreak != null) {
-          final breakType = detectedBreak['type'] as String?;
-          if (breakType == 'SPACE' ||
-              breakType == 'SURE_SPACE' ||
-              breakType == 'EOL_SURE_SPACE' ||
-              breakType == 'LINE_BREAK') {
-            buffer.write(' ');
-          } else if (breakType == 'HYPHEN') {
-            buffer.write('-');
-          }
-        }
-      }
-    }
-
-    return buffer.toString().trim();
-  }
-
   String getPreviewText(String? fullText, {int maxLines = 2}) {
     if (fullText == null || fullText.isEmpty) {
       return '';
     }
 
-    final lines = fullText.split('\n').where((line) => line.trim().isNotEmpty).toList();
+    final lines =
+        fullText.split('\n').where((line) => line.trim().isNotEmpty).toList();
 
     if (lines.isEmpty) {
       return '';

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:home_widget/home_widget.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
@@ -116,23 +115,9 @@ class AppBootstrap extends StatelessWidget {
     try {
       debugPrint('🚀 초기화 시작');
 
-      // .env 파일 로드
-      debugPrint('📄 .env 파일 로드 시작');
-      try {
-        await dotenv.load(fileName: ".env");
-        debugPrint('✅ .env 파일 로드 완료');
-      } catch (e) {
-        debugPrint('⚠️ .env 파일 로드 실패: $e');
-        // .env 파일이 없어도 계속 진행 (환경변수로 대체 가능)
-      }
-
-      debugPrint('🔑 API 키 검증 시작');
-      try {
-        AppConfig.validateApiKeys();
-        debugPrint('✅ API 키 검증 완료');
-      } catch (e) {
-        debugPrint('⚠️ API 키 검증 실패: $e');
-      }
+      debugPrint('🔑 런타임 설정 검증 시작');
+      AppConfig.validateRuntimeConfig();
+      debugPrint('✅ 런타임 설정 검증 완료');
 
       // Firebase 초기화 (이미 초기화되어 있으면 스킵)
       debugPrint('🔥 Firebase 초기화 시작');
@@ -157,8 +142,10 @@ class AppBootstrap extends StatelessWidget {
       await Supabase.initialize(
         url: AppConfig.supabaseUrl,
         anonKey: AppConfig.supabaseAnonKey,
-        realtimeClientOptions: const RealtimeClientOptions(
-          logLevel: RealtimeLogLevel.info,
+        realtimeClientOptions: RealtimeClientOptions(
+          logLevel: AppConfig.isProduction
+              ? RealtimeLogLevel.error
+              : RealtimeLogLevel.info,
         ),
       );
       debugPrint('✅ Supabase 초기화 성공');

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -382,14 +382,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
-  flutter_dotenv:
-    dependency: "direct main"
-    description:
-      name: flutter_dotenv
-      sha256: b7c7be5cd9f6ef7a78429cabd2774d3c4af50e79cb2b7593e3d5d763ef95c61b
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.2.1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: "독서 목표를 설정하고 독서 진행 상황을 추적하는
 
 publish_to: "none"
 
-version: 1.0.1+1
+version: 1.0.2+15002
 
 environment:
   sdk: ^3.5.3
@@ -17,7 +17,6 @@ dependencies:
 
   cupertino_icons: ^1.0.8
   http: ^1.1.0
-  flutter_dotenv: ^5.1.0
   supabase_flutter: ^2.5.6
   provider: ^6.1.2
   image_picker: ^1.1.2
@@ -96,7 +95,6 @@ flutter:
 
   assets:
     - assets/images/
-    - .env
 
 dependency_overrides:
   # Fix iOS build error: Color.withValues not in Flutter 3.16.

--- a/supabase/functions/aladin-books/handler.ts
+++ b/supabase/functions/aladin-books/handler.ts
@@ -1,0 +1,108 @@
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const jsonHeaders = {
+  ...corsHeaders,
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store",
+};
+
+type RequestBody = {
+  action?: "search" | "lookup";
+  query?: string;
+  isbn?: string;
+  maxResults?: number;
+};
+
+type HandlerDependencies = {
+  apiKey: string;
+  authenticate: (request: Request) => Promise<boolean>;
+  fetchUpstream: typeof fetch;
+};
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), { status, headers: jsonHeaders });
+}
+
+export function createHandler(
+  dependencies: HandlerDependencies,
+): (request: Request) => Promise<Response> {
+  return async (request: Request) => {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: corsHeaders });
+    }
+    if (request.method !== "POST") {
+      return jsonResponse({ error: "Method not allowed" }, 405);
+    }
+    if (!dependencies.apiKey) {
+      return jsonResponse({ error: "Service configuration unavailable" }, 503);
+    }
+    if (!(await dependencies.authenticate(request))) {
+      return jsonResponse({ error: "Unauthorized" }, 401);
+    }
+
+    let body: RequestBody;
+    try {
+      body = (await request.json()) as RequestBody;
+    } catch {
+      return jsonResponse({ error: "Invalid request" }, 400);
+    }
+
+    const params = new URLSearchParams({
+      ttbkey: dependencies.apiKey,
+      output: "js",
+      Version: "20131101",
+      Cover: "Big",
+    });
+    let endpoint: string;
+
+    if (body.action === "search") {
+      const query = body.query?.trim() ?? "";
+      if (!query || query.length > 200) {
+        return jsonResponse({ error: "Invalid query" }, 400);
+      }
+      const requestedResults = Number(body.maxResults ?? 10);
+      if (!Number.isFinite(requestedResults)) {
+        return jsonResponse({ error: "Invalid result count" }, 400);
+      }
+      const maxResults = Math.min(
+        Math.max(Math.trunc(requestedResults), 1),
+        10,
+      );
+      endpoint = "https://www.aladin.co.kr/ttb/api/ItemSearch.aspx";
+      params.set("Query", query);
+      params.set("QueryType", "Title");
+      params.set("MaxResults", maxResults.toString());
+      params.set("start", "1");
+      params.set("SearchTarget", "Book");
+    } else if (body.action === "lookup") {
+      const isbn = (body.isbn ?? "").replaceAll(/[^0-9Xx]/g, "");
+      if (!/^(?:[0-9]{10}|[0-9]{13})$/.test(isbn)) {
+        return jsonResponse({ error: "Invalid ISBN" }, 400);
+      }
+      endpoint = "https://www.aladin.co.kr/ttb/api/ItemLookUp.aspx";
+      params.set("itemIdType", isbn.length === 13 ? "ISBN13" : "ISBN");
+      params.set("ItemId", isbn);
+      params.set("OptResult", "ebookList,usedList,reviewList");
+    } else {
+      return jsonResponse({ error: "Invalid action" }, 400);
+    }
+
+    try {
+      const upstream = await dependencies.fetchUpstream(
+        `${endpoint}?${params.toString()}`,
+        { signal: AbortSignal.timeout(8000) },
+      );
+      if (!upstream.ok) {
+        return jsonResponse({ error: "Book service unavailable" }, 502);
+      }
+      return jsonResponse(await upstream.json(), 200);
+    } catch {
+      return jsonResponse({ error: "Book service request failed" }, 502);
+    }
+  };
+}

--- a/supabase/functions/aladin-books/index.ts
+++ b/supabase/functions/aladin-books/index.ts
@@ -1,0 +1,32 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+import { createHandler } from "./handler.ts";
+
+async function authenticate(request: Request): Promise<boolean> {
+  try {
+    const authHeader = request.headers.get("Authorization") ?? "";
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
+    return error == null && user != null;
+  } catch {
+    return false;
+  }
+}
+
+if (import.meta.main) {
+  serve(
+    createHandler({
+      apiKey: Deno.env.get("ALADIN_TTB_KEY") ?? "",
+      authenticate,
+      fetchUpstream: fetch,
+    }),
+  );
+}

--- a/supabase/functions/aladin-books/index_test.ts
+++ b/supabase/functions/aladin-books/index_test.ts
@@ -1,0 +1,66 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+
+import { createHandler } from "./handler.ts";
+
+function request(body: unknown): Request {
+  return new Request("http://localhost/aladin-books", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer test",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+Deno.test("aladin proxy rejects unauthenticated requests", async () => {
+  const handler = createHandler({
+    apiKey: "test-key",
+    authenticate: () => Promise.resolve(false),
+    fetchUpstream: () => Promise.reject(new Error("must not run")),
+  });
+
+  const response = await handler(request({ action: "search", query: "book" }));
+
+  assertEquals(response.status, 401);
+});
+
+Deno.test("aladin proxy validates search input before upstream request", async () => {
+  const handler = createHandler({
+    apiKey: "test-key",
+    authenticate: () => Promise.resolve(true),
+    fetchUpstream: () => Promise.reject(new Error("must not run")),
+  });
+
+  const response = await handler(request({ action: "search", query: "" }));
+
+  assertEquals(response.status, 400);
+});
+
+Deno.test("aladin proxy limits result count and keeps the key server-side", async () => {
+  let requestedUrl = "";
+  const handler = createHandler({
+    apiKey: "server-key",
+    authenticate: () => Promise.resolve(true),
+    fetchUpstream: (input) => {
+      requestedUrl = input.toString();
+      return Promise.resolve(
+        new Response(JSON.stringify({ item: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    },
+  });
+
+  const response = await handler(
+    request({ action: "search", query: "habits", maxResults: 999 }),
+  );
+
+  assertEquals(response.status, 200);
+  assertStringIncludes(requestedUrl, "MaxResults=10");
+  assertStringIncludes(requestedUrl, "ttbkey=server-key");
+});

--- a/supabase/functions/vision-ocr/handler.ts
+++ b/supabase/functions/vision-ocr/handler.ts
@@ -1,0 +1,104 @@
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const jsonHeaders = {
+  ...corsHeaders,
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store",
+};
+
+type RequestBody = {
+  imageBase64?: string;
+};
+
+type HandlerDependencies = {
+  apiKey: string;
+  authenticate: (request: Request) => Promise<boolean>;
+  fetchUpstream: typeof fetch;
+};
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), { status, headers: jsonHeaders });
+}
+
+export function createHandler(
+  dependencies: HandlerDependencies,
+): (request: Request) => Promise<Response> {
+  return async (request: Request) => {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: corsHeaders });
+    }
+    if (request.method !== "POST") {
+      return jsonResponse({ error: "Method not allowed" }, 405);
+    }
+    if (!dependencies.apiKey) {
+      return jsonResponse({ error: "Service configuration unavailable" }, 503);
+    }
+    if (!(await dependencies.authenticate(request))) {
+      return jsonResponse({ error: "Unauthorized" }, 401);
+    }
+
+    const contentLength = Number(request.headers.get("content-length") ?? 0);
+    if (contentLength > 11_300_000) {
+      return jsonResponse({ error: "Invalid image" }, 400);
+    }
+
+    let body: RequestBody;
+    try {
+      body = (await request.json()) as RequestBody;
+    } catch {
+      return jsonResponse({ error: "Invalid request" }, 400);
+    }
+
+    const { imageBase64 } = body;
+    if (
+      !imageBase64 ||
+      imageBase64.length > 11_200_000 ||
+      !/^[A-Za-z0-9+/]+={0,2}$/.test(imageBase64)
+    ) {
+      return jsonResponse({ error: "Invalid image" }, 400);
+    }
+
+    try {
+      const upstream = await dependencies.fetchUpstream(
+        `https://vision.googleapis.com/v1/images:annotate?key=${dependencies.apiKey}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            requests: [
+              {
+                image: { content: imageBase64 },
+                features: [
+                  { type: "DOCUMENT_TEXT_DETECTION", maxResults: 1 },
+                ],
+                imageContext: { languageHints: ["ko", "en"] },
+              },
+            ],
+          }),
+          signal: AbortSignal.timeout(15000),
+        },
+      );
+      if (!upstream.ok) {
+        return jsonResponse({ error: "OCR service unavailable" }, 502);
+      }
+
+      const data = await upstream.json();
+      const result = data.responses?.[0];
+      if (result?.error) {
+        return jsonResponse({ error: "OCR service failed" }, 502);
+      }
+
+      const text = result?.fullTextAnnotation?.text ??
+        result?.textAnnotations?.[0]?.description ??
+        "";
+      return jsonResponse({ text }, 200);
+    } catch {
+      return jsonResponse({ error: "OCR request failed" }, 502);
+    }
+  };
+}

--- a/supabase/functions/vision-ocr/index.ts
+++ b/supabase/functions/vision-ocr/index.ts
@@ -1,0 +1,32 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+import { createHandler } from "./handler.ts";
+
+async function authenticate(request: Request): Promise<boolean> {
+  try {
+    const authHeader = request.headers.get("Authorization") ?? "";
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
+    return error == null && user != null;
+  } catch {
+    return false;
+  }
+}
+
+if (import.meta.main) {
+  serve(
+    createHandler({
+      apiKey: Deno.env.get("GOOGLE_CLOUD_VISION_API_KEY") ?? "",
+      authenticate,
+      fetchUpstream: fetch,
+    }),
+  );
+}

--- a/supabase/functions/vision-ocr/index_test.ts
+++ b/supabase/functions/vision-ocr/index_test.ts
@@ -1,0 +1,76 @@
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+
+import { createHandler } from "./handler.ts";
+
+function request(body: unknown, contentLength?: number): Request {
+  const payload = JSON.stringify(body);
+  return new Request("http://localhost/vision-ocr", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer test",
+      "Content-Type": "application/json",
+      "Content-Length": String(contentLength ?? payload.length),
+    },
+    body: payload,
+  });
+}
+
+Deno.test("vision proxy rejects unauthenticated requests", async () => {
+  const handler = createHandler({
+    apiKey: "test-key",
+    authenticate: () => Promise.resolve(false),
+    fetchUpstream: () => Promise.reject(new Error("must not run")),
+  });
+
+  const response = await handler(request({ imageBase64: "dGVzdA==" }));
+
+  assertEquals(response.status, 401);
+});
+
+Deno.test("vision proxy rejects oversized requests before upstream transfer", async () => {
+  const handler = createHandler({
+    apiKey: "test-key",
+    authenticate: () => Promise.resolve(true),
+    fetchUpstream: () => Promise.reject(new Error("must not run")),
+  });
+
+  const response = await handler(
+    request({ imageBase64: "dGVzdA==" }, 11_300_001),
+  );
+
+  assertEquals(response.status, 400);
+});
+
+Deno.test("vision proxy sends valid content without exposing response secrets", async () => {
+  let requestedUrl = "";
+  let requestedBody = "";
+  const handler = createHandler({
+    apiKey: "server-key",
+    authenticate: () => Promise.resolve(true),
+    fetchUpstream: (input, init) => {
+      requestedUrl = input.toString();
+      requestedBody = init != null && "body" in init
+        ? init.body?.toString() ?? ""
+        : "";
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            responses: [{ fullTextAnnotation: { text: "recognized" } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    },
+  });
+
+  const response = await handler(request({ imageBase64: "dGVzdA==" }));
+  const body = await response.json();
+
+  assertEquals(response.status, 200);
+  assertEquals(body, { text: "recognized" });
+  assertStringIncludes(requestedUrl, "key=server-key");
+  assertStringIncludes(requestedBody, "DOCUMENT_TEXT_DETECTION");
+});


### PR DESCRIPTION
## 목적

1.0.2 앱 번들에서 서버 전용 Aladin 및 Google Vision 키를 제거하고 인증된 서버 경계로 이동합니다.

## 주요 변경

- 앱의 .env 의존성과 서버 전용 API 키 참조 제거
- Aladin 검색과 Vision OCR을 로그인 검증 Edge Function으로 전환
- 입력 크기 및 형식 제한, 업스트림 타임아웃, 일반화된 오류 응답 적용
- Dev/Production 워크플로의 함수 시크릿 주입과 dart-define 구성 정리
- share_plus iOS 잠금 파일 정합성 복구

## 배경

클라이언트 번들에 포함된 서버 API 키는 추출될 수 있으므로 1.0.2 출시 전 차단이 필요합니다.

## 검증

- deno test: 6 passed
- deno check: passed
- flutter analyze --no-fatal-infos: errors 0
- flutter test: 275 passed
- iOS release no-codesign build: passed, Runner.app 70.6MB
- workflow YAML parse: passed
- target-version gate: passed
- git diff --check: passed

## 관련 이슈

- 별도 이슈 식별자 없음

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store