### PR TITLE
ci: add App Store download metrics

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -321,7 +321,9 @@ jobs:
           working-directory: app/ios
 
       - name: Test App Store download reporter
-        run: ruby app/ios/fastlane/test/app_store_download_reporter_test.rb
+        run: |
+          cd app/ios
+          bundle exec ruby fastlane/test/app_store_download_reporter_test.rb
 
       - name: Report App Store downloads
         env:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -17,13 +17,14 @@ on:
   workflow_dispatch:
     inputs:
       operation:
-        description: 'Deploy a new build or verify an existing TestFlight build'
+        description: 'Deploy, verify TestFlight, or report production App Store downloads'
         required: true
         default: deploy
         type: choice
         options:
           - deploy
           - verify
+          - report-downloads
       marketing_version:
         description: 'Marketing version used by verify'
         required: true
@@ -302,3 +303,31 @@ jobs:
         run: |
           cd app/ios
           bundle exec ruby fastlane/scripts/verify_testflight_build.rb
+
+  report-app-store-downloads:
+    name: Report Production App Store Downloads
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.operation == 'report-downloads' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: app/ios
+
+      - name: Test App Store download reporter
+        run: ruby app/ios/fastlane/test/app_store_download_reporter_test.rb
+
+      - name: Report App Store downloads
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+        run: |
+          cd app/ios
+          bundle exec ruby fastlane/scripts/report_app_store_downloads.rb --create-if-missing

--- a/app/ios/fastlane/lib/app_store_download_reporter.rb
+++ b/app/ios/fastlane/lib/app_store_download_reporter.rb
@@ -231,13 +231,12 @@ module AppStoreDownloadReporter
     end
 
     def call
-      app = find_app
-      report_request = find_report_request(app.fetch("id"))
+      report_request = find_report_request(APP_APPLE_ID)
 
       if report_request.nil?
         return pending("missing_report_request") unless @create_if_missing
 
-        created = create_report_request(app.fetch("id"))
+        created = create_report_request(APP_APPLE_ID)
         return pending("report_request_created", request_id: created.fetch("id"))
       end
 
@@ -276,15 +275,6 @@ module AppStoreDownloadReporter
     end
 
     private
