### PR TITLE
feat(web): add data-informed admin dashboard

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3272,32 +3272,6 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -3921,11 +3895,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.1",
@@ -3940,14 +3917,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4138,13 +4117,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6507,16 +6479,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -6977,7 +6952,6 @@
       "version": "8.5.22",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
       "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/web/package.json
+++ b/web/package.json
@@ -39,6 +39,7 @@
     "typescript": "^5"
   },
   "overrides": {
+    "minimatch": "10.2.6",
     "postcss": "8.5.22"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:monitoring": "node --test tests/monitoring.test.mjs"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/web/src/app/admin/layout.tsx
+++ b/web/src/app/admin/layout.tsx
@@ -9,7 +9,7 @@ import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 
 const navItems = [
-  { href: "/admin", label: "대시보드", icon: "📊" },
+  { href: "/admin", label: "성장·운영", icon: "📊" },
   { href: "/admin/users", label: "유저 관리", icon: "👥" },
   { href: "/admin/push-templates", label: "푸시 템플릿", icon: "📝" },
   { href: "/admin/push-logs", label: "발송 로그", icon: "📋" },

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -1,237 +1,358 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Activity,
+  BookOpen,
+  BrainCircuit,
+  Database,
+  Megaphone,
+  RefreshCw,
+  Sparkles,
+  Users,
+} from "lucide-react";
+
 import { Badge } from "@/components/ui/badge";
-import { supabase, PushLog } from "@/lib/supabase";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  formatGeneratedAt,
+  formatMetric,
+  formatPercentage,
+  getNextAction,
+  percentage,
+} from "@/lib/admin/monitoring";
+import type {
+  AdminMonitoringMetrics,
+  MetricValue,
+} from "@/types/monitoring";
 
-type DashboardStats = {
-  todaySent: number;
-  todayClicked: number;
-  ctr: number;
-  activeUsers: number;
-  fatigueUsers: number;
+type MetricCardProps = {
+  label: string;
+  value: MetricValue;
+  description: string;
+  icon: React.ReactNode;
 };
 
-type TypeStats = {
-  push_type: string;
-  sent: number;
-  clicked: number;
-  ctr: number;
-};
+function MetricCard({ label, value, description, icon }: MetricCardProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          {label}
+        </CardTitle>
+        <span className="text-primary">{icon}</span>
+      </CardHeader>
+      <CardContent>
+        <div className="text-3xl font-bold text-foreground">
+          {formatMetric(value)}
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">{description}</p>
+      </CardContent>
+    </Card>
+  );
+}
 
