### PR TITLE
fix(governance): activate web 1.0.0 policy

### DIFF
--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -57,7 +57,9 @@
     "web": {
       "profile": "web-release-train",
       "mode": "version-line",
-      "active_versions": [],
+      "active_versions": [
+        "1.0.0"
+      ],
       "target_version_source": ".byungskerlab/release-lines.json",
       "production_branch": "main",
       "allowed_paths": [


### PR DESCRIPTION
## 목적

웹 1.0.0 릴리스 레지스트리와 브랜치 정책의 활성 버전을 일치시켜 웹 작업의 Target Version Contract 검증을 복구합니다.

## 주요 변경

- `.byungskerlab/branch-policy.json`의 web 활성 버전을 `1.0.0`으로 설정
- `.byungskerlab/release-lines.json`의 기존 활성 버전과 일치하도록 정정

## 배경

이전 거버넌스 변경에서 릴리스 레지스트리만 갱신되어, 신뢰된 기본 브랜치 검증기가 웹 PR을 거부했습니다.

## 검증

- JSON 파싱
- `git diff --check`
- 회사 target-delivery preflight로 policy/registry 활성 버전 일치 확인
- trusted validator로 governance 및 web 1.0.0 계약 확인

## 롤백

이 PR의 단일 정책 변경을 revert하면 원상복구됩니다.

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local