### PR TITLE
fix: verify the TestFlight development app

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -253,7 +253,7 @@ jobs:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
-          TESTFLIGHT_APP_IDENTIFIER: com.bookgolas.app
+          TESTFLIGHT_APP_IDENTIFIER: com.bookgolas.app.dev
           TESTFLIGHT_MARKETING_VERSION: ${{ steps.build-metadata.outputs.marketing-version }}
           TESTFLIGHT_BUILD_NUMBER: ${{ steps.build-metadata.outputs.build-number }}
         run: |
@@ -296,7 +296,7 @@ jobs:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
-          TESTFLIGHT_APP_IDENTIFIER: com.bookgolas.app
+          TESTFLIGHT_APP_IDENTIFIER: com.bookgolas.app.dev
           TESTFLIGHT_MARKETING_VERSION: ${{ inputs.marketing_version }}
           TESTFLIGHT_BUILD_NUMBER: ${{ inputs.build_number }}
         run: |

--- a/app/ios/fastlane/test/testflight_build_verifier_test.rb
+++ b/app/ios/fastlane/test/testflight_build_verifier_test.rb
@@ -73,6 +73,18 @@ class TestFlightBuildVerifierTest < Minitest::Test
     end
   end
 
+  def test_testflight_workflow_targets_dev_app
+    repository_root = File.expand_path("../../../..", __dir__)
+    workflow = File.read(
+      File.join(repository_root, ".github/workflows/ios-testflight.yml")
+    )
+    identifiers = workflow.scan(
+      /TESTFLIGHT_APP_IDENTIFIER:\s+(\S+)/
+    ).flatten
+
+    assert_equal %w[com.bookgolas.app.dev com.bookgolas.app.dev], identifiers
+  end
+
   private
 
   def build_with(state)


### PR DESCRIPTION
## 목적

TestFlight 빌드 상태 조회 대상을 실제 beta lane 업로드 앱과 일치시킵니다.

## 주요 변경

- TestFlight 검증 App ID를 com.bookgolas.app.dev로 교정
- 수동 확인과 자동 업로드 후 확인에 동일한 개발 App ID 적용
- 운영 배포는 com.bookgolas.app 유지
- 워크플로 App ID 회귀 테스트 추가

## 검증

- Ruby: 8 runs, 21 assertions, 0 failures
- actionlint 1.7.12 통과
- target-version gate 로컬 검증 통과
- git diff --check 통과

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store