### PR TITLE
fix(ios): localize permissions and quick actions

### DIFF
--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -106,7 +106,7 @@
 				<key>UIApplicationShortcutItemType</key>
 				<string>com.bookgolas.continue-reading</string>
 				<key>UIApplicationShortcutItemTitle</key>
-				<string>이어서 읽기</string>
+				<string>QUICK_ACTION_CONTINUE_READING</string>
 				<key>UIApplicationShortcutItemIconType</key>
 				<string>UIApplicationShortcutIconTypeBookmark</string>
 			</dict>
@@ -114,7 +114,7 @@
 				<key>UIApplicationShortcutItemType</key>
 				<string>com.bookgolas.scan-page</string>
 				<key>UIApplicationShortcutItemTitle</key>
-				<string>페이지 스캔</string>
+				<string>QUICK_ACTION_SCAN_PAGE</string>
 				<key>UIApplicationShortcutItemIconType</key>
 				<string>UIApplicationShortcutIconTypeCapturePhoto</string>
 			</dict>
@@ -122,7 +122,7 @@
 				<key>UIApplicationShortcutItemType</key>
 				<string>com.bookgolas.add-book</string>
 				<key>UIApplicationShortcutItemTitle</key>
-				<string>책 추가</string>
+				<string>QUICK_ACTION_ADD_BOOK</string>
 				<key>UIApplicationShortcutItemIconType</key>
 				<string>UIApplicationShortcutIconTypeAdd</string>
 			</dict>

--- a/app/ios/en.lproj/InfoPlist.strings
+++ b/app/ios/en.lproj/InfoPlist.strings
@@ -1,3 +1,9 @@
 /* English localization */
 "CFBundleDisplayName" = "Bookgolas";
 "CFBundleName" = "Bookgolas";
+"NSCameraUsageDescription" = "Camera access is required to scan book pages.";
+"NSPhotoLibraryUsageDescription" = "Photo library access is required to select a profile image or book page image.";
+"NSPhotoLibraryAddUsageDescription" = "Photo library access is required to save scanned images.";
+"QUICK_ACTION_CONTINUE_READING" = "Continue Reading";
+"QUICK_ACTION_SCAN_PAGE" = "Scan Page";
+"QUICK_ACTION_ADD_BOOK" = "Add Book";

--- a/app/ios/ko.lproj/InfoPlist.strings
+++ b/app/ios/ko.lproj/InfoPlist.strings
@@ -1,3 +1,9 @@
 /* Korean localization */
 "CFBundleDisplayName" = "북골라스";
 "CFBundleName" = "북골라스";
+"NSCameraUsageDescription" = "책 페이지를 스캔하기 위해 카메라 권한이 필요합니다.";
+"NSPhotoLibraryUsageDescription" = "프로필 이미지 또는 책 페이지 이미지를 선택하기 위해 사진 보관함 권한이 필요합니다.";
+"NSPhotoLibraryAddUsageDescription" = "스캔한 이미지를 저장하기 위해 사진 보관함 권한이 필요합니다.";
+"QUICK_ACTION_CONTINUE_READING" = "이어서 읽기";
+"QUICK_ACTION_SCAN_PAGE" = "페이지 스캔";
+"QUICK_ACTION_ADD_BOOK" = "책 추가";


### PR DESCRIPTION
## 목적

북골라스 1.0.2의 iOS 네이티브 권한 안내와 홈 화면 빠른 실행 제목을 한국어·영어로 제공합니다.

## 주요 변경

- 카메라와 사진 보관함 권한 목적을 ko/en `InfoPlist.strings`에 추가했습니다.
- 사진 보관함 문구에 프로필 이미지와 책 페이지 이미지 선택 목적을 모두 명시했습니다.
- 정적 빠른 실행 제목을 현지화 키로 전환하고 두 언어 값을 추가했습니다.

## 배경

기존 빠른 실행 제목은 한국어로 고정되어 있었고, 권한 목적 문자열도 영어 환경에서 현지화되지 않았습니다. 이는 BOK-345와 1.0.2 출시 계획의 REL-102-04 범위입니다.

## 검증

- `plutil -lint`로 Info.plist와 ko/en InfoPlist.strings 검증
- `flutter analyze --no-fatal-infos` 종료 코드 0, 기존 기준선 135 info
- 배포 없는 iOS prod release 빌드 성공: 1.0.2+15002
- 빌드된 Runner.app에서 ko/en 권한 문구와 빠른 실행 제목을 read-back
- 독립 품질 검토 후 수정 요청 반영 및 재검토 통과
- `git diff --check` 통과

## 미검증

- 실제 기기에서 표시되는 ko/en 시스템 권한 팝업
- 홈 화면 롱프레스에서 표시되는 ko/en 빠른 실행 제목

## 관련 이슈

- BOK-345

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized iOS Quick Action titles for continuing reading, scanning pages, and adding books in English and Korean.
  * Added localized explanations for camera and photo library access requests.

* **Localization**
  * Improved Korean and English localization for app shortcuts and permission prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->