### PR TITLE
fix(mobile): make book status tabs accessible

### DIFF
--- a/app/lib/ui/book_list/widgets/book_list_screen.dart
+++ b/app/lib/ui/book_list/widgets/book_list_screen.dart
@@ -45,9 +45,14 @@ class _BookListScreenState extends State<BookListScreen>
   }
 
   void _syncTabController() {
-    if (_tabController.index != _viewModel.selectedTabIndex) {
-      _tabController.animateTo(_viewModel.selectedTabIndex);
-    }
+    if (!mounted || _tabController.index == _viewModel.selectedTabIndex) return;
+    final disableAnimations =
+        MediaQuery.maybeOf(context)?.disableAnimations ?? false;
+    _tabController.animateTo(
+      _viewModel.selectedTabIndex,
+      duration:
+          disableAnimations ? Duration.zero : const Duration(milliseconds: 300),
+    );
   }
 
   @override

--- a/app/lib/ui/book_list/widgets/book_list_screen.dart
+++ b/app/lib/ui/book_list/widgets/book_list_screen.dart
@@ -26,57 +26,34 @@ class BookListScreen extends StatefulWidget {
 class _BookListScreenState extends State<BookListScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
-  late ScrollController _tabScrollController;
+  late final BookListViewModel _viewModel;
   bool _isRefreshing = false;
 
   @override
   void initState() {
     super.initState();
-    _tabScrollController = ScrollController();
-    final vm = context.read<BookListViewModel>();
+    _viewModel = context.read<BookListViewModel>();
     _tabController = TabController(
-        length: 5, vsync: this, initialIndex: vm.selectedTabIndex);
+        length: 5, vsync: this, initialIndex: _viewModel.selectedTabIndex);
     _tabController.addListener(() {
       if (!_tabController.indexIsChanging) {
-        vm.setSelectedTabIndex(_tabController.index);
+        _viewModel.setSelectedTabIndex(_tabController.index);
       }
     });
 
-    vm.addListener(_syncTabController);
+    _viewModel.addListener(_syncTabController);
   }
 
   void _syncTabController() {
-    final vm = context.read<BookListViewModel>();
-    if (_tabController.index != vm.selectedTabIndex) {
-      _tabController.animateTo(vm.selectedTabIndex);
-      _scrollToSelectedTab(vm.selectedTabIndex);
+    if (_tabController.index != _viewModel.selectedTabIndex) {
+      _tabController.animateTo(_viewModel.selectedTabIndex);
     }
-  }
-
-  void _scrollToSelectedTab(int index) {
-    if (!_tabScrollController.hasClients) return;
-
-    const tabWidth = 100.0;
-    final screenWidth = MediaQuery.of(context).size.width;
-    final targetOffset =
-        (index * tabWidth) - (screenWidth / 2) + (tabWidth / 2);
-    final clampedOffset = targetOffset.clamp(
-      0.0,
-      _tabScrollController.position.maxScrollExtent,
-    );
-
-    _tabScrollController.animateTo(
-      clampedOffset,
-      duration: const Duration(milliseconds: 300),
-      curve: Curves.easeOutCubic,
-    );
   }
 
   @override
   void dispose() {
-    context.read<BookListViewModel>().removeListener(_syncTabController);
+    _viewModel.removeListener(_syncTabController);
     _tabController.dispose();
-    _tabScrollController.dispose();
     super.dispose();
   }
 
@@ -118,7 +95,6 @@ class _BookListScreenState extends State<BookListScreen>
     final l10n = AppLocalizations.of(context);
     return ScrollableTabBar(
       controller: _tabController,
-      scrollController: _tabScrollController,
       selectedIndex: vm.selectedTabIndex,
       tabs: [
         l10n.bookListTabReading,
@@ -127,7 +103,6 @@ class _BookListScreenState extends State<BookListScreen>
         l10n.bookListTabReread,
         l10n.bookListTabAll,
       ],
-      onTabSelected: (index) => _scrollToSelectedTab(index),
     );
   }
 

--- a/app/lib/ui/core/widgets/empty_state_view.dart
+++ b/app/lib/ui/core/widgets/empty_state_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_svg/flutter_svg.dart';
 