-export default function AdminDashboard() {
-  const [stats, setStats] = useState<DashboardStats>({
-    todaySent: 0,
-    todayClicked: 0,
-    ctr: 0,
-    activeUsers: 0,
-    fatigueUsers: 0,
-  });
-  const [typeStats, setTypeStats] = useState<TypeStats[]>([]);
-  const [recentLogs, setRecentLogs] = useState<PushLog[]>([]);
-  const [loading, setLoading] = useState(true);
+export function AdminDashboard({
+  initialMetrics = null,
+}: {
+  initialMetrics?: AdminMonitoringMetrics | null;
+}) {
+  const [metrics, setMetrics] = useState<AdminMonitoringMetrics | null>(
+    initialMetrics
+  );
+  const [loading, setLoading] = useState(initialMetrics === null);
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchDashboardData();
-  }, []);
+  const loadMetrics = useCallback(async () => {
+    setLoading(true);
+    setError(null);
 
-  async function fetchDashboardData() {
     try {
-      const today = new Date().toISOString().split("T")[0];
+      const response = await fetch("/api/admin/monitoring", {
+        cache: "no-store",
+      });
 
-      const { data: todayLogs } = await supabase
-        .from("push_logs")
-        .select("*")
-        .gte("sent_at", today);
-
-      if (todayLogs) {
-        const sent = todayLogs.length;
-        const clicked = todayLogs.filter((l) => l.is_clicked).length;
-        setStats({
-          todaySent: sent,
-          todayClicked: clicked,
-          ctr: sent > 0 ? Math.round((clicked / sent) * 100 * 10) / 10 : 0,
-          activeUsers: new Set(todayLogs.map((l) => l.user_id)).size,
-          fatigueUsers: 0,
-        });
-
-        const typeMap = new Map<string, { sent: number; clicked: number }>();
-        todayLogs.forEach((log) => {
-          const curr = typeMap.get(log.push_type) || { sent: 0, clicked: 0 };
-          curr.sent++;
-          if (log.is_clicked) curr.clicked++;
-          typeMap.set(log.push_type, curr);
-        });
-
-        setTypeStats(
-          Array.from(typeMap.entries()).map(([type, data]) => ({
-            push_type: type,
-            sent: data.sent,
-            clicked: data.clicked,
-            ctr:
-              data.sent > 0
-                ? Math.round((data.clicked / data.sent) * 100 * 10) / 10
-                : 0,
-          }))
-        );
+      if (!response.ok) {
+        throw new Error("성장 데이터를 불러오지 못했습니다.");
       }
 
-      const { data: recent } = await supabase
-        .from("push_logs")
-        .select("*")
-        .order("sent_at", { ascending: false })
-        .limit(10);
-
-      if (recent) {
-        setRecentLogs(recent);
-      }
-    } catch (error) {
-      console.error("Failed to fetch dashboard data:", error);
+      setMetrics((await response.json()) as AdminMonitoringMetrics);
+    } catch {
+      setError("데이터 연결을 확인한 뒤 다시 시도해 주세요.");
     } finally {
       setLoading(false);
     }
-  }
+  }, []);
 
-  if (loading) {
+  useEffect(() => {
+    if (initialMetrics === null) {
+      loadMetrics();
+    }
+  }, [initialMetrics, loadMetrics]);
+
+  const insight = useMemo(
+    () => (metrics ? getNextAction(metrics) : null),
+    [metrics]
+  );
+
+  if (loading && !metrics) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-muted-foreground">로딩 중...</div>
+      <div className="flex h-64 items-center justify-center text-muted-foreground">
+        성장 지표를 불러오는 중...
       </div>
     );
   }
 