-
-    def find_app
-      apps = @api_client.get_all(
-        "/v1/apps?filter[bundleId]=#{URI.encode_www_form_component(APP_BUNDLE_ID)}&limit=2"
-      )
-      raise "App Store Connect app not found for #{APP_BUNDLE_ID}" unless apps.length == 1
-
-      apps.fetch(0)
-    end
 
     def find_report_request(app_id)
       requests = @api_client.get_all(

--- a/app/ios/fastlane/lib/app_store_download_reporter.rb
+++ b/app/ios/fastlane/lib/app_store_download_reporter.rb
@@ -1,0 +1,340 @@
+require "base64"
+require "csv"
+require "date"
+require "digest"
+require "json"
+require "net/http"
+require "openssl"
+require "stringio"
+require "uri"
+require "zlib"
+
+require "jwt"
+
+module AppStoreDownloadReporter
+  class ApiError < StandardError
+    attr_reader :status
+
+    def initialize(status, body)
+      @status = status
+      super("App Store Connect API returned HTTP #{status}: #{body}")
+    end
+  end
+
+  class ApiClient
+    BASE_URL = "https://api.appstoreconnect.apple.com".freeze
+
+    def initialize(key_id:, issuer_id:, key_content_base64:)
+      @key_id = key_id
+      @issuer_id = issuer_id
+      @private_key = OpenSSL::PKey::EC.new(Base64.decode64(key_content_base64))
+    end
+
+    def get_all(path)
+      records = []
+      next_url = path
+
+      while next_url
+        response = get_json(next_url)
+        records.concat(response.fetch("data"))
+        next_url = response.dig("links", "next")
+      end
+
+      records
+    end
+
+    def get_json(path)
+      JSON.parse(request(:get, path))
+    end
+
+    def post_json(path, payload)
+      JSON.parse(request(:post, path, body: JSON.generate(payload)))
+    end
+
+    def download(url, redirects_remaining: 5)
+      uri = URI(url)
+      response = perform(Net::HTTP::Get.new(uri), uri)
+
+      if response.is_a?(Net::HTTPRedirection)
+        raise ApiError.new(response.code.to_i, "too many redirects") if redirects_remaining.zero?
+
+        return download(
+          URI.join(url, response.fetch("location")).to_s,
+          redirects_remaining: redirects_remaining - 1
+        )
+      end
+
+      return response.body if response.is_a?(Net::HTTPSuccess)
+
+      raise ApiError.new(response.code.to_i, response.body.to_s[0, 500])
+    end
+
+    private
+
+    def request(method, path, body: nil)
+      uri = path.start_with?("http") ? URI(path) : URI.join(BASE_URL, path)
+      request = method == :post ? Net::HTTP::Post.new(uri) : Net::HTTP::Get.new(uri)
+      request["Authorization"] = "Bearer #{token}"
+      request["Content-Type"] = "application/json" if body
+      request.body = body if body
+      response = perform(request, uri)
+
+      return response.body if response.is_a?(Net::HTTPSuccess)
+
+      raise ApiError.new(response.code.to_i, response.body.to_s[0, 500])
+    end
+
+    def perform(request, uri)
+      Net::HTTP.start(
+        uri.host,
+        uri.port,
+        use_ssl: uri.scheme == "https",
+        open_timeout: 15,
+        read_timeout: 60
+      ) do |http|
+        http.request(request)
+      end
+    end
+
+    def token
+      now = Time.now.to_i
+      payload = {
+        "iss" => @issuer_id,
+        "iat" => now,
+        "exp" => now + 900,
+        "aud" => "appstoreconnect-v1"
+      }
+      headers = {
+        "kid" => @key_id,
+        "typ" => "JWT"
+      }
+      JWT.encode(payload, @private_key, "ES256", headers)
+    end
+  end
+
+  class SegmentReader
+    def initialize(api_client)
+      @api_client = api_client
+    end
+
+    def read(segment)
+      attributes = segment.fetch("attributes")
+      compressed = @api_client.download(attributes.fetch("url"))
+      verify_size!(compressed, attributes["sizeInBytes"])
+      verify_checksum!(compressed, attributes["checksum"])
+      Zlib::GzipReader.new(StringIO.new(compressed)).read
+    end
+
+    private
+
+    def verify_size!(content, expected)
+      return if expected.nil? || content.bytesize == expected
+
+      raise "Analytics report segment size mismatch"
+    end
+
+    def verify_checksum!(content, expected)
+      return if expected.nil? || expected.empty?
+
+      actual =
+        case expected.length
+        when 32
+          Digest::MD5.hexdigest(content)
+        when 64
+          Digest::SHA256.hexdigest(content)
+        else
+          raise "Unsupported analytics report checksum"
+        end
+      raise "Analytics report segment checksum mismatch" unless actual.casecmp?(expected)
+    end
+  end
+
+  class Aggregator
+    DOWNLOAD_TYPES = {
+      "first-time download" => "first_time_downloads",
+      "redownload" => "redownloads",
+      "manual update" => "manual_updates",
+      "auto-update" => "auto_updates",
+      "restore" => "restores"
+    }.freeze
+
+    def initialize(app_apple_id)
+      @app_apple_id = app_apple_id.to_s
+    end
+
+    def aggregate(instance_rows)
+      latest_by_date = {}
+
+      instance_rows.sort_by { |item| item.fetch(:processing_date) }.each do |item|
+        partitions = parse_partitions(item.fetch(:contents))
+
+        partitions.each do |date, counts|
+          existing = latest_by_date[date]
+          next if existing && existing.fetch(:processing_date) > item.fetch(:processing_date)
+
+          latest_by_date[date] = {
+            processing_date: item.fetch(:processing_date),
+            counts: counts
+          }
+        end
+      end
+
+      totals = DOWNLOAD_TYPES.values.to_h { |key| [key, 0] }
+      latest_by_date.each_value do |partition|
+        partition.fetch(:counts).each do |key, count|
+          totals[key] += count
+        end
+      end
+
+      totals["updates"] = totals.fetch("manual_updates") + totals.fetch("auto_updates")
+      totals["total_download_events"] = DOWNLOAD_TYPES.values.sum { |key| totals.fetch(key) }
+      {
+        "by_type" => totals,
+        "first_reported_date" => latest_by_date.keys.min,
+        "last_reported_date" => latest_by_date.keys.max,
+        "partitions" => latest_by_date.length
+      }
+    end
+
+    private
+
+    def parse_partitions(contents)
+      partitions = Hash.new { |hash, key| hash[key] = Hash.new(0) }
+
+      contents.each do |content|
+        CSV.parse(content, headers: true, col_sep: "\t").each do |row|
+          next unless row.fetch("App Apple Identifier").to_s == @app_apple_id
+
+          key = DOWNLOAD_TYPES[normalize(row.fetch("Download Type"))]
+          next unless key
+
+          partitions[row.fetch("Date")][key] += Integer(row.fetch("Counts"))
+        end
+      end
+
+      partitions
+    end
+
+    def normalize(value)
+      value.to_s.strip.downcase.tr("‑–—", "---")
+    end
+  end
+
+  class Runner
+    APP_BUNDLE_ID = "com.bookgolas.app".freeze
+    APP_APPLE_ID = "6757021809".freeze
+
+    def initialize(api_client:, segment_reader:, create_if_missing:)
+      @api_client = api_client
+      @segment_reader = segment_reader
+      @create_if_missing = create_if_missing
+    end
+
+    def call
+      app = find_app
+      report_request = find_report_request(app.fetch("id"))
+
+      if report_request.nil?
+        return pending("missing_report_request") unless @create_if_missing
+
+        created = create_report_request(app.fetch("id"))
+        return pending("report_request_created", request_id: created.fetch("id"))
+      end
+
+      reports = @api_client.get_all(
+        "/v1/analyticsReportRequests/#{report_request.fetch("id")}/reports?filter[category]=COMMERCE&limit=200"
+      )
+      report = select_download_report(reports)
+      return pending("downloads_report_generating", request_id: report_request.fetch("id")) unless report
+
+      instances = @api_client.get_all(
+        "/v1/analyticsReports/#{report.fetch("id")}/instances?filter[granularity]=DAILY&limit=200"
+      )
+      return pending("downloads_instances_generating", request_id: report_request.fetch("id")) if instances.empty?
+
+      instance_rows = instances.map do |instance|
+        segments = @api_client.get_all(
+          "/v1/analyticsReportInstances/#{instance.fetch("id")}/segments?limit=200"
+        )
+        {
+          processing_date: Date.iso8601(instance.dig("attributes", "processingDate")),
+          contents: segments.map { |segment| @segment_reader.read(segment) }
+        }
+      end
+      result = Aggregator.new(APP_APPLE_ID).aggregate(instance_rows)
+      latest_processing_date = instance_rows.map { |item| item.fetch(:processing_date) }.max
+
+      {
+        "status" => "ready",
+        "app_bundle_id" => APP_BUNDLE_ID,
+        "app_apple_id" => APP_APPLE_ID,
+        "report_name" => report.dig("attributes", "name"),
+        "report_request_id" => report_request.fetch("id"),
+        "latest_processing_date" => latest_processing_date.iso8601,
+        "complete_through" => (latest_processing_date - 2).iso8601
+      }.merge(result)
+    end
+
+    private
+
+    def find_app
+      apps = @api_client.get_all(
+        "/v1/apps?filter[bundleId]=#{URI.encode_www_form_component(APP_BUNDLE_ID)}&limit=2"
+      )
+      raise "App Store Connect app not found for #{APP_BUNDLE_ID}" unless apps.length == 1
+
+      apps.fetch(0)
+    end
+
+    def find_report_request(app_id)
+      requests = @api_client.get_all(
+        "/v1/apps/#{app_id}/analyticsReportRequests?limit=200"
+      )
+      active = requests.reject { |request| request.dig("attributes", "stoppedDueToInactivity") }
+      active.find { |request| request.dig("attributes", "accessType") == "ONGOING" } ||
+        active.max_by { |request| request.fetch("id") }
+    end
+
+    def create_report_request(app_id)
+      response = @api_client.post_json(
+        "/v1/analyticsReportRequests",
+        {
+          "data" => {
+            "type" => "analyticsReportRequests",
+            "attributes" => {
+              "accessType" => "ONE_TIME_SNAPSHOT"
+            },
+            "relationships" => {
+              "app" => {
+                "data" => {
+                  "type" => "apps",
+                  "id" => app_id
+                }
+              }
+            }
+          }
+        }
+      )
+      response.fetch("data")
+    end
+
+    def select_download_report(reports)
+      candidates = reports.select do |report|
+        report.dig("attributes", "name").to_s.downcase.include?("app store downloads")
+      end
+      candidates.find do |report|
+        report.dig("attributes", "name").to_s.downcase.include?("standard")
+      end || candidates.first
+    end
+
+    def pending(reason, request_id: nil)
+      {
+        "status" => "pending",
+        "reason" => reason,
+        "app_bundle_id" => APP_BUNDLE_ID,
+        "app_apple_id" => APP_APPLE_ID,
+        "report_request_id" => request_id
+      }.compact
+    end
+  end
+end

--- a/app/ios/fastlane/scripts/report_app_store_downloads.rb
+++ b/app/ios/fastlane/scripts/report_app_store_downloads.rb
@@ -1,0 +1,29 @@
+require "json"
+
+require_relative "../lib/app_store_download_reporter"
+
+def required_environment(name)
+  value = ENV[name]
+  raise ArgumentError, "Missing required environment variable #{name}" if value.nil? || value.empty?
+
+  value
+end
+
+client = AppStoreDownloadReporter::ApiClient.new(
+  key_id: required_environment("APP_STORE_CONNECT_API_KEY_ID"),
+  issuer_id: required_environment("APP_STORE_CONNECT_ISSUER_ID"),
+  key_content_base64: required_environment("APP_STORE_CONNECT_API_KEY_CONTENT")
+)
+result = AppStoreDownloadReporter::Runner.new(
+  api_client: client,
+  segment_reader: AppStoreDownloadReporter::SegmentReader.new(client),
+  create_if_missing: ARGV.include?("--create-if-missing")
+).call
+output = JSON.pretty_generate(result)
+puts output
+
+summary_path = ENV["GITHUB_STEP_SUMMARY"]
+if summary_path && !summary_path.empty?
+  lines = ["## Bookgolas App Store downloads", "", "```json", output, "```", ""]
+  File.open(summary_path, "a") { |file| file.write(lines.join("\n")) }
+end

--- a/app/ios/fastlane/test/app_store_download_reporter_test.rb
+++ b/app/ios/fastlane/test/app_store_download_reporter_test.rb
@@ -101,8 +101,7 @@ class AppStoreDownloadReporterTest < Minitest::Test
 
   def test_runner_creates_snapshot_when_no_request_exists
     client = FakeApiClient.new(
-      "/v1/apps?" => [{ "id" => "app-id" }],
-      "/v1/apps/app-id/analyticsReportRequests" => []
+      "/v1/apps/6757021809/analyticsReportRequests" => []
     )
 
     result = AppStoreDownloadReporter::Runner.new(
@@ -126,8 +125,7 @@ class AppStoreDownloadReporterTest < Minitest::Test
       2026-07-24\tBookgolas\t6757021809\tRedownload\t1
     TSV
     client = FakeApiClient.new(
-      "/v1/apps?" => [{ "id" => "app-id" }],
-      "/v1/apps/app-id/analyticsReportRequests" => [
+      "/v1/apps/6757021809/analyticsReportRequests" => [
         {
           "id" => "request-id",
           "attributes" => {

--- a/app/ios/fastlane/test/app_store_download_reporter_test.rb
+++ b/app/ios/fastlane/test/app_store_download_reporter_test.rb
@@ -1,0 +1,176 @@
+require "minitest/autorun"
+
+require_relative "../lib/app_store_download_reporter"
+
+class AppStoreDownloadReporterTest < Minitest::Test
+  class FakeApiClient
+    attr_reader :posted
+
+    def initialize(responses)
+      @responses = responses
+      @posted = []
+    end
+
+    def get_all(path)
+      response = @responses.find { |pattern, _| path.start_with?(pattern) }
+      raise "Unexpected API path #{path}" unless response
+
+      response.fetch(1)
+    end
+
+    def post_json(path, payload)
+      @posted << [path, payload]
+      {
+        "data" => {
+          "type" => "analyticsReportRequests",
+          "id" => "created-request"
+        }
+      }
+    end
+  end
+
+  class FakeSegmentReader
+    def initialize(contents)
+      @contents = contents
+    end
+
+    def read(segment)
+      @contents.fetch(segment.fetch("id"))
+    end
+  end
+
+  def test_latest_processing_date_replaces_earlier_partition
+    header = [
+      "Date",
+      "App Name",
+      "App Apple Identifier",
+      "Download Type",
+      "Counts"
+    ].join("\t")
+    earlier = [
+      header,
+      "2026-07-24\tBookgolas\t6757021809\tFirst-time Download\t1",
+      "2026-07-25\tBookgolas\t6757021809\tRedownload\t2"
+    ].join("\n")
+    later = [
+      header,
+      "2026-07-24\tBookgolas\t6757021809\tFirst-time Download\t3",
+      "2026-07-24\tBookgolas\t6757021809\tManual update\t4"
+    ].join("\n")
+
+    result = AppStoreDownloadReporter::Aggregator.new("6757021809").aggregate(
+      [
+        {
+          processing_date: Date.new(2026, 7, 25),
+          contents: [earlier]
+        },
+        {
+          processing_date: Date.new(2026, 7, 26),
+          contents: [later]
+        }
+      ]
+    )
+
+    assert_equal 3, result.dig("by_type", "first_time_downloads")
+    assert_equal 2, result.dig("by_type", "redownloads")
+    assert_equal 4, result.dig("by_type", "updates")
+    assert_equal 9, result.dig("by_type", "total_download_events")
+    assert_equal 2, result.fetch("partitions")
+  end
+
+  def test_ignores_other_apps_and_unknown_download_types
+    content = <<~TSV
+      Date\tApp Name\tApp Apple Identifier\tDownload Type\tCounts
+      2026-07-24\tBookgolas\t6757021809\tFirst-time Download\t1
+      2026-07-24\tOther\t1234567890\tFirst-time Download\t8
+      2026-07-24\tBookgolas\t6757021809\tUnknown\t4
+    TSV
+
+    result = AppStoreDownloadReporter::Aggregator.new("6757021809").aggregate(
+      [
+        {
+          processing_date: Date.new(2026, 7, 26),
+          contents: [content]
+        }
+      ]
+    )
+
+    assert_equal 1, result.dig("by_type", "first_time_downloads")
+    assert_equal 1, result.dig("by_type", "total_download_events")
+  end
+
+  def test_runner_creates_snapshot_when_no_request_exists
+    client = FakeApiClient.new(
+      "/v1/apps?" => [{ "id" => "app-id" }],
+      "/v1/apps/app-id/analyticsReportRequests" => []
+    )
+
+    result = AppStoreDownloadReporter::Runner.new(
+      api_client: client,
+      segment_reader: FakeSegmentReader.new({}),
+      create_if_missing: true
+    ).call
+
+    assert_equal "pending", result.fetch("status")
+    assert_equal "report_request_created", result.fetch("reason")
+    assert_equal "created-request", result.fetch("report_request_id")
+    assert_equal 1, client.posted.length
+    assert_equal "ONE_TIME_SNAPSHOT",
+                 client.posted.dig(0, 1, "data", "attributes", "accessType")
+  end
+
+  def test_runner_reports_first_time_downloads
+    content = <<~TSV
+      Date\tApp Name\tApp Apple Identifier\tDownload Type\tCounts
+      2026-07-24\tBookgolas\t6757021809\tFirst-time Download\t2
+      2026-07-24\tBookgolas\t6757021809\tRedownload\t1
+    TSV
+    client = FakeApiClient.new(
+      "/v1/apps?" => [{ "id" => "app-id" }],
+      "/v1/apps/app-id/analyticsReportRequests" => [
+        {
+          "id" => "request-id",
+          "attributes" => {
+            "accessType" => "ONGOING",
+            "stoppedDueToInactivity" => false
+          }
+        }
+      ],
+      "/v1/analyticsReportRequests/request-id/reports" => [
+        {
+          "id" => "report-id",
+          "attributes" => {
+            "name" => "App Store Downloads Standard",
+            "category" => "COMMERCE"
+          }
+        }
+      ],
+      "/v1/analyticsReports/report-id/instances" => [
+        {
+          "id" => "instance-id",
+          "attributes" => {
+            "granularity" => "DAILY",
+            "processingDate" => "2026-07-28"
+          }
+        }
+      ],
+      "/v1/analyticsReportInstances/instance-id/segments" => [
+        {
+          "id" => "segment-id",
+          "attributes" => {}
+        }
+      ]
+    )
+
+    result = AppStoreDownloadReporter::Runner.new(
+      api_client: client,
+      segment_reader: FakeSegmentReader.new("segment-id" => content),
+      create_if_missing: true
+    ).call
+
+    assert_equal "ready", result.fetch("status")
+    assert_equal 2, result.dig("by_type", "first_time_downloads")
+    assert_equal 1, result.dig("by_type", "redownloads")
+    assert_equal "2026-07-26", result.fetch("complete_through")
+  end
+end

--- a/docs/guides/app-store-download-metrics.md
+++ b/docs/guides/app-store-download-metrics.md
@@ -1,0 +1,81 @@
+# App Store Download Metrics
+
+Bookgolas download counts are retrieved through Apple Analytics Reports rather
+than copied from the App Store Connect dashboard.
+
+## Local tools
+
+Apple Reporter 2.2 is installed at:
+
+```text
+~/.local/share/apple-reporter/2.2/Reporter.jar
+```
+
+The `apple-reporter` command uses:
+
+```text
+~/.config/apple-reporter/Reporter.properties
+```
+
+The properties file must remain mode `0600`. Its `AccessToken` value is a
+credential and must never be added to the repository or command output.
+
+Verify the installation:
+
+```bash
+apple-reporter
+```
+
+Reporter access tokens expire after 180 days. Generate and store a token only
+when the legacy Sales and Trends report path is needed.
+
+## GitHub Actions
+
+Run the `iOS TestFlight Deploy` workflow with:
+
+```text
+operation: report-downloads
+ref: version/mobile/1.0.2
+```
+
+The job reuses these existing GitHub Secrets:
+
+```text
+APP_STORE_CONNECT_API_KEY_ID
+APP_STORE_CONNECT_ISSUER_ID
+APP_STORE_CONNECT_API_KEY_BASE64
+```
+
+The key must have an App Store Connect role that can access Analytics Reports.
+An Admin key can create the first report request. Sales and Reports or Finance
+keys can download reports after an Admin has created the request.
+
+If no request exists, the first run creates a one-time snapshot request. Apple
+normally generates the report in 24–48 hours, so run the same operation again
+after the report is ready.
+
+The result distinguishes:
+
+- `first_time_downloads`
+- `redownloads`
+- `manual_updates`
+- `auto_updates`
+- `restores`
+- `total_download_events`
+
+Instances with a later processing date replace earlier data for the same event
+date. This prevents corrected partitions from being counted twice. Daily
+download data is complete within two days, and the output includes
+`complete_through`.
+
+## Rollback
+
+Remove the `report-downloads` operation and the reporter files to disable the
+GitHub automation. Remove the local command, configuration, and Reporter JAR to
+uninstall the local tool:
+
+```bash
+rm ~/.local/bin/apple-reporter
+rm ~/.config/apple-reporter/Reporter.properties
+rm ~/.local/share/apple-reporter/2.2/Reporter.jar
+```


### PR DESCRIPTION
## 목적

App Store Connect 화면에 의존하지 않고 북골라스의 실제 최초 다운로드와 재다운로드를 조회합니다.

## 주요 변경

- Apple Analytics Reports API 조회기와 보정 파티션 집계 추가
- 기존 App Store Connect GitHub Secret을 재사용하는 수동 작업 추가
- Apple Reporter 2.2 로컬 설치·보안·롤백 절차 문서화

## 배경

App Analytics의 데이터 부족 표시는 다운로드 0건을 뜻하지 않으므로, App Store Downloads Standard 보고서를 직접 집계합니다.

## 검증 방법

- Ruby 단위 테스트: 4 runs, 16 assertions, 0 failures
- actionlint 구조 검증 통과
- Apple Reporter 2.2 설치 및 버전 확인
- GitHub Actions run 30414863555 성공
- Apple one-time snapshot 요청 생성 확인

## 관련 이슈

- 없음 — 1.0.2 운영 계측

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store