### PR TITLE
chore(governance): open web 1.0.0 admin release line

### DIFF
--- a/.byungskerlab/release-lines.json
+++ b/.byungskerlab/release-lines.json
@@ -26,8 +26,12 @@
       }
     },
     "web": {
-      "active_versions": [],
-      "evidence_refs": [],
+      "active_versions": [
+        "1.0.0"
+      ],
+      "evidence_refs": [
+        "docs/product-roadmap.md"
+      ],
       "promotion_sources": {
         "release": {},
         "hotfix": {}

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -1,6 +1,6 @@
 # Bookgolas Product Roadmap
 
-Last updated: 2026-07-25
+Last updated: 2026-07-29
 
 ## Priority order
 
@@ -9,6 +9,9 @@ Bookgolas follows this release order:
 1. Ship the next patch release: **1.0.2**.
 2. Prepare and validate the Android / Google Play release.
 3. Publish the Android release to Google Play after the test and policy gates pass.
+
+The independently delivered web admin has an approved parallel release train:
+**web 1.0.0**. It does not change the mobile 1.0.2 binary scope.
 
 ## P0 — 1.0.2 patch release
 
@@ -52,6 +55,27 @@ unverified.
   complete and byungsker gives explicit publication authority.
 - Verify the public listing, install, sign-in, core reading flow, analytics,
   support entrypoint, and rollback/hold criteria after approval.
+
+## Parallel track — web 1.0.0 data-informed admin
+
+- Replace direct browser-side operational queries with an authenticated
+  server-side aggregate metrics boundary.
+- Present the reading growth path from users through book registration,
+  reading records, AI Recall, and seven-day active use.
+- Keep push operations separate from growth interpretation while exposing
+  delivery health and click outcomes as supporting evidence.
+- Show metric definitions, data freshness, partial-data states, and
+  low-sample warnings without exposing user content or identifiers.
+- Preserve loading, empty, stale, authorization, and upstream-error states.
+
+Exit gate:
+
+- The admin can identify the current activation stage and the largest observed
+  drop without accessing row-level customer data.
+- Missing acquisition, retention, or monetization sources remain explicitly
+  unavailable rather than appearing as zero.
+- Admin and non-admin authorization checks, lint, build, and browser smoke
+  checks pass on the approved web release line.
 
 ## Current evidence and unknowns
 


### PR DESCRIPTION
## 목적

북골라스 데이터 기반 어드민 개선을 위한 web 1.0.0 릴리스 라인을 엽니다.

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local

## 주요 변경

- `.byungskerlab/release-lines.json`에 web 1.0.0 활성 버전 등록
- 제품 로드맵에 데이터 기반 어드민의 범위와 종료 게이트 기록
- 모바일 1.0.2 바이너리 범위와 독립된 web release train 명시

## 영향

정책이 병합된 뒤 `version/web/1.0.0`을 운영 `main`에서 열고, 인증된 집계 API와 성장 퍼널 UI 작업을 같은 버전 라인으로 진행할 수 있습니다. 이 PR은 제품 코드나 운영 배포를 변경하지 않습니다.

## 검증

- Target Version Contract 로컬 검증 통과
- JSON 파싱 통과
- `git diff --check` 통과
- 변경 경로가 governance allowlist에 포함됨

## 롤백

병합 전에는 PR을 닫고 브랜치를 삭제합니다. 병합 후 구현을 시작하지 않았다면 web active version과 로드맵 항목을 되돌리는 governance PR로 복구합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for the independently delivered web admin release (version 1.0.0).
  * Defined an aggregate metrics experience that helps users identify growth stages and the largest observed drop.
  * Added guidance for freshness, partial-data, low-sample, and unavailable-data messaging.

* **Documentation**
  * Clarified that the web release follows a separate release track and does not change the mobile 1.0.2 scope.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->