+  if (!metrics) {
+    return (
+      <Card className="mx-auto max-w-xl">
+        <CardHeader>
+          <CardTitle>성장 데이터를 연결하지 못했습니다</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">{error}</p>
+          <Button onClick={loadMetrics} variant="outline">
+            <RefreshCw className="mr-2 h-4 w-4" />
+            다시 시도
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const bookActivation = percentage(
+    metrics.books.users_with_books,
+    metrics.users.total
+  );
+  const readingActivation = percentage(
+    metrics.reading.users_with_records,
+    metrics.users.total
+  );
+  const recallActivation = percentage(
+    metrics.recall.users_with_recall,
+    metrics.users.total
+  );
+  const pushCtr = percentage(
+    metrics.push.clicked_7d,
+    metrics.push.sent_7d
+  );
+  const generatedAt = formatGeneratedAt(metrics.generated_at);
+  const lowSample =
+    metrics.users.active_7d !== null && metrics.users.active_7d < 30;
+
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-bold text-foreground">Push Notification Dashboard</h1>
+      <section className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-2xl font-bold text-foreground">
+              성장·운영 대시보드
+            </h1>
+            <Badge
+              variant={
+                metrics.source_status === "connected" ? "default" : "outline"
+              }
+            >
+              {metrics.source_status === "connected"
+                ? "제품 데이터 연결됨"
+                : "일부 데이터 연결 필요"}
+            </Badge>
+          </div>
+          <p className="mt-2 text-sm text-muted-foreground">
+            최근 {metrics.period_days}일 제품 행동을 개인정보 없이 집계합니다.
+            마지막 갱신 {generatedAt}
+          </p>
+        </div>
+        <Button onClick={loadMetrics} variant="outline" disabled={loading}>
+          <RefreshCw
+            className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`}
+          />
+          새로고침
+        </Button>
+      </section>
 
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              오늘 발송
-            </CardTitle>
+      {metrics.source_status === "partial" && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-700 dark:text-amber-300">
+          고유 사용자 기반 지표는 성장 집계 RPC 배포 후 표시됩니다. 연결되지
+          않은 값은 0이 아니라 ‘연결 필요’로 표시합니다.
+        </div>
+      )}
+
+      {lowSample && (
+        <div className="rounded-lg border border-blue-500/30 bg-blue-500/10 p-4 text-sm text-blue-700 dark:text-blue-300">
+          최근 7일 활성 사용자가 30명 미만이라 비율 변화가 크게 흔들릴 수
+          있습니다. 현재 수치는 방향 탐색용으로만 사용하세요.
+        </div>
+      )}
+
+      <section>
+        <div className="mb-3 flex items-center gap-2">
+          <Activity className="h-4 w-4 text-primary" />
+          <h2 className="text-sm font-semibold">최근 7일 핵심 행동</h2>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-5">
+          <MetricCard
+            label="신규 사용자"
+            value={metrics.users.new_7d}
+            description="최근 7일 가입"
+            icon={<Users className="h-4 w-4" />}
+          />
+          <MetricCard
+            label="활성 사용자"
+            value={metrics.users.active_7d}
+            description="책·독서 기록·Recall 행동의 고유 사용자"
+            icon={<Activity className="h-4 w-4" />}
+          />
+          <MetricCard
+            label="등록한 책"
+            value={metrics.books.created_7d}
+            description="최근 7일 새 책 등록"
+            icon={<BookOpen className="h-4 w-4" />}
+          />
+          <MetricCard
+            label="독서 기록"
+            value={metrics.reading.records_7d}
+            description="최근 7일 진행 기록"
+            icon={<Sparkles className="h-4 w-4" />}
+          />
+          <MetricCard
+            label="AI Recall"
+            value={metrics.recall.created_7d}
+            description="최근 7일 Recall 검색"
+            icon={<BrainCircuit className="h-4 w-4" />}
+          />
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Card className="xl:col-span-2">
+          <CardHeader>
+            <CardTitle className="text-base">누적 활성화 흐름</CardTitle>
           </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold text-foreground">{stats.todaySent}</div>
+          <CardContent className="space-y-5">
+            {[
+              {
+                label: "가입 → 책 등록 경험",
+                value: bookActivation,
+                detail: `${formatMetric(metrics.books.users_with_books)} / ${formatMetric(metrics.users.total)}명`,
+              },
+              {
+                label: "가입 → 독서 기록 경험",
+                value: readingActivation,
+                detail: `${formatMetric(metrics.reading.users_with_records)} / ${formatMetric(metrics.users.total)}명`,
+              },
+              {
+                label: "가입 → AI Recall 경험",
+                value: recallActivation,
+                detail: `${formatMetric(metrics.recall.users_with_recall)} / ${formatMetric(metrics.users.total)}명`,
+              },
+            ].map((item) => (
+              <div key={item.label}>
+                <div className="mb-2 flex items-center justify-between gap-4 text-sm">
+                  <span className="font-medium">{item.label}</span>
+                  <span className="text-muted-foreground">
+                    {formatPercentage(item.value)} · {item.detail}
+                  </span>
+                </div>
+                <div className="h-2 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-primary"
+                    style={{ width: `${item.value ?? 0}%` }}
+                  />
+                </div>
+              </div>
+            ))}
+            <p className="text-xs text-muted-foreground">
+              이 비율은 동일 기간 코호트가 아닌 누적 경험 비율입니다. 원인이나
+              전환 효과로 해석하지 마세요.
+            </p>
           </CardContent>
         </Card>
 
         <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              CTR
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Sparkles className="h-4 w-4 text-primary" />
+              다음 관찰 우선순위
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-foreground">{stats.ctr}%</div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              활성 유저
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold text-foreground">{stats.activeUsers}</div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              미클릭 3+
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold text-orange-400">
-              {stats.fatigueUsers}
-            </div>
+            <p className="font-semibold">{insight?.title}</p>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              {insight?.description}
+            </p>
           </CardContent>
         </Card>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <Card>
           <CardHeader>
-            <CardTitle className="text-foreground">타입별 발송 현황</CardTitle>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Megaphone className="h-4 w-4 text-primary" />
+              푸시 반응
+            </CardTitle>
           </CardHeader>
-          <CardContent>
-            {typeStats.length === 0 ? (
-              <div className="text-muted-foreground text-center py-8">
-                오늘 발송된 알림이 없습니다
-              </div>
-            ) : (
-              <div className="space-y-3">
-                {typeStats.map((stat) => (
-                  <div key={stat.push_type} className="flex items-center gap-4">
-                    <div className="w-24 font-medium text-foreground">{stat.push_type}</div>
-                    <div className="flex-1 bg-muted rounded-full h-4">
-                      <div
-                        className="bg-blue-500 rounded-full h-4"
-                        style={{
-                          width: `${Math.min((stat.sent / Math.max(...typeStats.map((s) => s.sent))) * 100, 100)}%`,
-                        }}
-                      />
-                    </div>
-                    <div className="w-32 text-sm text-muted-foreground">
-                      {stat.sent} (CTR {stat.ctr}%)
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
+          <CardContent className="grid grid-cols-3 gap-4">
+            <div>
+              <p className="text-xs text-muted-foreground">7일 발송</p>
+              <p className="mt-1 text-2xl font-bold">
+                {formatMetric(metrics.push.sent_7d)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">7일 클릭</p>
+              <p className="mt-1 text-2xl font-bold">
+                {formatMetric(metrics.push.clicked_7d)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">CTR</p>
+              <p className="mt-1 text-2xl font-bold">
+                {formatPercentage(pushCtr)}
+              </p>
+            </div>
+            <p className="col-span-3 text-xs text-muted-foreground">
+              푸시 CTR은 독서 가치나 리텐션을 직접 증명하지 않습니다. 발송
+              빈도와 메시지 품질을 점검하는 운영 지표로만 사용하세요.
+            </p>
           </CardContent>
         </Card>
 
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle className="text-foreground">최근 발송 로그</CardTitle>
-            <Link
-              href="/admin/push-logs"
-              className="text-sm text-blue-400 hover:underline"
-            >
-              더보기 →
-            </Link>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Database className="h-4 w-4 text-primary" />
+              데이터 상태
+            </CardTitle>
           </CardHeader>
-          <CardContent>
-            {recentLogs.length === 0 ? (
-              <div className="text-muted-foreground text-center py-8">
-                발송 로그가 없습니다
-              </div>
-            ) : (
-              <div className="space-y-2">
-                {recentLogs.slice(0, 5).map((log) => (
-                  <div
-                    key={log.id}
-                    className="flex items-center justify-between py-2 border-b border-border last:border-0"
-                  >
-                    <div className="flex items-center gap-3">
-                      <span className="text-sm text-muted-foreground">
-                        {new Date(log.sent_at).toLocaleTimeString("ko-KR", {
-                          hour: "2-digit",
-                          minute: "2-digit",
-                        })}
-                      </span>
-                      <Badge variant="outline">{log.push_type}</Badge>
-                    </div>
-                    <div>
-                      {log.is_clicked ? (
-                        <span className="text-green-400">✅ clicked</span>
-                      ) : (
-                        <span className="text-muted-foreground">⏳ pending</span>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
+          <CardContent className="space-y-3 text-sm">
+            <div className="flex items-center justify-between">
+              <span>제품 행동 · Supabase</span>
+              <Badge variant="outline">
+                {metrics.source_status === "connected" ? "연결됨" : "부분 연결"}
+              </Badge>
+            </div>
+            <div className="flex items-center justify-between">
+              <span>앱스토어 유입 · App Store Connect</span>
+              <Badge variant="secondary">외부 확인</Badge>
+            </div>
+            <div className="flex items-center justify-between">
+              <span>광고 수익 · AdMob</span>
+              <Badge variant="secondary">Company Control Plane</Badge>
+            </div>
+            <p className="pt-2 text-xs text-muted-foreground">
+              이 화면은 집계값만 반환하며 이메일, 책 제목, 독서 메모, 검색
+              내용은 조회하지 않습니다.
+            </p>
           </CardContent>
         </Card>
       </div>
     </div>
   );
+}
+
+export default function AdminDashboardPage() {
+  return <AdminDashboard />;
 }

--- a/web/src/app/api/admin/monitoring/route.ts
+++ b/web/src/app/api/admin/monitoring/route.ts
@@ -1,0 +1,185 @@
+import { createClient } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+
+import { requireAdminUser } from "@/lib/supabase-server";
+import type { AdminMonitoringMetrics } from "@/types/monitoring";
+
+type GrowthMetricsRpc = {
+  total_users: number;
+  new_users_7d: number;
+  active_users_7d: number;
+  total_books: number;
+  books_created_7d: number;
+  users_with_books: number;
+  total_reading_records: number;
+  reading_records_7d: number;
+  users_with_reading_records: number;
+  total_ai_recalls: number;
+  ai_recalls_7d: number;
+  users_with_ai_recall: number;
+};
+
+export const dynamic = "force-dynamic";
+
+function getAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return null;
+  }
+
+  return createClient(supabaseUrl.trim(), serviceRoleKey.trim(), {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
+
+export async function GET() {
+  if (!(await requireAdminUser())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabaseAdmin = getAdminClient();
+  if (!supabaseAdmin) {
+    return NextResponse.json(
+      { error: "Server configuration error" },
+      { status: 500 }
+    );
+  }
+
+  const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [
+    rpcResult,
+    totalUsersResult,
+    newUsersResult,
+    totalBooksResult,
+    newBooksResult,
+    totalReadingResult,
+    newReadingResult,
+    totalRecallResult,
+    newRecallResult,
+    sentPushResult,
+    clickedPushResult,
+  ] = await Promise.all([
+    supabaseAdmin.rpc("get_control_plane_growth_metrics"),
+    supabaseAdmin.from("users").select("id", { count: "exact", head: true }),
+    supabaseAdmin
+      .from("users")
+      .select("id", { count: "exact", head: true })
+      .gte("created_at", cutoff),
+    supabaseAdmin.from("books").select("id", { count: "exact", head: true }),
+    supabaseAdmin
+      .from("books")
+      .select("id", { count: "exact", head: true })
+      .gte("created_at", cutoff),
+    supabaseAdmin
+      .from("reading_progress_history")
+      .select("id", { count: "exact", head: true }),
+    supabaseAdmin
+      .from("reading_progress_history")
+      .select("id", { count: "exact", head: true })
+      .gte("created_at", cutoff),
+    supabaseAdmin
+      .from("recall_search_history")
+      .select("id", { count: "exact", head: true }),
+    supabaseAdmin
+      .from("recall_search_history")
+      .select("id", { count: "exact", head: true })
+      .gte("created_at", cutoff),
+    supabaseAdmin
+      .from("push_logs")
+      .select("id", { count: "exact", head: true })
+      .gte("sent_at", cutoff),
+    supabaseAdmin
+      .from("push_logs")
+      .select("id", { count: "exact", head: true })
+      .gte("sent_at", cutoff)
+      .eq("is_clicked", true),
+  ]);
+
+  const rpcMetrics = rpcResult.error
+    ? null
+    : (rpcResult.data as GrowthMetricsRpc | null);
+  const unavailableMetrics: string[] = [];
+
+  function countOrNull(
+    result: { count: number | null; error: { message: string } | null },
+    metricName: string
+  ) {
+    if (result.error) {
+      unavailableMetrics.push(metricName);
+      return null;
+    }
+
+    return result.count ?? 0;
+  }
+
+  if (!rpcMetrics) {
+    unavailableMetrics.push(
+      "active_users_7d",
+      "users_with_books",
+      "users_with_reading_records",
+      "users_with_ai_recall"
+    );
+  }
+
+  const metrics: AdminMonitoringMetrics = {
+    generated_at: new Date().toISOString(),
+    period_days: 7,
+    source_status: "connected",
+    unavailable_metrics: unavailableMetrics,
+    users: {
+      total:
+        rpcMetrics?.total_users ??
+        countOrNull(totalUsersResult, "total_users"),
+      new_7d:
+        rpcMetrics?.new_users_7d ??
+        countOrNull(newUsersResult, "new_users_7d"),
+      active_7d: rpcMetrics?.active_users_7d ?? null,
+    },
+    books: {
+      total:
+        rpcMetrics?.total_books ??
+        countOrNull(totalBooksResult, "total_books"),
+      created_7d:
+        rpcMetrics?.books_created_7d ??
+        countOrNull(newBooksResult, "books_created_7d"),
+      users_with_books: rpcMetrics?.users_with_books ?? null,
+    },
+    reading: {
+      total_records:
+        rpcMetrics?.total_reading_records ??
+        countOrNull(totalReadingResult, "total_reading_records"),
+      records_7d:
+        rpcMetrics?.reading_records_7d ??
+        countOrNull(newReadingResult, "reading_records_7d"),
+      users_with_records: rpcMetrics?.users_with_reading_records ?? null,
+    },
+    recall: {
+      total:
+        rpcMetrics?.total_ai_recalls ??
+        countOrNull(totalRecallResult, "total_ai_recalls"),
+      created_7d:
+        rpcMetrics?.ai_recalls_7d ??
+        countOrNull(newRecallResult, "ai_recalls_7d"),
+      users_with_recall: rpcMetrics?.users_with_ai_recall ?? null,
+    },
+    push: {
+      sent_7d: countOrNull(sentPushResult, "push_sent_7d"),
+      clicked_7d: countOrNull(clickedPushResult, "push_clicked_7d"),
+    },
+  };
+
+  metrics.source_status =
+    metrics.unavailable_metrics.length > 0 ? "partial" : "connected";
+
+  return NextResponse.json(metrics, {
+    headers: {
+      "Cache-Control": "private, no-store",
+    },
+  });
+}

--- a/web/src/lib/admin/monitoring.ts
+++ b/web/src/lib/admin/monitoring.ts
@@ -63,7 +63,18 @@ export function getNextAction(metrics: AdminMonitoringMetrics): {
     };
   }
 
-  if ((metrics.books.created_7d ?? 0) === 0) {
+  if (
+    metrics.books.created_7d === null ||
+    metrics.reading.records_7d === null
+  ) {
+    return {
+      title: "핵심 행동 지표 연결을 확인하세요",
+      description:
+        "최근 7일 책 등록 또는 독서 기록 수치를 불러오지 못했습니다. 데이터 연결 상태를 먼저 확인하세요.",
+    };
+  }
+
+  if (metrics.books.created_7d === 0) {
     return {
       title: "책 등록 진입 흐름을 점검하세요",
       description:
@@ -71,7 +82,7 @@ export function getNextAction(metrics: AdminMonitoringMetrics): {
     };
   }
 
-  if ((metrics.reading.records_7d ?? 0) < (metrics.books.created_7d ?? 0)) {
+  if (metrics.reading.records_7d < metrics.books.created_7d) {
     return {
       title: "첫 독서 기록 전환을 개선하세요",
       description:

--- a/web/src/lib/admin/monitoring.ts
+++ b/web/src/lib/admin/monitoring.ts
@@ -1,0 +1,87 @@
+import type {
+  AdminMonitoringMetrics,
+  MetricValue,
+} from "@/types/monitoring";
+
+export function percentage(
+  numerator: MetricValue,
+  denominator: MetricValue
+): number | null {
+  if (numerator === null || denominator === null || denominator <= 0) {
+    return null;
+  }
+
+  return Math.round((numerator / denominator) * 1000) / 10;
+}
+
+export function formatMetric(value: MetricValue): string {
+  return value === null ? "연결 필요" : value.toLocaleString("ko-KR");
+}
+
+export function formatPercentage(value: number | null): string {
+  return value === null ? "계산 불가" : `${value.toFixed(1)}%`;
+}
+
+export function formatGeneratedAt(value: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  })
+    .formatToParts(new Date(value))
+    .reduce<Record<string, string>>((result, part) => {
+      result[part.type] = part.value;
+      return result;
+    }, {});
+
+  return `${parts.year}.${parts.month}.${parts.day} ${parts.hour}:${parts.minute} KST`;
+}
+
+export function getNextAction(metrics: AdminMonitoringMetrics): {
+  title: string;
+  description: string;
+} {
+  const activeUsers = metrics.users.active_7d;
+
+  if (activeUsers === null) {
+    return {
+      title: "활성 사용자 집계를 먼저 연결하세요",
+      description:
+        "성장 지표 RPC가 배포되면 사용자 식별정보를 노출하지 않고 최근 7일 활성 사용자를 확인할 수 있습니다.",
+    };
+  }
+
+  if (activeUsers < 30) {
+    return {
+      title: "표본을 늘리고 추세만 관찰하세요",
+      description:
+        "최근 7일 활성 사용자가 30명 미만입니다. 비율 최적화보다 첫 독서 기록까지의 사용성 문제를 직접 관찰하는 편이 안전합니다.",
+    };
+  }
+
+  if ((metrics.books.created_7d ?? 0) === 0) {
+    return {
+      title: "책 등록 진입 흐름을 점검하세요",
+      description:
+        "최근 7일 책 등록이 없습니다. 검색, 직접 입력, 표지 촬영 흐름에서 이탈 지점을 확인하세요.",
+    };
+  }
+
+  if ((metrics.reading.records_7d ?? 0) < (metrics.books.created_7d ?? 0)) {
+    return {
+      title: "첫 독서 기록 전환을 개선하세요",
+      description:
+        "최근 책 등록보다 독서 기록 수가 적습니다. 등록 직후 첫 페이지 기록으로 이어지는 안내를 우선 점검하세요.",
+    };
+  }
+
+  return {
+    title: "AI Recall 재사용 경험을 관찰하세요",
+    description:
+      "핵심 독서 행동은 발생하고 있습니다. 독서 기록이 실제 Recall 검색으로 이어지는지 사용자 인터뷰와 함께 확인하세요.",
+  };
+}

--- a/web/src/types/monitoring.ts
+++ b/web/src/types/monitoring.ts
@@ -1,0 +1,32 @@
+export type MetricValue = number | null;
+
+export type AdminMonitoringMetrics = {
+  generated_at: string;
+  period_days: number;
+  source_status: "connected" | "partial";
+  unavailable_metrics: string[];
+  users: {
+    total: MetricValue;
+    new_7d: MetricValue;
+    active_7d: MetricValue;
+  };
+  books: {
+    total: MetricValue;
+    created_7d: MetricValue;
+    users_with_books: MetricValue;
+  };
+  reading: {
+    total_records: MetricValue;
+    records_7d: MetricValue;
+    users_with_records: MetricValue;
+  };
+  recall: {
+    total: MetricValue;
+    created_7d: MetricValue;
+    users_with_recall: MetricValue;
+  };
+  push: {
+    sent_7d: MetricValue;
+    clicked_7d: MetricValue;
+  };
+};

--- a/web/tests/monitoring.test.mjs
+++ b/web/tests/monitoring.test.mjs
@@ -39,3 +39,43 @@ test("next action prioritizes an unavailable active-user metric", () => {
 
   assert.equal(action.title, "활성 사용자 집계를 먼저 연결하세요");
 });
+
+test("next action does not treat an unavailable book metric as zero", () => {
+  const action = getNextAction({
+    generated_at: "2026-07-29T04:00:00.000Z",
+    period_days: 7,
+    source_status: "partial",
+    unavailable_metrics: ["books_created_7d"],
+    users: { total: 50, new_7d: 12, active_7d: 35 },
+    books: { total: 80, created_7d: null, users_with_books: 42 },
+    reading: {
+      total_records: 140,
+      records_7d: 20,
+      users_with_records: 31,
+    },
+    recall: { total: 36, created_7d: 8, users_with_recall: 18 },
+    push: { sent_7d: 45, clicked_7d: 9 },
+  });
+
+  assert.equal(action.title, "핵심 행동 지표 연결을 확인하세요");
+});
+
+test("next action does not compare an unavailable reading metric", () => {
+  const action = getNextAction({
+    generated_at: "2026-07-29T04:00:00.000Z",
+    period_days: 7,
+    source_status: "partial",
+    unavailable_metrics: ["reading_records_7d"],
+    users: { total: 50, new_7d: 12, active_7d: 35 },
+    books: { total: 80, created_7d: 18, users_with_books: 42 },
+    reading: {
+      total_records: 140,
+      records_7d: null,
+      users_with_records: 31,
+    },
+    recall: { total: 36, created_7d: 8, users_with_recall: 18 },
+    push: { sent_7d: 45, clicked_7d: 9 },
+  });
+
+  assert.equal(action.title, "핵심 행동 지표 연결을 확인하세요");
+});

--- a/web/tests/monitoring.test.mjs
+++ b/web/tests/monitoring.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  formatGeneratedAt,
+  getNextAction,
+  percentage,
+} from "../src/lib/admin/monitoring.ts";
+
+test("percentage returns a rounded rate and preserves unavailable values", () => {
+  assert.equal(percentage(1, 3), 33.3);
+  assert.equal(percentage(null, 3), null);
+  assert.equal(percentage(1, 0), null);
+});
+
+test("generated time is stable in Korea Standard Time", () => {
+  assert.equal(
+    formatGeneratedAt("2026-07-29T04:00:00.000Z"),
+    "2026.07.29 13:00 KST"
+  );
+});
+
+test("next action prioritizes an unavailable active-user metric", () => {
+  const action = getNextAction({
+    generated_at: "2026-07-29T04:00:00.000Z",
+    period_days: 7,
+    source_status: "partial",
+    unavailable_metrics: ["active_users_7d"],
+    users: { total: 12, new_7d: 2, active_7d: null },
+    books: { total: 18, created_7d: 4, users_with_books: null },
+    reading: {
+      total_records: 43,
+      records_7d: 9,
+      users_with_records: null,
+    },
+    recall: { total: 6, created_7d: 2, users_with_recall: null },
+    push: { sent_7d: 21, clicked_7d: 4 },
+  });
+
+  assert.equal(action.title, "활성 사용자 집계를 먼저 연결하세요");
+});


### PR DESCRIPTION
Target-Delivery-Unit: web
Target-Version: 1.0.0
Delivery-Profile: web-release-train
Promotion-Source-SHA:

제품 행동과 푸시 운영을 개인정보 없는 집계 지표로 분리합니다.

## 📋 Changes

- 책 등록, 독서 기록, AI Recall의 최근 7일 지표와 누적 경험 비율을 표시합니다.
- 서버 전용 집계 API로 브라우저의 전체 푸시 로그 조회를 제거합니다.
- 부분 연결, 저표본, 외부 데이터 상태와 다음 관찰 우선순위를 표시합니다.
- KST 시각 형식과 지표 계산 자동 테스트를 추가합니다.

## 🧠 Context & Background

기존 대시보드는 푸시 수신자를 활성 사용자로 표시해 제품 성장을 오해할 수 있었고, 브라우저가 운영 로그 전체를 직접 조회했습니다. 성장 지표와 푸시 운영 지표를 분리하고 연결되지 않은 값은 0 대신 연결 필요로 표현합니다.

## ✅ How to Test

- [x] 타깃 버전 원본, branch, base, PR metadata가 모두 일치한다.
- [x] web npm run lint
- [x] web npm run build
- [x] web npm run test:monitoring
- [x] 390px 모바일 폭에서 가로 넘침 없음
- [x] 비인증 접근은 로그인으로 리디렉션되고 집계 API는 401 응답

## 🗄️ Database Migration Checklist

- [x] DB 스키마 변경 없음
- [x] Edge Function 변경 없음

## 🙌 Additional Notes

고유 사용자 기반 지표는 별도 성장 집계 RPC가 배포되기 전까지 부분 연결 상태로 안전하게 표시됩니다. 이 PR은 운영 배포나 병합을 수행하지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Growth·Operations admin dashboard showing seven-day activity, activation progress, reading engagement, and push performance.
  * Added an admin monitoring API that powers the dashboard, including loading/error states and partial-data/low-sample indicators.
  * Added monitoring-driven “next observation” insights based on current metrics.
  * Updated the admin navigation label for the dashboard route.
* **Tests**
  * Added a Node.js test suite for monitoring calculations, date formatting, and recommended-action prioritization, with a dedicated `test:monitoring` script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->