### PR TITLE
fix: quarantine orphaned image owners

### DIFF
--- a/supabase/migrations/20260727144950_secure_legacy_book_image_ownership.sql
+++ b/supabase/migrations/20260727144950_secure_legacy_book_image_ownership.sql
@@ -84,6 +84,8 @@ AS $$
       ON storage.objects.bucket_id = 'book-images'
       AND storage.objects.name = normalized_claims.object_name
       AND storage.objects.owner_id = normalized_claims.user_id::text
+    INNER JOIN auth.users
+      ON auth.users.id = normalized_claims.user_id
     WHERE NULLIF(BTRIM(normalized_claims.object_name), '') IS NOT NULL
   ),
   inserted_ownership AS (

--- a/supabase/tests/database/book_image_ownership.test.sql
+++ b/supabase/tests/database/book_image_ownership.test.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(19);
+SELECT plan(20);
 
 INSERT INTO auth.users (
   instance_id,
@@ -96,6 +96,12 @@ VALUES
     'book-images',
     '11111111-1111-1111-1111-111111111111/foreign-owner.jpg',
     '22222222-2222-2222-2222-222222222222'
+  ),
+  (
+    'cccccccc-5555-5555-5555-555555555555',
+    'book-images',
+    'legacy/orphan-owner.jpg',
+    '33333333-3333-3333-3333-333333333333'
   );
 
 INSERT INTO public.book_images (book_id, image_url, user_id)
@@ -114,6 +120,11 @@ VALUES
     'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
     'legacy/owner-b.jpg',
     '22222222-2222-2222-2222-222222222222'
+  ),
+  (
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    'legacy/orphan-owner.jpg',
+    '33333333-3333-3333-3333-333333333333'
   );
 
 SELECT public.backfill_book_image_legacy_ownership();
@@ -149,6 +160,16 @@ SELECT results_eq(
   $$,
   ARRAY[0::bigint],
   'mutable metadata cannot claim another storage owner object'
+);
+
+SELECT results_eq(
+  $$
+    SELECT COUNT(*)
+    FROM public.book_image_legacy_ownership
+    WHERE object_name = 'legacy/orphan-owner.jpg'
+  $$,
+  ARRAY[0::bigint],
+  'orphaned storage ownership is quarantined instead of backfilled'
 );
 
 SET LOCAL ROLE authenticated;


### PR DESCRIPTION
Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store

## 목적

PR #286 병합 후 자동 TestFlight 파이프라인에서 Dev migration이 고아 책 이미지 소유자 때문에 실패한 문제를 해결합니다.

## 주요 변경

- legacy 책 이미지 소유권 backfill에서 현재 `auth.users`에 존재하는 사용자만 허용
- 탈퇴·고아 사용자 ID가 남은 `book_images` 및 Storage 객체는 소유권을 부여하지 않고 격리
- 실제 실패 데이터를 재현하는 pgTAP 회귀 fixture와 격리 assertion 추가

## 배경과 적용 근거

- 실패 run: https://github.com/byungsker/book-golas/actions/runs/30372801498
- Dev 로그에서 `20260727144950_secure_legacy_book_image_ownership.sql`이 미적용 migration으로 열거된 뒤 FK 위반으로 롤백됨
- Production은 해당 migration이 포함된 1.0.2 version line이 아직 `main`으로 승격되지 않아 CI 적용 전 상태
- 정상 사용자는 기존처럼 Storage `owner_id`와 `auth.users.id`가 모두 일치해야만 legacy 소유권을 획득
- 고아 객체는 ownership row가 생성되지 않아 Storage SELECT/DELETE RLS의 legacy 경로를 얻지 못함

## 검증

- 전체 local migration 재적용: 통과
- pgTAP: 20/20 통과
- `supabase db lint --local --level error`: schema error 없음
- `git diff --check`: 통과
- 독립 품질 리뷰: `APPROVE_NEXT` (결함 없음)

## 롤백

- 이 migration은 Dev/Production에 성공 적용되기 전이므로 PR 미병합 시 기존 version line으로 복귀
- 병합 후 문제가 발견되면 이 커밋을 revert하고 TestFlight pipeline을 중단한 상태로 유지
- Production DB에는 로컬에서 직접 적용하지 않음

## 체크리스트

- [x] target version source, branch, base, PR metadata가 일치함
- [x] 최신 `version/mobile/1.0.2`에서 분기함
- [x] 기존 정상 소유권과 fail-closed RLS 의미를 유지함
- [x] 고아 소유자 회귀 테스트 추가
- [x] 새 head의 필수 CI 전체 통과
- [ ] 병합 후 Dev migration 적용 및 TestFlight 처리 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for legacy book image ownership by excluding records linked to nonexistent accounts.
  * Orphaned legacy storage objects are now quarantined instead of being assigned ownership during backfill.

* **Tests**
  * Added coverage to verify orphaned image ownership is not restored incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->