### PR TITLE
fix(storage): restore private book image migration

### DIFF
--- a/app/lib/data/services/book_image_storage_service.dart
+++ b/app/lib/data/services/book_image_storage_service.dart
@@ -1,0 +1,77 @@
+import 'dart:typed_data';
+
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class BookImageStorageService {
+  BookImageStorageService({SupabaseClient? client})
+    : _client = client ?? Supabase.instance.client;
+
+  static const bucketName = 'book-images';
+  static const signedUrlExpiresInSeconds = 3600;
+
+  final SupabaseClient _client;
+
+  static String? storagePathFromValue(String? value) {
+    final trimmed = value?.trim();
+    if (trimmed == null || trimmed.isEmpty) return null;
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri == null || !uri.hasScheme) {
+      return trimmed.startsWith('/') ? trimmed.substring(1) : trimmed;
+    }
+
+    const markers = [
+      '/storage/v1/object/public/$bucketName/',
+      '/storage/v1/object/sign/$bucketName/',
+      '/storage/v1/object/authenticated/$bucketName/',
+    ];
+
+    for (final marker in markers) {
+      final markerIndex = uri.path.indexOf(marker);
+      if (markerIndex < 0) continue;
+
+      try {
+        return Uri.decodeComponent(
+          uri.path.substring(markerIndex + marker.length),
+        );
+      } on FormatException {
+        return null;
+      }
+    }
+
+    return null;
+  }
+
+  Future<String> upload({
+    required Uint8List imageBytes,
+    required String userId,
+    required String bookId,
+  }) async {
+    final storagePath =
+        '$userId/$bookId/${DateTime.now().microsecondsSinceEpoch}.jpg';
+    await _client.storage
+        .from(bucketName)
+        .uploadBinary(
+          storagePath,
+          imageBytes,
+          fileOptions: const FileOptions(upsert: false),
+        );
+    return storagePath;
+  }
+
+  Future<String?> createSignedUrl(String? storedValue) async {
+    final storagePath = storagePathFromValue(storedValue);
+    if (storagePath == null) return null;
+
+    return _client.storage
+        .from(bucketName)
+        .createSignedUrl(storagePath, signedUrlExpiresInSeconds);
+  }
+
+  Future<void> remove(String? storedValue) async {
+    final storagePath = storagePathFromValue(storedValue);
+    if (storagePath == null) return;
+
+    await _client.storage.from(bucketName).remove([storagePath]);
+  }
+}

--- a/app/lib/data/services/recall_service.dart
+++ b/app/lib/data/services/recall_service.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import 'package:book_golas/data/services/book_image_storage_service.dart';
 import 'package:book_golas/domain/models/recall_models.dart';
 import 'package:book_golas/utils/subscription_utils.dart';
 import 'package:book_golas/exceptions/subscription_exceptions.dart';