+import 'package:book_golas/ui/core/theme/design_system.dart';
 import 'package:book_golas/ui/core/widgets/liquid_glass_button.dart';
 
 class EmptyStateView extends StatelessWidget {
@@ -20,6 +21,7 @@ class EmptyStateView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
     return Center(
       child: Padding(
         padding: const EdgeInsets.only(left: 16, right: 16, bottom: 80),
@@ -37,9 +39,12 @@ class EmptyStateView extends StatelessWidget {
             const SizedBox(height: 16),
             Text(
               message,
-              style: const TextStyle(
+              key: const ValueKey('empty-state-message'),
+              style: TextStyle(
                 fontSize: 15,
-                color: Colors.grey,
+                color: isDark
+                    ? BLabColors.textTertiaryDark
+                    : BLabColors.textTertiaryLight,
               ),
               textAlign: TextAlign.center,
             ),

--- a/app/lib/ui/core/widgets/empty_state_view.dart
+++ b/app/lib/ui/core/widgets/empty_state_view.dart
@@ -21,7 +21,6 @@ class EmptyStateView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     return Center(
       child: Padding(
         padding: const EdgeInsets.only(left: 16, right: 16, bottom: 80),
@@ -40,11 +39,8 @@ class EmptyStateView extends StatelessWidget {
             Text(
               message,
               key: const ValueKey('empty-state-message'),
-              style: TextStyle(
-                fontSize: 15,
-                color: isDark
-                    ? BLabColors.textTertiaryDark
-                    : BLabColors.textTertiaryLight,
+              style: AppTypography.bodyMedium.copyWith(
+                color: BLabColors.textTertiary(context),
               ),
               textAlign: TextAlign.center,
             ),

--- a/app/lib/ui/core/widgets/scrollable_tab_bar.dart
+++ b/app/lib/ui/core/widgets/scrollable_tab_bar.dart
@@ -39,21 +39,27 @@ class ScrollableTabBar extends StatefulWidget {
 class _ScrollableTabBarState extends State<ScrollableTabBar> {
   late ScrollController _scrollController;
   List<double> _tabWidths = const [];
+  bool _canScrollBackward = false;
+  bool _canScrollForward = false;
+  bool _disableAnimations = false;
 
   @override
   void initState() {
     super.initState();
     _scrollController = widget.scrollController ?? ScrollController();
+    _scrollController.addListener(_updateScrollAffordances);
   }
 
   @override
   void didUpdateWidget(covariant ScrollableTabBar oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.scrollController != widget.scrollController) {
+      _scrollController.removeListener(_updateScrollAffordances);
       if (oldWidget.scrollController == null) {
         _scrollController.dispose();
       }
       _scrollController = widget.scrollController ?? ScrollController();
+      _scrollController.addListener(_updateScrollAffordances);
     }
     if (oldWidget.selectedIndex != widget.selectedIndex ||
         oldWidget.tabs != widget.tabs) {
@@ -63,6 +69,7 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
 
   @override
   void dispose() {
+    _scrollController.removeListener(_updateScrollAffordances);
     if (widget.scrollController == null) {
       _scrollController.dispose();
     }
@@ -72,17 +79,17 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    _disableAnimations =
+        MediaQuery.maybeOf(context)?.disableAnimations ?? false;
     final textScaler = MediaQuery.textScalerOf(context);
     final textDirection = Directionality.of(context);
-    final bgColor =
-        widget.backgroundColor ??
+    final bgColor = widget.backgroundColor ??
         (isDark ? BLabColors.scaffoldDark : Colors.white);
     final indicator =
         widget.indicatorColor ?? (isDark ? Colors.white : Colors.black);
     final selectedColor =
         widget.selectedTextColor ?? (isDark ? Colors.white : Colors.black);
-    final unselectedColor =
-        widget.unselectedTextColor ??
+    final unselectedColor = widget.unselectedTextColor ??
         (isDark ? Colors.grey[400]! : Colors.grey[600]!);
     final selectedStyle = TextStyle(
       fontSize: 14,
@@ -114,51 +121,111 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
     final totalWidth = tabWidths.fold<double>(0, (sum, width) => sum + width);
     _tabWidths = tabWidths;
     _scheduleSelectedTabVisibility();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _updateScrollAffordances();
+      }
+    });
 
     return Container(
       color: bgColor,
       child: SizedBox(
         height: tabBarHeight,
-        child: SingleChildScrollView(
-          key: const ValueKey('scrollable-tab-bar-scroll-view'),
-          controller: _scrollController,
-          scrollDirection: Axis.horizontal,
-          child: SizedBox(
-            width: totalWidth,
-            height: tabBarHeight,
-            child: Stack(
-              children: [
-                Row(
-                  children: List.generate(widget.tabs.length, (index) {
-                    return _buildTabItem(
-                      title: widget.tabs[index],
-                      index: index,
-                      width: tabWidths[index],
-                      height: tabBarHeight - 2,
-                      style: widget.selectedIndex == index
-                          ? selectedStyle
-                          : unselectedStyle,
-                    );
-                  }),
+        child: Stack(
+          children: [
+            SingleChildScrollView(
+              key: const ValueKey('scrollable-tab-bar-scroll-view'),
+              controller: _scrollController,
+              scrollDirection: Axis.horizontal,
+              child: SizedBox(
+                width: totalWidth,
+                height: tabBarHeight,
+                child: Stack(
+                  children: [
+                    Row(
+                      children: List.generate(widget.tabs.length, (index) {
+                        return _buildTabItem(
+                          title: widget.tabs[index],
+                          index: index,
+                          width: tabWidths[index],
+                          height: tabBarHeight - 2,
+                          style: widget.selectedIndex == index
+                              ? selectedStyle
+                              : unselectedStyle,
+                        );
+                      }),
+                    ),
+                    AnimatedBuilder(
+                      animation: widget.controller.animation!,
+                      builder: (context, child) {
+                        final geometry = _indicatorGeometry(
+                          widget.controller.animation!.value,
+                          tabWidths,
+                        );
+                        return Positioned(
+                          left: geometry.left,
+                          bottom: 0,
+                          width: geometry.width,
+                          height: 2,
+                          child: ColoredBox(color: indicator),
+                        );
+                      },
+                    ),
+                  ],
                 ),
-                AnimatedBuilder(
-                  animation: widget.controller.animation!,
-                  builder: (context, child) {
-                    final geometry = _indicatorGeometry(
-                      widget.controller.animation!.value,
-                      tabWidths,
-                    );
-                    return Positioned(
-                      left: geometry.left,
-                      bottom: 0,
-                      width: geometry.width,
-                      height: 2,
-                      child: ColoredBox(color: indicator),
-                    );
-                  },
-                ),
-              ],
+              ),
             ),
+            if (_canScrollBackward)
+              Align(
+                alignment: Alignment.centerLeft,
+                child: _buildScrollAffordance(
+                  key: const ValueKey('scrollable-tab-bar-leading-affordance'),
+                  backgroundColor: bgColor,
+                  foregroundColor: unselectedColor,
+                  isLeading: true,
+                ),
+              ),
+            if (_canScrollForward)
+              Align(
+                alignment: Alignment.centerRight,
+                child: _buildScrollAffordance(
+                  key: const ValueKey('scrollable-tab-bar-trailing-affordance'),
+                  backgroundColor: bgColor,
+                  foregroundColor: unselectedColor,
+                  isLeading: false,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildScrollAffordance({
+    required Key key,
+    required Color backgroundColor,
+    required Color foregroundColor,
+    required bool isLeading,
+  }) {
+    return ExcludeSemantics(
+      child: IgnorePointer(
+        child: Container(
+          key: key,
+          width: 72,
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: isLeading ? Alignment.centerLeft : Alignment.centerRight,
+              end: isLeading ? Alignment.centerRight : Alignment.centerLeft,
+              colors: [backgroundColor, backgroundColor.withValues(alpha: 0)],
+              stops: const [0.42, 1],
+            ),
+          ),
+          alignment: isLeading ? Alignment.centerLeft : Alignment.centerRight,
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Icon(
+            isLeading ? Icons.chevron_left : Icons.chevron_right,
+            color: foregroundColor,
+            size: 28,
           ),
         ),
       ),
@@ -175,7 +242,12 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
     final isSelected = widget.selectedIndex == index;
 
     void selectTab() {
-      widget.controller.animateTo(index);
+      widget.controller.animateTo(
+        index,
+        duration: _disableAnimations
+            ? Duration.zero
+            : const Duration(milliseconds: 300),
+      );
       widget.onTabSelected?.call(index);
       _ensureTabVisible(index);
     }
@@ -228,8 +300,7 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
     final upperLeft = _offsetForIndex(upperIndex, widths);
     return (
       left: lowerLeft + ((upperLeft - lowerLeft) * progress),
-      width:
-          widths[lowerIndex] +
+      width: widths[lowerIndex] +
           ((widths[upperIndex] - widths[lowerIndex]) * progress),
     );
   }
@@ -269,10 +340,31 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
     if ((targetOffset - currentOffset).abs() < 0.5) {
       return;
     }
+    if (_disableAnimations) {
+      _scrollController.jumpTo(targetOffset);
+      return;
+    }
     _scrollController.animateTo(
       targetOffset,
       duration: const Duration(milliseconds: 300),
       curve: Curves.easeOutCubic,
     );
+  }
+
+  void _updateScrollAffordances() {
+    if (!_scrollController.hasClients || !mounted) {
+      return;
+    }
+    final position = _scrollController.position;
+    final canScrollBackward = position.pixels > 0.5;
+    final canScrollForward = position.pixels < position.maxScrollExtent - 0.5;
+    if (canScrollBackward == _canScrollBackward &&
+        canScrollForward == _canScrollForward) {
+      return;
+    }
+    setState(() {
+      _canScrollBackward = canScrollBackward;
+      _canScrollForward = canScrollForward;
+    });
   }
 }

--- a/app/lib/ui/core/widgets/scrollable_tab_bar.dart
+++ b/app/lib/ui/core/widgets/scrollable_tab_bar.dart
@@ -37,10 +37,16 @@ class ScrollableTabBar extends StatefulWidget {
 }
 
 class _ScrollableTabBarState extends State<ScrollableTabBar> {
+  static const _minimumAffordanceWidth = 32.0;
+  static const _affordanceFadeWidth = 8.0;
+
   late ScrollController _scrollController;
   List<double> _tabWidths = const [];
+  List<double> _labelWidths = const [];
   bool _canScrollBackward = false;
   bool _canScrollForward = false;
+  double _leadingAffordanceWidth = 0;
+  double _trailingAffordanceWidth = 0;
   bool _disableAnimations = false;
 
   @override
@@ -120,6 +126,7 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
     final tabBarHeight = math.max(widget.height, contentHeight + 24 + 2);
     final totalWidth = tabWidths.fold<double>(0, (sum, width) => sum + width);
     _tabWidths = tabWidths;
+    _labelWidths = metrics.map((metric) => metric.width).toList();
     _scheduleSelectedTabVisibility();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
@@ -175,7 +182,7 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
                 ),
               ),
             ),
-            if (_canScrollBackward)
+            if (_canScrollBackward && _leadingAffordanceWidth > 0)
               Align(
                 alignment: Alignment.centerLeft,
                 child: _buildScrollAffordance(
@@ -183,9 +190,10 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
                   backgroundColor: bgColor,
                   foregroundColor: unselectedColor,
                   isLeading: true,
+                  width: _leadingAffordanceWidth,
                 ),
               ),
-            if (_canScrollForward)
+            if (_canScrollForward && _trailingAffordanceWidth > 0)
               Align(
                 alignment: Alignment.centerRight,
                 child: _buildScrollAffordance(
@@ -193,6 +201,7 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
                   backgroundColor: bgColor,
                   foregroundColor: unselectedColor,
                   isLeading: false,
+                  width: _trailingAffordanceWidth,
                 ),
               ),
           ],
@@ -206,26 +215,30 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
     required Color backgroundColor,
     required Color foregroundColor,
     required bool isLeading,
+    required double width,
   }) {
     return ExcludeSemantics(
       child: IgnorePointer(
         child: Container(
           key: key,
-          width: 72,
+          width: width,
           decoration: BoxDecoration(
             gradient: LinearGradient(
               begin: isLeading ? Alignment.centerLeft : Alignment.centerRight,
               end: isLeading ? Alignment.centerRight : Alignment.centerLeft,
               colors: [backgroundColor, backgroundColor.withValues(alpha: 0)],
-              stops: const [0.42, 1],
+              stops: [
+                ((width - _affordanceFadeWidth) / width).clamp(0.0, 1.0),
+                1,
+              ],
             ),
           ),
           alignment: isLeading ? Alignment.centerLeft : Alignment.centerRight,
-          padding: const EdgeInsets.symmetric(horizontal: 8),
+          padding: const EdgeInsets.symmetric(horizontal: 4),
           child: Icon(
             isLeading ? Icons.chevron_left : Icons.chevron_right,
             color: foregroundColor,
-            size: 28,
+            size: 24,
           ),
         ),
       ),
@@ -325,15 +338,9 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
     }
     final viewportWidth = _scrollController.position.viewportDimension;
     final tabStart = _offsetForIndex(index, _tabWidths);
-    final tabEnd = tabStart + _tabWidths[index];
+    final tabCenter = tabStart + (_tabWidths[index] / 2);
     final currentOffset = _scrollController.offset;
-    var targetOffset = currentOffset;
-    if (tabStart < currentOffset) {
-      targetOffset = tabStart;
-    } else if (tabEnd > currentOffset + viewportWidth) {
-      targetOffset = tabEnd - viewportWidth;
-    }
-    targetOffset = targetOffset.clamp(
+    final targetOffset = (tabCenter - (viewportWidth / 2)).clamp(
       0.0,
       _scrollController.position.maxScrollExtent,
     );
@@ -358,13 +365,61 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
     final position = _scrollController.position;
     final canScrollBackward = position.pixels > 0.5;
     final canScrollForward = position.pixels < position.maxScrollExtent - 0.5;
+    final leadingWidth = canScrollBackward
+        ? _partialLabelAffordanceWidth(
+            viewportStart: position.pixels,
+            viewportEnd: position.pixels + position.viewportDimension,
+            isLeading: true,
+          )
+        : 0.0;
+    final trailingWidth = canScrollForward
+        ? _partialLabelAffordanceWidth(
+            viewportStart: position.pixels,
+            viewportEnd: position.pixels + position.viewportDimension,
+            isLeading: false,
+          )
+        : 0.0;
     if (canScrollBackward == _canScrollBackward &&
-        canScrollForward == _canScrollForward) {
+        canScrollForward == _canScrollForward &&
+        (leadingWidth - _leadingAffordanceWidth).abs() < 0.5 &&
+        (trailingWidth - _trailingAffordanceWidth).abs() < 0.5) {
       return;
     }
     setState(() {
       _canScrollBackward = canScrollBackward;
       _canScrollForward = canScrollForward;
+      _leadingAffordanceWidth = leadingWidth;
+      _trailingAffordanceWidth = trailingWidth;
     });
+  }
+
+  double _partialLabelAffordanceWidth({
+    required double viewportStart,
+    required double viewportEnd,
+    required bool isLeading,
+  }) {
+    for (var index = 0; index < _tabWidths.length; index += 1) {
+      final tabStart = _offsetForIndex(index, _tabWidths);
+      final labelInset = (_tabWidths[index] - _labelWidths[index]) / 2;
+      final labelStart = tabStart + labelInset;
+      final labelEnd = labelStart + _labelWidths[index];
+      if (isLeading &&
+          labelStart < viewportStart - 0.5 &&
+          labelEnd > viewportStart + 0.5) {
+        return math.max(
+          _minimumAffordanceWidth,
+          (labelEnd - viewportStart) + _affordanceFadeWidth,
+        );
+      }
+      if (!isLeading &&
+          labelStart < viewportEnd - 0.5 &&
+          labelEnd > viewportEnd + 0.5) {
+        return math.max(
+          _minimumAffordanceWidth,
+          (viewportEnd - labelStart) + _affordanceFadeWidth,
+        );
+      }
+    }
+    return 0;
   }
 }

--- a/app/lib/ui/core/widgets/scrollable_tab_bar.dart
+++ b/app/lib/ui/core/widgets/scrollable_tab_bar.dart
@@ -1,8 +1,10 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 import 'package:book_golas/ui/core/theme/design_system.dart';
 
-class ScrollableTabBar extends StatelessWidget {
+class ScrollableTabBar extends StatefulWidget {
   final TabController controller;
   final List<String> tabs;
   final ScrollController? scrollController;
@@ -31,88 +33,246 @@ class ScrollableTabBar extends StatelessWidget {
   });
 
   @override
+  State<ScrollableTabBar> createState() => _ScrollableTabBarState();
+}
+
+class _ScrollableTabBarState extends State<ScrollableTabBar> {
+  late ScrollController _scrollController;
+  List<double> _tabWidths = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = widget.scrollController ?? ScrollController();
+  }
+
+  @override
+  void didUpdateWidget(covariant ScrollableTabBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.scrollController != widget.scrollController) {
+      if (oldWidget.scrollController == null) {
+        _scrollController.dispose();
+      }
+      _scrollController = widget.scrollController ?? ScrollController();
+    }
+    if (oldWidget.selectedIndex != widget.selectedIndex ||
+        oldWidget.tabs != widget.tabs) {
+      _scheduleSelectedTabVisibility();
+    }
+  }
+
+  @override
+  void dispose() {
+    if (widget.scrollController == null) {
+      _scrollController.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    final textScaler = MediaQuery.textScalerOf(context);
+    final textDirection = Directionality.of(context);
     final bgColor =
-        backgroundColor ?? (isDark ? BLabColors.scaffoldDark : Colors.white);
-    final indicator = indicatorColor ?? (isDark ? Colors.white : Colors.black);
+        widget.backgroundColor ??
+        (isDark ? BLabColors.scaffoldDark : Colors.white);
+    final indicator =
+        widget.indicatorColor ?? (isDark ? Colors.white : Colors.black);
+    final selectedColor =
+        widget.selectedTextColor ?? (isDark ? Colors.white : Colors.black);
+    final unselectedColor =
+        widget.unselectedTextColor ??
+        (isDark ? Colors.grey[400]! : Colors.grey[600]!);
+    final selectedStyle = TextStyle(
+      fontSize: 14,
+      fontWeight: FontWeight.w600,
+      color: selectedColor,
+    );
+    final unselectedStyle = TextStyle(
+      fontSize: 14,
+      fontWeight: FontWeight.w400,
+      color: unselectedColor,
+    );
+    final metrics = widget.tabs.map((title) {
+      final painter = TextPainter(
+        text: TextSpan(text: title, style: selectedStyle),
+        textDirection: textDirection,
+        textScaler: textScaler,
+        maxLines: 1,
+      )..layout();
+      return (width: painter.width, height: painter.height);
+    }).toList();
+    final tabWidths = metrics
+        .map((metric) => math.max(widget.tabWidth, metric.width + 32))
+        .toList();
+    final contentHeight = metrics.fold<double>(
+      0,
+      (height, metric) => math.max(height, metric.height),
+    );
+    final tabBarHeight = math.max(widget.height, contentHeight + 24 + 2);
+    final totalWidth = tabWidths.fold<double>(0, (sum, width) => sum + width);
+    _tabWidths = tabWidths;
+    _scheduleSelectedTabVisibility();
 
     return Container(
       color: bgColor,
       child: SizedBox(
-        height: height,
+        height: tabBarHeight,
         child: SingleChildScrollView(
-          controller: scrollController,
+          key: const ValueKey('scrollable-tab-bar-scroll-view'),
+          controller: _scrollController,
           scrollDirection: Axis.horizontal,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              SizedBox(
-                height: height - 2,
-                child: Row(
-                  children: tabs.asMap().entries.map((entry) {
+          child: SizedBox(
+            width: totalWidth,
+            height: tabBarHeight,
+            child: Stack(
+              children: [
+                Row(
+                  children: List.generate(widget.tabs.length, (index) {
                     return _buildTabItem(
-                      context,
-                      entry.value,
-                      entry.key,
-                      isDark,
+                      title: widget.tabs[index],
+                      index: index,
+                      width: tabWidths[index],
+                      height: tabBarHeight - 2,
+                      style: widget.selectedIndex == index
+                          ? selectedStyle
+                          : unselectedStyle,
                     );
-                  }).toList(),
+                  }),
                 ),
-              ),
-              AnimatedBuilder(
-                animation: controller.animation!,
-                builder: (context, child) {
-                  final animationValue = controller.animation!.value;
-                  return Transform.translate(
-                    offset: Offset(tabWidth * animationValue, 0),
-                    child: Container(
-                      width: tabWidth,
+                AnimatedBuilder(
+                  animation: widget.controller.animation!,
+                  builder: (context, child) {
+                    final geometry = _indicatorGeometry(
+                      widget.controller.animation!.value,
+                      tabWidths,
+                    );
+                    return Positioned(
+                      left: geometry.left,
+                      bottom: 0,
+                      width: geometry.width,
                       height: 2,
-                      color: indicator,
-                    ),
-                  );
-                },
-              ),
-            ],
+                      child: ColoredBox(color: indicator),
+                    );
+                  },
+                ),
+              ],
+            ),
           ),
         ),
       ),
     );
   }
 
-  Widget _buildTabItem(
-    BuildContext context,
-    String title,
-    int index,
-    bool isDark,
-  ) {
-    final isSelected = selectedIndex == index;
-    final selectedColor =
-        selectedTextColor ?? (isDark ? Colors.white : Colors.black);
-    final unselectedColor =
-        unselectedTextColor ?? (isDark ? Colors.grey[400] : Colors.grey[600]);
+  Widget _buildTabItem({
+    required String title,
+    required int index,
+    required double width,
+    required double height,
+    required TextStyle style,
+  }) {
+    final isSelected = widget.selectedIndex == index;
 
-    return GestureDetector(
-      onTap: () {
-        controller.animateTo(index);
-        onTabSelected?.call(index);
-      },
-      child: SizedBox(
-        width: tabWidth,
-        height: height - 2,
-        child: Center(
-          child: Text(
-            title,
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              fontSize: 14,
-              fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-              color: isSelected ? selectedColor : unselectedColor,
+    void selectTab() {
+      widget.controller.animateTo(index);
+      widget.onTabSelected?.call(index);
+      _ensureTabVisible(index);
+    }
+
+    return Semantics(
+      key: ValueKey('scrollable-tab-$index'),
+      button: true,
+      selected: isSelected,
+      label: title,
+      onTap: selectTab,
+      child: ExcludeSemantics(
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: selectTab,
+          child: SizedBox(
+            width: width,
+            height: height,
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  title,
+                  key: ValueKey('scrollable-tab-label-$index'),
+                  maxLines: 1,
+                  softWrap: false,
+                  overflow: TextOverflow.visible,
+                  textAlign: TextAlign.center,
+                  style: style,
+                ),
+              ),
             ),
           ),
         ),
       ),
+    );
+  }
+
+  ({double left, double width}) _indicatorGeometry(
+    double animationValue,
+    List<double> widths,
+  ) {
+    if (widths.isEmpty) {
+      return (left: 0, width: 0);
+    }
+    final value = animationValue.clamp(0.0, widths.length - 1.0);
+    final lowerIndex = value.floor();
+    final upperIndex = value.ceil();
+    final progress = value - lowerIndex;
+    final lowerLeft = _offsetForIndex(lowerIndex, widths);
+    final upperLeft = _offsetForIndex(upperIndex, widths);
+    return (
+      left: lowerLeft + ((upperLeft - lowerLeft) * progress),
+      width:
+          widths[lowerIndex] +
+          ((widths[upperIndex] - widths[lowerIndex]) * progress),
+    );
+  }
+
+  double _offsetForIndex(int index, List<double> widths) {
+    return widths.take(index).fold<double>(0, (sum, width) => sum + width);
+  }
+
+  void _scheduleSelectedTabVisibility() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _ensureTabVisible(widget.selectedIndex);
+      }
+    });
+  }
+
+  void _ensureTabVisible(int index) {
+    if (!_scrollController.hasClients ||
+        index < 0 ||
+        index >= _tabWidths.length) {
+      return;
+    }
+    final viewportWidth = _scrollController.position.viewportDimension;
+    final tabStart = _offsetForIndex(index, _tabWidths);
+    final tabEnd = tabStart + _tabWidths[index];
+    final currentOffset = _scrollController.offset;
+    var targetOffset = currentOffset;
+    if (tabStart < currentOffset) {
+      targetOffset = tabStart;
+    } else if (tabEnd > currentOffset + viewportWidth) {
+      targetOffset = tabEnd - viewportWidth;
+    }
+    targetOffset = targetOffset.clamp(
+      0.0,
+      _scrollController.position.maxScrollExtent,
+    );
+    if ((targetOffset - currentOffset).abs() < 0.5) {
+      return;
+    }
+    _scrollController.animateTo(
+      targetOffset,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOutCubic,
     );
   }
 }

--- a/app/lib/ui/core/widgets/scrollable_tab_bar.dart
+++ b/app/lib/ui/core/widgets/scrollable_tab_bar.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:book_golas/ui/core/theme/design_system.dart';
@@ -37,7 +38,7 @@ class ScrollableTabBar extends StatefulWidget {
 }
 
 class _ScrollableTabBarState extends State<ScrollableTabBar> {
-  static const _minimumAffordanceWidth = 32.0;
+  static const _affordanceGutterWidth = 32.0;
   static const _affordanceFadeWidth = 8.0;
 
   late ScrollController _scrollController;
@@ -48,6 +49,7 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
   double _leadingAffordanceWidth = 0;
   double _trailingAffordanceWidth = 0;
   bool _disableAnimations = false;
+  bool _didInitialReveal = false;
 
   @override
   void initState() {
@@ -66,9 +68,10 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
       }
       _scrollController = widget.scrollController ?? ScrollController();
       _scrollController.addListener(_updateScrollAffordances);
+      _didInitialReveal = false;
     }
     if (oldWidget.selectedIndex != widget.selectedIndex ||
-        oldWidget.tabs != widget.tabs) {
+        !listEquals(oldWidget.tabs, widget.tabs)) {
       _scheduleSelectedTabVisibility();
     }
   }
@@ -90,21 +93,16 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
     final textScaler = MediaQuery.textScalerOf(context);
     final textDirection = Directionality.of(context);
     final bgColor = widget.backgroundColor ??
-        (isDark ? BLabColors.scaffoldDark : Colors.white);
-    final indicator =
-        widget.indicatorColor ?? (isDark ? Colors.white : Colors.black);
+        (isDark ? BLabColors.scaffoldDark : BLabColors.surfaceLight);
+    final indicator = widget.indicatorColor ?? BLabColors.textPrimary(context);
     final selectedColor =
-        widget.selectedTextColor ?? (isDark ? Colors.white : Colors.black);
-    final unselectedColor = widget.unselectedTextColor ??
-        (isDark ? Colors.grey[400]! : Colors.grey[600]!);
-    final selectedStyle = TextStyle(
-      fontSize: 14,
-      fontWeight: FontWeight.w600,
+        widget.selectedTextColor ?? BLabColors.textPrimary(context);
+    final unselectedColor =
+        widget.unselectedTextColor ?? BLabColors.textTertiary(context);
+    final selectedStyle = AppTypography.labelLarge.copyWith(
       color: selectedColor,
     );
-    final unselectedStyle = TextStyle(
-      fontSize: 14,
-      fontWeight: FontWeight.w400,
+    final unselectedStyle = AppTypography.bodySmall.copyWith(
       color: unselectedColor,
     );
     final metrics = widget.tabs.map((title) {
@@ -127,7 +125,10 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
     final totalWidth = tabWidths.fold<double>(0, (sum, width) => sum + width);
     _tabWidths = tabWidths;
     _labelWidths = metrics.map((metric) => metric.width).toList();
-    _scheduleSelectedTabVisibility();
+    if (!_didInitialReveal) {
+      _didInitialReveal = true;
+      _scheduleSelectedTabVisibility();
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         _updateScrollAffordances();
@@ -138,89 +139,131 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
       color: bgColor,
       child: SizedBox(
         height: tabBarHeight,
-        child: Stack(
+        child: Row(
           children: [
-            SingleChildScrollView(
-              key: const ValueKey('scrollable-tab-bar-scroll-view'),
-              controller: _scrollController,
-              scrollDirection: Axis.horizontal,
-              child: SizedBox(
-                width: totalWidth,
-                height: tabBarHeight,
-                child: Stack(
-                  children: [
-                    Row(
-                      children: List.generate(widget.tabs.length, (index) {
-                        return _buildTabItem(
-                          title: widget.tabs[index],
-                          index: index,
-                          width: tabWidths[index],
-                          height: tabBarHeight - 2,
-                          style: widget.selectedIndex == index
-                              ? selectedStyle
-                              : unselectedStyle,
-                        );
-                      }),
+            _buildScrollGutter(
+              key: const ValueKey('scrollable-tab-bar-leading-affordance'),
+              backgroundColor: bgColor,
+              foregroundColor: unselectedColor,
+              isLeading: true,
+              visible: _canScrollBackward,
+            ),
+            Expanded(
+              child: Stack(
+                children: [
+                  SingleChildScrollView(
+                    key: const ValueKey('scrollable-tab-bar-scroll-view'),
+                    controller: _scrollController,
+                    scrollDirection: Axis.horizontal,
+                    child: SizedBox(
+                      width: totalWidth,
+                      height: tabBarHeight,
+                      child: Stack(
+                        children: [
+                          Row(
+                            children: List.generate(widget.tabs.length, (
+                              index,
+                            ) {
+                              return _buildTabItem(
+                                title: widget.tabs[index],
+                                index: index,
+                                width: tabWidths[index],
+                                height: tabBarHeight - 2,
+                                style: widget.selectedIndex == index
+                                    ? selectedStyle
+                                    : unselectedStyle,
+                              );
+                            }),
+                          ),
+                          AnimatedBuilder(
+                            animation: widget.controller.animation!,
+                            builder: (context, child) {
+                              final geometry = _indicatorGeometry(
+                                widget.controller.animation!.value,
+                                tabWidths,
+                              );
+                              return Positioned(
+                                left: geometry.left,
+                                bottom: 0,
+                                width: geometry.width,
+                                height: 2,
+                                child: ColoredBox(color: indicator),
+                              );
+                            },
+                          ),
+                        ],
+                      ),
                     ),
-                    AnimatedBuilder(
-                      animation: widget.controller.animation!,
-                      builder: (context, child) {
-                        final geometry = _indicatorGeometry(
-                          widget.controller.animation!.value,
-                          tabWidths,
-                        );
-                        return Positioned(
-                          left: geometry.left,
-                          bottom: 0,
-                          width: geometry.width,
-                          height: 2,
-                          child: ColoredBox(color: indicator),
-                        );
-                      },
+                  ),
+                  if (_leadingAffordanceWidth > 0)
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: _buildBoundaryMask(
+                        backgroundColor: bgColor,
+                        isLeading: true,
+                        width: _leadingAffordanceWidth,
+                      ),
                     ),
-                  ],
-                ),
+                  if (_trailingAffordanceWidth > 0)
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: _buildBoundaryMask(
+                        backgroundColor: bgColor,
+                        isLeading: false,
+                        width: _trailingAffordanceWidth,
+                      ),
+                    ),
+                ],
               ),
             ),
-            if (_canScrollBackward && _leadingAffordanceWidth > 0)
-              Align(
-                alignment: Alignment.centerLeft,
-                child: _buildScrollAffordance(
-                  key: const ValueKey('scrollable-tab-bar-leading-affordance'),
-                  backgroundColor: bgColor,
-                  foregroundColor: unselectedColor,
-                  isLeading: true,
-                  width: _leadingAffordanceWidth,
-                ),
-              ),
-            if (_canScrollForward && _trailingAffordanceWidth > 0)
-              Align(
-                alignment: Alignment.centerRight,
-                child: _buildScrollAffordance(
-                  key: const ValueKey('scrollable-tab-bar-trailing-affordance'),
-                  backgroundColor: bgColor,
-                  foregroundColor: unselectedColor,
-                  isLeading: false,
-                  width: _trailingAffordanceWidth,
-                ),
-              ),
+            _buildScrollGutter(
+              key: const ValueKey('scrollable-tab-bar-trailing-affordance'),
+              backgroundColor: bgColor,
+              foregroundColor: unselectedColor,
+              isLeading: false,
+              visible: _canScrollForward,
+            ),
           ],
         ),
       ),
     );
   }
 
-  Widget _buildScrollAffordance({
+  Widget _buildScrollGutter({
     required Key key,
     required Color backgroundColor,
     required Color foregroundColor,
+    required bool isLeading,
+    required bool visible,
+  }) {
+    if (!visible) {
+      return const SizedBox(width: _affordanceGutterWidth);
+    }
+    return ExcludeSemantics(
+      child: IgnorePointer(
+        child: Container(
+          key: key,
+          width: _affordanceGutterWidth,
+          color: backgroundColor,
+          alignment: Alignment.center,
+          child: Icon(
+            isLeading ? Icons.chevron_left : Icons.chevron_right,
+            color: foregroundColor,
+            size: 24,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBoundaryMask({
+    required Color backgroundColor,
     required bool isLeading,
     required double width,
   }) {
     return ExcludeSemantics(
       child: IgnorePointer(
         child: Container(
-          key: key,
           width: width,
           decoration: BoxDecoration(
             gradient: LinearGradient(
@@ -232,13 +275,6 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
                 1,
               ],
             ),
-          ),
-          alignment: isLeading ? Alignment.centerLeft : Alignment.centerRight,
-          padding: const EdgeInsets.symmetric(horizontal: 4),
-          child: Icon(
-            isLeading ? Icons.chevron_left : Icons.chevron_right,
-            color: foregroundColor,
-            size: 24,
           ),
         ),
       ),
@@ -272,23 +308,28 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
       label: title,
       onTap: selectTab,
       child: ExcludeSemantics(
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: selectTab,
-          child: SizedBox(
-            width: width,
-            height: height,
-            child: Center(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text(
-                  title,
-                  key: ValueKey('scrollable-tab-label-$index'),
-                  maxLines: 1,
-                  softWrap: false,
-                  overflow: TextOverflow.visible,
-                  textAlign: TextAlign.center,
-                  style: style,
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            key: ValueKey('scrollable-tab-action-$index'),
+            onTap: selectTab,
+            canRequestFocus: true,
+            focusColor: BLabColors.primary.withValues(alpha: 0.18),
+            child: SizedBox(
+              width: width,
+              height: height,
+              child: Center(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Text(
+                    title,
+                    key: ValueKey('scrollable-tab-label-$index'),
+                    maxLines: 1,
+                    softWrap: false,
+                    overflow: TextOverflow.visible,
+                    textAlign: TextAlign.center,
+                    style: style,
+                  ),
                 ),
               ),
             ),
@@ -406,18 +447,12 @@ class _ScrollableTabBarState extends State<ScrollableTabBar> {
       if (isLeading &&
           labelStart < viewportStart - 0.5 &&
           labelEnd > viewportStart + 0.5) {
-        return math.max(
-          _minimumAffordanceWidth,
-          (labelEnd - viewportStart) + _affordanceFadeWidth,
-        );
+        return (labelEnd - viewportStart) + _affordanceFadeWidth;
       }
       if (!isLeading &&
           labelStart < viewportEnd - 0.5 &&
           labelEnd > viewportEnd + 0.5) {
-        return math.max(
-          _minimumAffordanceWidth,
-          (viewportEnd - labelStart) + _affordanceFadeWidth,
-        );
+        return (viewportEnd - labelStart) + _affordanceFadeWidth;
       }
     }
     return 0;

--- a/app/test/ui/book_list/widgets/book_list_screen_test.dart
+++ b/app/test/ui/book_list/widgets/book_list_screen_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:book_golas/data/repositories/reading_progress_repository.dart';
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_list/view_model/book_list_view_model.dart';
+import 'package:book_golas/ui/book_list/widgets/book_list_screen.dart';
+import 'package:book_golas/ui/core/widgets/scrollable_tab_bar.dart';
+
+void main() {
+  testWidgets('reduced motion synchronizes the selected book status tab', (
+    tester,
+  ) async {
+    final viewModel = BookListViewModel(
+      readingProgressRepository: _FakeReadingProgressRepository(),
+    );
+    addTearDown(viewModel.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: viewModel,
+        child: const MaterialApp(
+          locale: Locale('en'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: MediaQuery(
+            data: MediaQueryData(disableAnimations: true),
+            child: Scaffold(body: BookListScreen()),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    viewModel.jumpToTab(4);
+    await tester.pump();
+
+    final selectedSemantics = tester.widget<Semantics>(
+      find.byKey(const ValueKey('scrollable-tab-4')),
+    );
+    expect(selectedSemantics.properties.selected, isTrue);
+    final tabBar = tester.widget<ScrollableTabBar>(
+      find.byType(ScrollableTabBar),
+    );
+    expect(tabBar.controller.index, 4);
+    expect(tabBar.controller.animation?.value, 4);
+  });
+}
+
+class _FakeReadingProgressRepository implements ReadingProgressRepository {
+  @override
+  Future<Map<String, int>> getTodayPagesReadByBook() async => {};
+}

--- a/app/test/ui/core/widgets/empty_state_view_test.dart
+++ b/app/test/ui/core/widgets/empty_state_view_test.dart
@@ -1,0 +1,60 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:book_golas/ui/core/theme/design_system.dart';
+import 'package:book_golas/ui/core/widgets/empty_state_view.dart';
+
+void main() {
+  for (final testCase in [
+    (
+      brightness: Brightness.light,
+      foreground: BLabColors.textTertiaryLight,
+      background: BLabColors.scaffoldLight,
+    ),
+    (
+      brightness: Brightness.dark,
+      foreground: BLabColors.textTertiaryDark,
+      background: BLabColors.scaffoldDark,
+    ),
+  ]) {
+    testWidgets(
+      'empty state message preserves contrast in ${testCase.brightness.name} mode',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              brightness: testCase.brightness,
+              scaffoldBackgroundColor: testCase.background,
+            ),
+            home: const Scaffold(
+              body: EmptyStateView(message: 'Empty state'),
+            ),
+          ),
+        );
+
+        final text = tester.widget<Text>(
+          find.byKey(const ValueKey('empty-state-message')),
+        );
+        expect(text.style?.color, testCase.foreground);
+        expect(
+          _contrastRatio(testCase.foreground, testCase.background),
+          greaterThanOrEqualTo(4.5),
+        );
+      },
+    );
+  }
+}
+
+double _contrastRatio(Color foreground, Color background) {
+  final lighter = math.max(
+    foreground.computeLuminance(),
+    background.computeLuminance(),
+  );
+  final darker = math.min(
+    foreground.computeLuminance(),
+    background.computeLuminance(),
+  );
+  return (lighter + 0.05) / (darker + 0.05);
+}

--- a/app/test/ui/core/widgets/empty_state_view_test.dart
+++ b/app/test/ui/core/widgets/empty_state_view_test.dart
@@ -48,12 +48,13 @@ void main() {
 }
 
 double _contrastRatio(Color foreground, Color background) {
+  final compositedForeground = Color.alphaBlend(foreground, background);
   final lighter = math.max(
-    foreground.computeLuminance(),
+    compositedForeground.computeLuminance(),
     background.computeLuminance(),
   );
   final darker = math.min(
-    foreground.computeLuminance(),
+    compositedForeground.computeLuminance(),
     background.computeLuminance(),
   );
   return (lighter + 0.05) / (darker + 0.05);

--- a/app/test/ui/core/widgets/scrollable_tab_bar_test.dart
+++ b/app/test/ui/core/widgets/scrollable_tab_bar_test.dart
@@ -5,6 +5,77 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:book_golas/ui/core/widgets/scrollable_tab_bar.dart';
 
 void main() {
+  for (final width in [320.0, 393.0]) {
+    for (final testCase in [
+      const ['Reading', 'To Read', 'Completed', 'Reread', 'All'],
+      const ['독서 중', '읽을 예정', '완독', '다시 읽을 책', '전체'],
+    ]) {
+      testWidgets(
+        'every selected tab avoids visible affordances at $width pixels',
+        (tester) async {
+          final semantics = tester.ensureSemantics();
+          final scrollController = ScrollController();
+          addTearDown(scrollController.dispose);
+          tester.view.physicalSize = Size(width, 640);
+          tester.view.devicePixelRatio = 1;
+          addTearDown(tester.view.resetPhysicalSize);
+          addTearDown(tester.view.resetDevicePixelRatio);
+
+          await tester.pumpWidget(
+            MaterialApp(
+              builder: (context, child) => MediaQuery(
+                data: MediaQuery.of(
+                  context,
+                ).copyWith(textScaler: const TextScaler.linear(2)),
+                child: child!,
+              ),
+              home: Scaffold(
+                body: _TabBarHarness(
+                  tabs: testCase,
+                  initialIndex: 0,
+                  scrollController: scrollController,
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          for (var index = 0; index < testCase.length; index += 1) {
+            tester.semantics.tap(find.semantics.byLabel(testCase[index]));
+            await tester.pumpAndSettle();
+
+            final labelRect = tester.getRect(
+              find.byKey(ValueKey('scrollable-tab-label-$index')),
+            );
+            for (final affordanceKey in const [
+              ValueKey('scrollable-tab-bar-leading-affordance'),
+              ValueKey('scrollable-tab-bar-trailing-affordance'),
+            ]) {
+              final affordance = find.byKey(affordanceKey);
+              if (affordance.evaluate().isNotEmpty) {
+                final affordanceRect = tester.getRect(affordance);
+                expect(
+                  labelRect.overlaps(affordanceRect),
+                  isFalse,
+                  reason:
+                      '${testCase[index]} $labelRect must not be covered by '
+                      '$affordanceKey $affordanceRect at offset '
+                      '${scrollController.offset}',
+                );
+              }
+            }
+            final selectedSemantics = tester.widget<Semantics>(
+              find.byKey(ValueKey('scrollable-tab-$index')),
+            );
+            expect(selectedSemantics.properties.selected, isTrue);
+          }
+
+          semantics.dispose();
+        },
+      );
+    }
+  }
+
   for (final testCase in [
     const ['Reading', 'To Read', 'Completed', 'Reread', 'All'],
     const ['독서 중', '읽을 예정', '완독', '다시 읽을 책', '전체'],

--- a/app/test/ui/core/widgets/scrollable_tab_bar_test.dart
+++ b/app/test/ui/core/widgets/scrollable_tab_bar_test.dart
@@ -100,6 +100,14 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('scrollable-tab-bar-trailing-affordance')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('scrollable-tab-bar-leading-affordance')),
+      findsNothing,
+    );
 
     tester.semantics.tap(find.semantics.byLabel('All'));
     await tester.pumpAndSettle();
@@ -109,6 +117,55 @@ void main() {
     );
     expect(selectedSemantics.properties.selected, isTrue);
     expect(scrollController.offset, greaterThan(0));
+    expect(
+      find.byKey(const ValueKey('scrollable-tab-bar-leading-affordance')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('scrollable-tab-bar-trailing-affordance')),
+      findsNothing,
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('reduced motion changes tabs without pending animations', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    const tabs = ['Reading', 'To Read', 'Completed', 'Reread', 'All'];
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    tester.view.physicalSize = const Size(320, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (context, child) => MediaQuery(
+          data: MediaQuery.of(context).copyWith(disableAnimations: true),
+          child: child!,
+        ),
+        home: Scaffold(
+          body: _TabBarHarness(
+            tabs: tabs,
+            initialIndex: 0,
+            scrollController: scrollController,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    tester.semantics.tap(find.semantics.byLabel('All'));
+    await tester.pump();
+
+    final selectedSemantics = tester.widget<Semantics>(
+      find.byKey(const ValueKey('scrollable-tab-4')),
+    );
+    expect(selectedSemantics.properties.selected, isTrue);
+    expect(scrollController.offset, scrollController.position.maxScrollExtent);
+    expect(tester.binding.transientCallbackCount, 0);
     semantics.dispose();
   });
 }

--- a/app/test/ui/core/widgets/scrollable_tab_bar_test.dart
+++ b/app/test/ui/core/widgets/scrollable_tab_bar_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:book_golas/ui/core/widgets/scrollable_tab_bar.dart';
@@ -68,8 +69,19 @@ void main() {
               find.byKey(ValueKey('scrollable-tab-$index')),
             );
             expect(selectedSemantics.properties.selected, isTrue);
+            expect(
+              find.byKey(
+                const ValueKey('scrollable-tab-bar-leading-affordance'),
+              ),
+              index == 0 ? findsNothing : findsOneWidget,
+            );
+            expect(
+              find.byKey(
+                const ValueKey('scrollable-tab-bar-trailing-affordance'),
+              ),
+              index == testCase.length - 1 ? findsNothing : findsOneWidget,
+            );
           }
-
           semantics.dispose();
         },
       );
@@ -239,17 +251,115 @@ void main() {
     expect(tester.binding.transientCallbackCount, 0);
     semantics.dispose();
   });
+
+  testWidgets('manual tab inspection is preserved after affordance rebuild', (
+    tester,
+  ) async {
+    const tabs = ['Reading', 'To Read', 'Completed', 'Reread', 'All'];
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    tester.view.physicalSize = const Size(320, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: _TabBarHarness(
+            tabs: tabs,
+            initialIndex: 2,
+            scrollController: scrollController,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, greaterThan(0));
+
+    scrollController.jumpTo(0);
+    await tester.pumpAndSettle();
+
+    expect(scrollController.offset, 0);
+    expect(
+      find.byKey(const ValueKey('scrollable-tab-bar-leading-affordance')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('keyboard focus activates the next tab', (tester) async {
+    const tabs = ['Reading', 'To Read', 'Completed', 'Reread', 'All'];
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: _TabBarHarness(
+            tabs: tabs,
+            initialIndex: 0,
+            scrollController: scrollController,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+
+    final selectedSemantics = tester.widget<Semantics>(
+      find.byKey(const ValueKey('scrollable-tab-1')),
+    );
+    expect(selectedSemantics.properties.selected, isTrue);
+  });
+
+  testWidgets('controller listener matches production selection wiring', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    const tabs = ['Reading', 'To Read', 'Completed', 'Reread', 'All'];
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: _TabBarHarness(
+            tabs: tabs,
+            initialIndex: 0,
+            scrollController: scrollController,
+            syncFromController: true,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    tester.semantics.tap(find.semantics.byLabel('All'));
+    await tester.pumpAndSettle();
+
+    final selectedSemantics = tester.widget<Semantics>(
+      find.byKey(const ValueKey('scrollable-tab-4')),
+    );
+    expect(selectedSemantics.properties.selected, isTrue);
+    semantics.dispose();
+  });
 }
 
 class _TabBarHarness extends StatefulWidget {
   final List<String> tabs;
   final int initialIndex;
   final ScrollController scrollController;
+  final bool syncFromController;
 
   const _TabBarHarness({
     required this.tabs,
     required this.initialIndex,
     required this.scrollController,
+    this.syncFromController = false,
   });
 
   @override
@@ -270,10 +380,21 @@ class _TabBarHarnessState extends State<_TabBarHarness>
       initialIndex: widget.initialIndex,
       vsync: this,
     );
+    if (widget.syncFromController) {
+      _tabController.addListener(_syncSelectedIndexFromController);
+    }
+  }
+
+  void _syncSelectedIndexFromController() {
+    if (_tabController.indexIsChanging || !mounted) return;
+    setState(() {
+      _selectedIndex = _tabController.index;
+    });
   }
 
   @override
   void dispose() {
+    _tabController.removeListener(_syncSelectedIndexFromController);
     _tabController.dispose();
     super.dispose();
   }
@@ -285,11 +406,13 @@ class _TabBarHarnessState extends State<_TabBarHarness>
       tabs: widget.tabs,
       selectedIndex: _selectedIndex,
       scrollController: widget.scrollController,
-      onTabSelected: (index) {
-        setState(() {
-          _selectedIndex = index;
-        });
-      },
+      onTabSelected: widget.syncFromController
+          ? null
+          : (index) {
+              setState(() {
+                _selectedIndex = index;
+              });
+            },
     );
   }
 }

--- a/app/test/ui/core/widgets/scrollable_tab_bar_test.dart
+++ b/app/test/ui/core/widgets/scrollable_tab_bar_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:book_golas/ui/core/widgets/scrollable_tab_bar.dart';
+
+void main() {
+  for (final testCase in [
+    const ['Reading', 'To Read', 'Completed', 'Reread', 'All'],
+    const ['독서 중', '읽을 예정', '완독', '다시 읽을 책', '전체'],
+  ]) {
+    testWidgets(
+      'large text tabs remain readable and selected destination is visible',
+      (tester) async {
+        final semantics = tester.ensureSemantics();
+        final scrollController = ScrollController();
+        addTearDown(scrollController.dispose);
+        tester.view.physicalSize = const Size(320, 640);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            builder: (context, child) => MediaQuery(
+              data: MediaQuery.of(
+                context,
+              ).copyWith(textScaler: const TextScaler.linear(2)),
+              child: child!,
+            ),
+            home: Scaffold(
+              body: _TabBarHarness(
+                tabs: testCase,
+                initialIndex: 4,
+                scrollController: scrollController,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        expect(scrollController.position.maxScrollExtent, greaterThan(0));
+        expect(scrollController.offset, greaterThan(0));
+
+        for (var index = 0; index < testCase.length; index += 1) {
+          final labelFinder = find.byKey(
+            ValueKey('scrollable-tab-label-$index'),
+          );
+          final paragraph = tester.renderObject<RenderParagraph>(labelFinder);
+          final semanticsNode = tester.getSemantics(
+            find.byKey(ValueKey('scrollable-tab-$index')),
+          );
+          expect(paragraph.didExceedMaxLines, isFalse);
+          expect(paragraph.textScaler.scale(14), 28);
+          expect(semanticsNode.label, testCase[index]);
+          expect(semanticsNode.flagsCollection.isButton, isTrue);
+          expect(
+            semanticsNode.getSemanticsData().hasAction(SemanticsAction.tap),
+            isTrue,
+          );
+        }
+
+        final viewport = tester.getRect(
+          find.byKey(const ValueKey('scrollable-tab-bar-scroll-view')),
+        );
+        final selectedTab = tester.getRect(
+          find.byKey(const ValueKey('scrollable-tab-4')),
+        );
+        expect(selectedTab.left, greaterThanOrEqualTo(viewport.left - 0.5));
+        expect(selectedTab.right, lessThanOrEqualTo(viewport.right + 0.5));
+        final selectedSemantics = tester.widget<Semantics>(
+          find.byKey(const ValueKey('scrollable-tab-4')),
+        );
+        expect(selectedSemantics.properties.selected, isTrue);
+        semantics.dispose();
+      },
+    );
+  }
+
+  testWidgets('semantic tap changes the selected tab', (tester) async {
+    final semantics = tester.ensureSemantics();
+    const tabs = ['Reading', 'To Read', 'Completed', 'Reread', 'All'];
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    tester.view.physicalSize = const Size(320, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: _TabBarHarness(
+            tabs: tabs,
+            initialIndex: 0,
+            scrollController: scrollController,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    tester.semantics.tap(find.semantics.byLabel('All'));
+    await tester.pumpAndSettle();
+
+    final selectedSemantics = tester.widget<Semantics>(
+      find.byKey(const ValueKey('scrollable-tab-4')),
+    );
+    expect(selectedSemantics.properties.selected, isTrue);
+    expect(scrollController.offset, greaterThan(0));
+    semantics.dispose();
+  });
+}
+
+class _TabBarHarness extends StatefulWidget {
+  final List<String> tabs;
+  final int initialIndex;
+  final ScrollController scrollController;
+
+  const _TabBarHarness({
+    required this.tabs,
+    required this.initialIndex,
+    required this.scrollController,
+  });
+
+  @override
+  State<_TabBarHarness> createState() => _TabBarHarnessState();
+}
+
+class _TabBarHarnessState extends State<_TabBarHarness>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+  late int _selectedIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedIndex = widget.initialIndex;
+    _tabController = TabController(
+      length: widget.tabs.length,
+      initialIndex: widget.initialIndex,
+      vsync: this,
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScrollableTabBar(
+      controller: _tabController,
+      tabs: widget.tabs,
+      selectedIndex: _selectedIndex,
+      scrollController: widget.scrollController,
+      onTabSelected: (index) {
+        setState(() {
+          _selectedIndex = index;
+        });
+      },
+    );
+  }
+}


### PR DESCRIPTION
## 목적

BOK-381의 대형 글자 독서 목록 상태 탭 잘림과 실제 화면 탐색 회귀를 수정합니다.

## 주요 변경

- 탭 양끝에 고정된 좌우 스크롤 단서를 배치해 숨은 상태의 방향을 일관되게 표시
- 실제 라벨 경계에서만 동적 마스크를 적용해 단어 일부가 잘려 보이는 상태 제거
- 선택 탭 변경 시에만 자동 노출하고, 사용자가 직접 살펴본 스크롤 위치는 리빌드 후에도 보존
- 탭을 키보드 포커스·Enter로 조작할 수 있게 하고 버튼·선택 상태·전체 라벨 의미 구조 유지
- BookListScreen의 외부 탭 변경도 시스템 '동작 줄이기' 설정에서 즉시 전환
- 빈 상태 문구를 저장소의 로컬 Blab 의미 색상·타이포그래피로 통일
- 한국어·영어, 320/393px, 200% 글자, 다섯 선택 인덱스, 수동 스크롤, 키보드, 의미 동작, 대비 회귀 테스트 추가

## 검증

- exact head `137657a170be41fd458ad83569bc10ae40750acf`
- GitHub Flutter Analyze and Test, Target Version Contract, Edge, Web, Vercel 검사 통과
- 전체 Flutter 테스트 통과
- 변경 파일 scoped analyze 0건; 전체 analyze 오류·경고 0건
- GitHub 미해결 리뷰 스레드 0개
- PR #299 merge commit `c55a22cdd7cc1c654de2bd6822a9dcc1e1a27d77`과 동기화한 HEAD tree `60f470c910ec7c723c9cfd4637a13f213e0de689`
- 통합 집중 테스트 26개와 iOS Simulator build 통과
- iPhone 17e, iOS 26.5, DisplayTextSize 26.0에서 ko/en × light/dark × 시작/마지막 탭 실제 화면 8종 확인
- 증거 manifest: `/tmp/bookgolas-1.0.2-integrated-evidence-v4/MANIFEST.md`
- 실제 기기 VoiceOver 음성 탐색은 아직 미검증이며 1.0.2 출시 게이트로 유지
- base 동기화 전 exact tree의 Product Designer·품질·법무 경계 승인 완료; 동일 tree의 새 exact-head 재리뷰 진행 중

## 관련 이슈

- BOK-381

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tab navigation with variable-width labels, animated indicators, scrolling visibility, gradient scroll cues, and accessibility support.
  * Added support for reduced-motion settings when synchronizing and animating tabs.
  * Enhanced book list tab selection and synchronization behavior.

* **Bug Fixes**
  * Improved empty-state message styling and contrast across light and dark themes.

* **Tests**
  * Added coverage for tab accessibility, scrolling, localization, text scaling, reduced motion, and empty-state contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->