@@ -11,6 +12,8 @@ class RecallService {
   RecallService._internal();
 
   final SupabaseClient _supabase = Supabase.instance.client;
+  final BookImageStorageService _bookImageStorageService =
+      BookImageStorageService();
 
   Future<void> generateEmbeddingForHighlight({
     required String userId,
@@ -232,7 +235,9 @@ class RecallService {
           .eq('id', sourceId)
           .maybeSingle();
 
-      return response?['image_url'] as String?;
+      return _bookImageStorageService.createSignedUrl(
+        response?['image_url'] as String?,
+      );
     } catch (e) {
       debugPrint('🔴 Failed to get image URL: $e');
       return null;

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -8,6 +8,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import 'package:book_golas/data/services/book_image_storage_service.dart';
 import 'package:book_golas/data/services/book_service.dart';
 import 'package:book_golas/domain/models/book.dart';
 import 'package:book_golas/domain/models/highlight_data.dart';
@@ -1001,22 +1002,25 @@ class _BookDetailContentState extends State<_BookDetailContent>
     final memorableVm = context.read<MemorablePageViewModel>();
     final bookVm = context.read<BookDetailViewModel>();
 
+    String? storagePath;
+    var recordInserted = false;
     try {
-      String? publicUrl;
+      final userId = Supabase.instance.client.auth.currentUser?.id;
+      final bookId = bookVm.currentBook.id;
+      if (userId == null || bookId == null) return false;
+
       if (imageBytes != null) {
-        final fileName =
-            'book_images/${DateTime.now().millisecondsSinceEpoch}.jpg';
-        final storage = Supabase.instance.client.storage;
-        await storage.from('book-images').uploadBinary(fileName, imageBytes,
-            fileOptions: const FileOptions(upsert: true));
-        publicUrl = storage.from('book-images').getPublicUrl(fileName);
+        storagePath = await BookImageStorageService().upload(
+          imageBytes: imageBytes,
+          userId: userId,
+          bookId: bookId,
+        );
       }
 
-      final userId = Supabase.instance.client.auth.currentUser?.id;
       final insertData = {
-        'book_id': bookVm.currentBook.id,
+        'book_id': bookId,
         'user_id': userId,
-        'image_url': publicUrl,
+        'image_url': storagePath,
         'caption': '',
         'extracted_text': extractedText.isEmpty ? null : extractedText,
         'page_number': pageNumber,
@@ -1030,14 +1034,15 @@ class _BookDetailContentState extends State<_BookDetailContent>
           .insert(insertData)
           .select('id')
           .single();
+      recordInserted = true;
 
       await memorableVm.fetchBookImages();
       memorableVm.clearPendingImage();
 
-      if (extractedText.isNotEmpty && userId != null) {
+      if (extractedText.isNotEmpty) {
         RecallService().generateEmbeddingForPhotoOcr(
           userId: userId,
-          bookId: bookVm.currentBook.id!,
+          bookId: bookId,
           photoId: insertResult['id'] as String,
           ocrText: extractedText,
           pageNumber: pageNumber,
@@ -1054,6 +1059,11 @@ class _BookDetailContentState extends State<_BookDetailContent>
       }
       return true;
     } catch (e, stackTrace) {
+      if (!recordInserted && storagePath != null) {
+        try {
+          await BookImageStorageService().remove(storagePath);
+        } catch (_) {}
+      }
       debugPrint('🔴 업로드 실패: $e');
       debugPrint('🔴 스택 트레이스: $stackTrace');
       if (mounted) {

--- a/app/lib/ui/book_detail/view_model/memorable_page_view_model.dart
+++ b/app/lib/ui/book_detail/view_model/memorable_page_view_model.dart
@@ -1,11 +1,15 @@
 import 'dart:typed_data';
 
+import 'package:book_golas/data/services/book_image_storage_service.dart';
 import 'package:book_golas/domain/models/highlight_data.dart';
 import 'package:book_golas/ui/core/view_model/base_view_model.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class MemorablePageViewModel extends BaseViewModel {
+  static const _storagePathKey = '_storage_path';
+
   String _bookId;
+  final BookImageStorageService _bookImageStorageService;
 
   List<Map<String, dynamic>>? _cachedImages;
   bool _isSelectionMode = false;
@@ -27,7 +31,12 @@ class MemorablePageViewModel extends BaseViewModel {
   int? get pendingPageNumber => _pendingPageNumber;
   Map<String, String> get editedTexts => _editedTexts;
 
-  MemorablePageViewModel({required String bookId}) : _bookId = bookId;
+  MemorablePageViewModel({
+    required String bookId,
+    BookImageStorageService? bookImageStorageService,
+  })  : _bookId = bookId,
+        _bookImageStorageService =
+            bookImageStorageService ?? BookImageStorageService();
 
   void updateBookId(String bookId) {
     _bookId = bookId;
@@ -41,13 +50,39 @@ class MemorablePageViewModel extends BaseViewModel {
           .eq('book_id', _bookId)
           .order('page_number', ascending: false);
 
-      final images = (response as List).cast<Map<String, dynamic>>();
+      final rawImages = (response as List).cast<Map<String, dynamic>>();
+      final images = await Future.wait(rawImages.map(_resolveImageUrl));
       _cachedImages = images;
       notifyListeners();
       return images;
     } catch (e) {
       setError('이미지를 불러오는데 실패했습니다: $e');
       return [];
+    }
+  }
+
+  Future<Map<String, dynamic>> _resolveImageUrl(
+    Map<String, dynamic> image,
+  ) async {
+    final storedValue = image['image_url'] as String?;
+    final storagePath =
+        BookImageStorageService.storagePathFromValue(storedValue);
+    if (storagePath == null) return image;
+
+    try {
+      final signedUrl =
+          await _bookImageStorageService.createSignedUrl(storagePath);
+      return {
+        ...image,
+        _storagePathKey: storagePath,
+        'image_url': signedUrl,
+      };
+    } catch (_) {
+      return {
+        ...image,
+        _storagePathKey: storagePath,
+        'image_url': null,
+      };
     }
   }
 
@@ -179,24 +214,25 @@ class MemorablePageViewModel extends BaseViewModel {
         return false;
       }
 
-      final fileName =
-          '$userId/$_bookId/${DateTime.now().millisecondsSinceEpoch}.jpg';
-      final storagePath = await Supabase.instance.client.storage
-          .from('book-images')
-          .uploadBinary(fileName, imageBytes);
+      final storagePath = await _bookImageStorageService.upload(
+        imageBytes: imageBytes,
+        userId: userId,
+        bookId: _bookId,
+      );
 
-      final imageUrl = Supabase.instance.client.storage
-          .from('book-images')
-          .getPublicUrl(storagePath);
-
-      await Supabase.instance.client.from('book_images').insert({
-        'book_id': _bookId,
-        'user_id': userId,
-        'image_url': imageUrl,
-        'page_number': pageNumber,
-        'extracted_text': extractedText ?? '',
-        'created_at': DateTime.now().toIso8601String(),
-      });
+      try {
+        await Supabase.instance.client.from('book_images').insert({
+          'book_id': _bookId,
+          'user_id': userId,
+          'image_url': storagePath,
+          'page_number': pageNumber,
+          'extracted_text': extractedText ?? '',
+          'created_at': DateTime.now().toIso8601String(),
+        });
+      } catch (_) {
+        await _bookImageStorageService.remove(storagePath);
+        rethrow;
+      }
 
       await fetchBookImages();
       clearPendingImage();
@@ -211,10 +247,18 @@ class MemorablePageViewModel extends BaseViewModel {
 
   Future<bool> deleteBookImage(String imageId) async {
     try {
+      final image = await _findImage(imageId);
+      if (image == null) return false;
+
       await Supabase.instance.client
           .from('book_images')
           .delete()
           .eq('id', imageId);
+      try {
+        await _bookImageStorageService.remove(
+          image[_storagePathKey] as String? ?? image['image_url'] as String?,
+        );
+      } catch (_) {}
 
       await fetchBookImages();
       return true;
@@ -240,6 +284,11 @@ class MemorablePageViewModel extends BaseViewModel {
             .from('book_images')
             .delete()
             .eq('id', img['id']);
+        try {
+          await _bookImageStorageService.remove(
+            img[_storagePathKey] as String? ?? img['image_url'] as String?,
+          );
+        } catch (_) {}
       }
 
       _selectedImageIds.clear();
@@ -306,30 +355,67 @@ class MemorablePageViewModel extends BaseViewModel {
     required String extractedText,
     int? pageNumber,
   }) async {
+    String? newStoragePath;
+    var recordUpdated = false;
     try {
-      final fileName = '${DateTime.now().millisecondsSinceEpoch}_$_bookId.jpg';
-      final storagePath = 'book_images/$fileName';
+      final userId = Supabase.instance.client.auth.currentUser?.id;
+      if (userId == null) {
+        setError('로그인이 필요합니다');
+        return null;
+      }
+      final existingImage = await _findImage(imageId);
+      if (existingImage == null) return null;
+      final existingStoragePath = existingImage[_storagePathKey] as String? ??
+          existingImage['image_url'] as String?;
 
-      await Supabase.instance.client.storage
-          .from('book-images')
-          .uploadBinary(storagePath, imageBytes);
-
-      final imageUrl = Supabase.instance.client.storage
-          .from('book-images')
-          .getPublicUrl(storagePath);
+      newStoragePath = await _bookImageStorageService.upload(
+        imageBytes: imageBytes,
+        userId: userId,
+        bookId: _bookId,
+      );
 
       await Supabase.instance.client.from('book_images').update({
-        'image_url': imageUrl,
+        'image_url': newStoragePath,
         'extracted_text': extractedText,
         'page_number': pageNumber,
       }).eq('id', imageId);
+      recordUpdated = true;
+
+      try {
+        await _bookImageStorageService.remove(existingStoragePath);
+      } catch (_) {}
 
       await fetchBookImages();
-      return imageUrl;
+      try {
+        return await _bookImageStorageService.createSignedUrl(newStoragePath);
+      } catch (_) {
+        return null;
+      }
     } catch (e) {
+      if (!recordUpdated && newStoragePath != null) {
+        try {
+          await _bookImageStorageService.remove(newStoragePath);
+        } catch (_) {}
+      }
       setError('이미지 교체에 실패했습니다: $e');
       return null;
     }
+  }
+
+  Future<Map<String, dynamic>?> _findImage(String imageId) async {
+    final cached = _cachedImages?.where(
+      (image) => image['id']?.toString() == imageId,
+    );
+    if (cached != null && cached.isNotEmpty) return cached.first;
+
+    final response = await Supabase.instance.client
+        .from('book_images')
+        .select()
+        .eq('id', imageId)
+        .maybeSingle();
+    if (response == null) return null;
+
+    return _resolveImageUrl(response);
   }
 
   void onImagesLoaded(List<Map<String, dynamic>> images) {

--- a/app/test/data/services/book_image_storage_service_test.dart
+++ b/app/test/data/services/book_image_storage_service_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:book_golas/data/services/book_image_storage_service.dart';
+
+void main() {
+  group('BookImageStorageService.storagePathFromValue', () {
+    test('returns a stored object path unchanged', () {
+      expect(
+        BookImageStorageService.storagePathFromValue(
+          'user-id/book-id/image.jpg',
+        ),
+        'user-id/book-id/image.jpg',
+      );
+    });
+
+    test('extracts a path from a legacy public URL', () {
+      expect(
+        BookImageStorageService.storagePathFromValue(
+          'https://example.supabase.co/storage/v1/object/public/book-images/'
+          'user-id/book-id/image%201.jpg',
+        ),
+        'user-id/book-id/image 1.jpg',
+      );
+    });
+
+    test('extracts a path from a signed URL without retaining its query', () {
+      expect(
+        BookImageStorageService.storagePathFromValue(
+          'https://example.supabase.co/storage/v1/object/sign/book-images/'
+          'user-id/book-id/image.jpg?token=secret',
+        ),
+        'user-id/book-id/image.jpg',
+      );
+    });
+
+    test('rejects URLs for a different bucket', () {
+      expect(
+        BookImageStorageService.storagePathFromValue(
+          'https://example.supabase.co/storage/v1/object/public/avatars/'
+          'user-id/avatar.jpg',
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null for malformed encoded URLs', () {
+      expect(
+        BookImageStorageService.storagePathFromValue(
+          'https://example.supabase.co/storage/v1/object/public/book-images/'
+          'user-id/%E0%A4%A.jpg',
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null for empty values', () {
+      expect(BookImageStorageService.storagePathFromValue(null), isNull);
+      expect(BookImageStorageService.storagePathFromValue('  '), isNull);
+    });
+  });
+}

--- a/supabase/functions/_shared/book-image-storage.test.ts
+++ b/supabase/functions/_shared/book-image-storage.test.ts
@@ -1,0 +1,54 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+import { getBookImagePath } from "./book-image-storage.ts";
+
+Deno.test("keeps a stored object path", () => {
+  assertEquals(
+    getBookImagePath("user-id/book-id/image.jpg"),
+    "user-id/book-id/image.jpg",
+  );
+});
+
+Deno.test("extracts a legacy public object path", () => {
+  assertEquals(
+    getBookImagePath(
+      "https://example.supabase.co/storage/v1/object/public/book-images/" +
+        "book_images/image%201.jpg",
+    ),
+    "book_images/image 1.jpg",
+  );
+});
+
+Deno.test("extracts a signed object path without its token", () => {
+  assertEquals(
+    getBookImagePath(
+      "https://example.supabase.co/storage/v1/object/sign/book-images/" +
+        "user-id/book-id/image.jpg?token=secret",
+    ),
+    "user-id/book-id/image.jpg",
+  );
+});
+
+Deno.test("rejects URLs for another bucket", () => {
+  assertEquals(
+    getBookImagePath(
+      "https://example.supabase.co/storage/v1/object/public/avatars/avatar.jpg",
+    ),
+    null,
+  );
+});
+
+Deno.test("rejects a malformed encoded URL", () => {
+  assertEquals(
+    getBookImagePath(
+      "https://example.supabase.co/storage/v1/object/public/book-images/" +
+        "user-id/%E0%A4%A.jpg",
+    ),
+    null,
+  );
+});
+
+Deno.test("rejects an empty path", () => {
+  assertEquals(getBookImagePath(""), null);
+  assertEquals(getBookImagePath("/"), null);
+});

--- a/supabase/functions/_shared/book-image-storage.ts
+++ b/supabase/functions/_shared/book-image-storage.ts
@@ -1,0 +1,28 @@
+const bucketName = "book-images";
+
+export function getBookImagePath(storedValue: string): string | null {
+  if (
+    !storedValue.startsWith("http://") &&
+    !storedValue.startsWith("https://")
+  ) {
+    return storedValue.replace(/^\/+/, "") || null;
+  }
+
+  const markers = [
+    `/storage/v1/object/public/${bucketName}/`,
+    `/storage/v1/object/sign/${bucketName}/`,
+    `/storage/v1/object/authenticated/${bucketName}/`,
+  ];
+  const marker = markers.find((candidate) => storedValue.includes(candidate));
+  if (!marker) return null;
+
+  const markerIndex = storedValue.indexOf(marker);
+  try {
+    const path = decodeURIComponent(
+      storedValue.slice(markerIndex + marker.length).split("?")[0],
+    );
+    return path || null;
+  } catch {
+    return null;
+  }
+}

--- a/supabase/functions/delete-user/index.ts
+++ b/supabase/functions/delete-user/index.ts
@@ -1,5 +1,7 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
+import { getBookImagePath } from "../_shared/book-image-storage.ts";
+
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
@@ -12,16 +14,6 @@ function jsonResponse(body: Record<string, unknown>, status: number): Response {
     status,
     headers: { "Content-Type": "application/json", ...corsHeaders },
   });
-}
-
-function getBookImagePath(imageUrl: string): string | null {
-  const marker = "/storage/v1/object/public/book-images/";
-  const markerIndex = imageUrl.indexOf(marker);
-  if (markerIndex < 0) return null;
-
-  return decodeURIComponent(
-    imageUrl.slice(markerIndex + marker.length).split("?")[0],
-  );
 }
 
 Deno.serve(async (req: Request) => {

--- a/supabase/migrations/20260726022112_privatize_book_images.sql
+++ b/supabase/migrations/20260726022112_privatize_book_images.sql
@@ -1,0 +1,74 @@
+UPDATE storage.buckets
+SET public = false
+WHERE id = 'book-images';
+
+DROP POLICY IF EXISTS "Allow public reads" ON storage.objects;
+DROP POLICY IF EXISTS "Allow authenticated reads" ON storage.objects;
+DROP POLICY IF EXISTS "Allow authenticated uploads" ON storage.objects;
+DROP POLICY IF EXISTS "Allow authenticated deletes" ON storage.objects;
+
+CREATE POLICY "Users can read their own book image objects"
+ON storage.objects
+FOR SELECT
+TO authenticated
+USING (
+  bucket_id = 'book-images'
+  AND (
+    (storage.foldername(name))[1] = (auth.uid())::text
+    OR EXISTS (
+      SELECT 1
+      FROM public.book_images
+      WHERE book_images.user_id = auth.uid()
+        AND (
+          book_images.image_url = storage.objects.name
+          OR book_images.image_url LIKE '%/storage/v1/object/public/book-images/' || storage.objects.name
+          OR book_images.image_url LIKE '%/storage/v1/object/sign/book-images/' || storage.objects.name || '%'
+          OR book_images.image_url LIKE '%/storage/v1/object/authenticated/book-images/' || storage.objects.name || '%'
+        )
+    )
+  )
+);
+
+CREATE POLICY "Users can upload their own book image objects"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'book-images'
+  AND (storage.foldername(name))[1] = (auth.uid())::text
+);
+
+CREATE POLICY "Users can update their own book image objects"
+ON storage.objects
+FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'book-images'
+  AND (storage.foldername(name))[1] = (auth.uid())::text
+)
+WITH CHECK (
+  bucket_id = 'book-images'
+  AND (storage.foldername(name))[1] = (auth.uid())::text
+);
+
+CREATE POLICY "Users can delete their own book image objects"
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'book-images'
+  AND (
+    (storage.foldername(name))[1] = (auth.uid())::text
+    OR EXISTS (
+      SELECT 1
+      FROM public.book_images
+      WHERE book_images.user_id = auth.uid()
+        AND (
+          book_images.image_url = storage.objects.name
+          OR book_images.image_url LIKE '%/storage/v1/object/public/book-images/' || storage.objects.name
+          OR book_images.image_url LIKE '%/storage/v1/object/sign/book-images/' || storage.objects.name || '%'
+          OR book_images.image_url LIKE '%/storage/v1/object/authenticated/book-images/' || storage.objects.name || '%'
+        )
+    )
+  )
+);


### PR DESCRIPTION
## 목적

Dev에 적용됐지만 저장소에서 누락된 도서 이미지 비공개 마이그레이션을 복원해 TestFlight의 migration history 불일치를 해소합니다.

## 주요 변경

- `20260726022112_privatize_book_images.sql` 이력 복원
- 도서 이미지 신규 업로드는 객체 경로를 저장하고 조회 시 서명 URL 발급
- 기존 공개 URL 데이터와 신규 경로 데이터 모두 호환
- 이미지 삭제·교체와 계정 삭제의 Storage 정리 경로 보강
- Flutter 및 Deno 경로 파서 테스트 추가

## 배경

Dev DB에는 `20260726022112`가 적용돼 있으나 저장소에 같은 버전 파일이 없어 iOS TestFlight의 `supabase db push`가 중단됐습니다. 마이그레이션만 복원하면 비공개 버킷에서 기존 공개 URL 사용이 깨질 수 있어 앱 호환 변경을 함께 포함합니다.

## 검증

- `flutter test` — 283 tests passed
- `flutter test test/data/services/book_image_storage_service_test.dart` — 6 passed
- `deno test supabase/functions/_shared/book-image-storage.test.ts` — 6 passed
- `deno check supabase/functions/delete-user/index.ts` — passed
- 변경 파일 대상 `flutter analyze` — 새 오류 없음; 기존 `book_detail_screen.dart` info 4건만 존재
- `git diff --check` — passed

## 롤백

앱 변경은 이 커밋을 되돌릴 수 있습니다. 이미 Dev에 적용된 마이그레이션 이력은 임의 repair하지 않으며, 긴급 시 버킷 공개 상태와 기존 Storage 정책을 별도 전진 마이그레이션으로 복원합니다.

## 관련 이슈

- TestFlight `Apply Migrations` 실패: remote-only version `20260726022112`

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store