### PR TITLE
fix(mobile): preserve pre-auth deep links

### DIFF
--- a/app/ios/BookgolasWidget/BookgolasWidget.swift
+++ b/app/ios/BookgolasWidget/BookgolasWidget.swift
@@ -321,7 +321,7 @@ struct BookgolasSmallWidgetView: View {
         if entry.isEmpty {
             EmptyStateView(isSmall: true)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .widgetURL(URL(string: "bookgolas://book/search"))
+                .widgetURL(URL(string: "bookgolas://book/search?homeWidget=true"))
         } else {
             VStack(alignment: .leading, spacing: 0) {
                 HStack(spacing: 10) {
@@ -353,7 +353,7 @@ struct BookgolasSmallWidgetView: View {
             }
             .padding(14)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .widgetURL(URL(string: "bookgolas://book/detail/\(entry.bookId)"))
+            .widgetURL(URL(string: "bookgolas://book/detail/\(entry.bookId)?homeWidget=true"))
         }
     }
 }
@@ -394,21 +394,21 @@ struct QuickActionSmallWidgetView: View {
                 "book.fill",
                 NSLocalizedString("widget_action_open_book", tableName: nil, bundle: .main, value: "Continue Reading", comment: ""),
                 entry.isEmpty ? "" : entry.displayTitle,
-                entry.isEmpty ? nil : URL(string: "bookgolas://book/detail/\(entry.bookId)")
+                entry.isEmpty ? nil : URL(string: "bookgolas://book/detail/\(entry.bookId)?homeWidget=true")
             )
         case "scan":
             return (
                 "doc.viewfinder",
                 NSLocalizedString("widget_action_scan_page", tableName: nil, bundle: .main, value: "Scan Page", comment: ""),
                 entry.isEmpty ? "" : entry.displayTitle,
-                entry.isEmpty ? nil : URL(string: "bookgolas://book/scan/\(entry.bookId)")
+                entry.isEmpty ? nil : URL(string: "bookgolas://book/scan/\(entry.bookId)?homeWidget=true")
             )
         case "add":
             return (
                 "plus.circle",
                 NSLocalizedString("widget_action_add_book", tableName: nil, bundle: .main, value: "Add Book", comment: ""),
                 "",
-                URL(string: "bookgolas://book/search")
+                URL(string: "bookgolas://book/search?homeWidget=true")
             )
         default:
             return ("book.fill", "Book", "", nil)
@@ -425,7 +425,7 @@ struct BookgolasMediumWidgetView: View {
         if entry.isEmpty {
             EmptyStateView(isSmall: false)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .widgetURL(URL(string: "bookgolas://book/search"))
+                .widgetURL(URL(string: "bookgolas://book/search?homeWidget=true"))
         } else {
             HStack(spacing: 12) {
                 CoverImageView(
@@ -472,17 +472,17 @@ struct BookgolasMediumWidgetView: View {
                     QuickActionButton(
                         systemImage: "book.fill",
                         label: NSLocalizedString("widget_action_book", tableName: nil, bundle: .main, value: "Book", comment: ""),
-                        url: URL(string: "bookgolas://book/detail/\(entry.bookId)")
+                        url: URL(string: "bookgolas://book/detail/\(entry.bookId)?homeWidget=true")
                     )
                     QuickActionButton(
                         systemImage: "doc.viewfinder",
                         label: NSLocalizedString("widget_action_scan", tableName: nil, bundle: .main, value: "Scan", comment: ""),
-                        url: URL(string: "bookgolas://book/scan/\(entry.bookId)")
+                        url: URL(string: "bookgolas://book/scan/\(entry.bookId)?homeWidget=true")
                     )
                     QuickActionButton(
                         systemImage: "plus.circle",
                         label: NSLocalizedString("widget_action_add", tableName: nil, bundle: .main, value: "Add", comment: ""),
-                        url: URL(string: "bookgolas://book/search")
+                        url: URL(string: "bookgolas://book/search?homeWidget=true")
                     )
                 }
                 .frame(width: 52)
@@ -619,7 +619,7 @@ struct BookgolasLockScreenCircularView: View {
                     .font(.system(size: 10, weight: .semibold))
             }
             .gaugeStyle(.accessoryCircular)
-            .widgetURL(URL(string: "bookgolas://book/detail/\(entry.bookId)"))
+            .widgetURL(URL(string: "bookgolas://book/detail/\(entry.bookId)?homeWidget=true"))
         } else {
             ZStack {
                 AccessoryWidgetBackground()
@@ -652,7 +652,7 @@ struct BookgolasLockScreenRectangularView: View {
                 }
                 .gaugeStyle(.accessoryLinear)
             }
-            .widgetURL(URL(string: "bookgolas://book/detail/\(entry.bookId)"))
+            .widgetURL(URL(string: "bookgolas://book/detail/\(entry.bookId)?homeWidget=true"))
         } else {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Bookgolas")
@@ -678,7 +678,7 @@ struct BookgolasLockScreenInlineView: View {
                 Label("\u{1F4D6} \(title) p.\(entry.currentPage)/\(entry.totalPages)", systemImage: "")
                 Label("p.\(entry.currentPage)/\(entry.totalPages)", systemImage: "book.fill")
             }
-            .widgetURL(URL(string: "bookgolas://book/detail/\(entry.bookId)"))
+            .widgetURL(URL(string: "bookgolas://book/detail/\(entry.bookId)?homeWidget=true"))
         } else {
             Label("Bookgolas", systemImage: "book.fill")
         }

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -7,6 +7,7 @@ import home_widget
 @main
 @objc class AppDelegate: FlutterAppDelegate {
   private var deepLinkChannel: FlutterMethodChannel?
+  private var pendingDeepLink: [String: Any]?
 
   override func application(
     _ application: UIApplication,
@@ -61,12 +62,43 @@ import home_widget
       name: "com.bookgolas.app/deep_link",
       binaryMessenger: controller.binaryMessenger
     )
-
-    if let url = launchOptions?[.url] as? URL, url.scheme == "bookgolas" {
-      deepLinkChannel?.invokeMethod("onDeepLink", arguments: url.absoluteString)
+    deepLinkChannel?.setMethodCallHandler { [weak self] call, result in
+      switch call.method {
+      case "consumePendingDeepLink":
+        result(self?.pendingDeepLink)
+      case "acknowledgeDeepLink":
+        guard let payload = call.arguments as? [String: Any],
+              let urlString = payload["url"] as? String,
+              let useReplacement = payload["useReplacement"] as? Bool else {
+          result(FlutterError(code: "INVALID_ARGUMENT", message: "Deep link payload is required", details: nil))
+          return
+        }
+        if self?.pendingDeepLink?["url"] as? String == urlString,
+           self?.pendingDeepLink?["useReplacement"] as? Bool == useReplacement {
+          self?.pendingDeepLink = nil
+        }
+        result(nil)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
     }
 
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    let didFinish = super.application(
+      application,
+      didFinishLaunchingWithOptions: launchOptions
+    )
+
+    if let url = launchOptions?[.url] as? URL, url.scheme == "bookgolas" {
+      sendDeepLink(url.absoluteString, useReplacement: isHomeWidgetURL(url))
+    }
+
+    if let shortcutItem = launchOptions?[.shortcutItem] as? UIApplicationShortcutItem,
+       let urlString = deepLinkURL(for: shortcutItem) {
+      sendDeepLink(urlString, useReplacement: true)
+      return false
+    }
+
+    return didFinish
   }
 
   override func application(
@@ -75,7 +107,8 @@ import home_widget
     options: [UIApplication.OpenURLOptionsKey : Any] = [:]
   ) -> Bool {
     if url.scheme == "bookgolas" {
-      deepLinkChannel?.invokeMethod("onDeepLink", arguments: url.absoluteString)
+      sendDeepLink(url.absoluteString, useReplacement: isHomeWidgetURL(url))
+      return true
     }
     return super.application(app, open: url, options: options)
   }
@@ -85,16 +118,39 @@ import home_widget
     performActionFor shortcutItem: UIApplicationShortcutItem,
     completionHandler: @escaping (Bool) -> Void
   ) {
+    guard let urlString = deepLinkURL(for: shortcutItem) else {
+      completionHandler(false)
+      return
+    }
+    sendDeepLink(urlString, useReplacement: true)
+    completionHandler(true)
+  }
+
+  private func sendDeepLink(_ urlString: String, useReplacement: Bool) {
+    let payload: [String: Any] = [
+      "url": urlString,
+      "useReplacement": useReplacement
+    ]
+    pendingDeepLink = payload
+    deepLinkChannel?.invokeMethod("onDeepLink", arguments: payload)
+  }
+
+  private func isHomeWidgetURL(_ url: URL) -> Bool {
+    URLComponents(url: url, resolvingAgainstBaseURL: false)?
+      .queryItems?
+      .contains(where: { $0.name == "homeWidget" }) == true
+  }
+
+  private func deepLinkURL(for shortcutItem: UIApplicationShortcutItem) -> String? {
     switch shortcutItem.type {
     case "com.bookgolas.continue-reading":
-      deepLinkChannel?.invokeMethod("onDeepLink", arguments: "bookgolas://book/detail/current")
+      return "bookgolas://book/detail/current"
     case "com.bookgolas.scan-page":
-      deepLinkChannel?.invokeMethod("onDeepLink", arguments: "bookgolas://book/scan/current")
+      return "bookgolas://book/scan/current"
     case "com.bookgolas.add-book":
-      deepLinkChannel?.invokeMethod("onDeepLink", arguments: "bookgolas://book/search")
+      return "bookgolas://book/search"
     default:
-      break
+      return nil
     }
-    completionHandler(true)
   }
 }

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -49,6 +49,8 @@
 		</array>
 		<key>GIDClientID</key>
 		<string>$(GID_CLIENT_ID)</string>
+		<key>FlutterDeepLinkingEnabled</key>
+		<false/>
 		<key>CFBundleVersion</key>
 		<string>$(FLUTTER_BUILD_NUMBER)</string>
 		<key>ITSAppUsesNonExemptEncryption</key>

--- a/app/lib/data/services/deep_link_service.dart
+++ b/app/lib/data/services/deep_link_service.dart
@@ -6,7 +6,6 @@ import 'package:flutter/services.dart';
 import 'package:home_widget/home_widget.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-import 'package:book_golas/data/services/book_service.dart';
 import 'package:book_golas/domain/models/book.dart';
 import 'package:book_golas/ui/book_detail/book_detail_screen.dart';
 import 'package:book_golas/ui/reading_start/widgets/reading_start_screen.dart';
@@ -25,6 +24,195 @@ class DeepLinkResult {
   const DeepLinkResult({required this.action, this.bookId});
 }
 
+class DeepLinkRequest {
+  final Uri uri;
+  final bool useReplacement;
+
+  const DeepLinkRequest({required this.uri, this.useReplacement = false});
+
+  static DeepLinkRequest? fromNativePayload(Object? payload) {
+    if (payload is String) {
+      final uri = Uri.tryParse(payload);
+      return uri == null ? null : DeepLinkRequest(uri: uri);
+    }
+    if (payload is! Map) return null;
+    final urlString = payload['url'];
+    if (urlString is! String) return null;
+    final uri = Uri.tryParse(urlString);
+    if (uri == null) return null;
+    return DeepLinkRequest(
+      uri: uri,
+      useReplacement: payload['useReplacement'] == true,
+    );
+  }
+}
+
+typedef DeepLinkDispatch = FutureOr<void> Function(DeepLinkRequest request);
+typedef UserScopedBookFetch = Future<Book?> Function(
+  String userId,
+  String bookId,
+);
+
+class DeepLinkBookResolver {
+  Future<Book?> fetchOwnedBook({
+    required String? userId,
+    required String bookId,
+    required UserScopedBookFetch fetch,
+  }) async {
+    if (userId == null) return null;
+    return fetch(userId, bookId);
+  }
+}
+
+class DeepLinkNavigator {
+  static void open(
+    NavigatorState navigator,
+    Route<void> route, {
+    required bool useReplacement,
+  }) {
+    navigator.popUntil((activeRoute) => activeRoute is! PopupRoute);
+    if (useReplacement) {
+      navigator.pushAndRemoveUntil<void>(route, (activeRoute) {
+        return activeRoute.isFirst;
+      });
+    } else {
+      navigator.push<void>(route);
+    }
+  }
+}
+
+class DeepLinkDispatchGuard {
+  final String userId;
+  final int navigationGeneration;
+
+  const DeepLinkDispatchGuard({
+    required this.userId,
+    required this.navigationGeneration,
+  });
+
+  bool canComplete({
+    required String? currentUserId,
+    required int currentNavigationGeneration,
+    required bool navigationReady,
+  }) {
+    return navigationReady &&
+        currentUserId == userId &&
+        currentNavigationGeneration == navigationGeneration;
+  }
+}
+
+class DeepLinkIntentCoordinator {
+  final DateTime Function() _now;
+  final Duration _duplicateWindow;
+  final Map<String, DateTime> _recentlyDispatched = {};
+  DeepLinkRequest? _pendingRequest;
+  bool _navigationReady = false;
+  bool _isDispatching = false;
+
+  DeepLinkIntentCoordinator({
+    DateTime Function()? now,
+    Duration duplicateWindow = const Duration(seconds: 2),
+  })  : _now = now ?? DateTime.now,
+        _duplicateWindow = duplicateWindow;
+
+  Future<void> receive(
+    DeepLinkRequest request, {
+    required bool isAuthenticated,
+    required DeepLinkDispatch dispatch,
+  }) async {
+    if (!_navigationReady || !isAuthenticated) {
+      _storePending(request);
+      return;
+    }
+
+    if (_isDispatching) {
+      _storePending(request);
+      return;
+    }
+
+    await _dispatch(request, dispatch);
+    await _drainPending(
+      isAuthenticated: isAuthenticated,
+      dispatch: dispatch,
+    );
+  }
+
+  Future<void> markNavigationReady({
+    required bool isAuthenticated,
+    required DeepLinkDispatch dispatch,
+  }) async {
+    _navigationReady = true;
+    await _drainPending(
+      isAuthenticated: isAuthenticated,
+      dispatch: dispatch,
+    );
+  }
+
+  void markNavigationUnavailable({required bool clearPending}) {
+    _navigationReady = false;
+    if (clearPending) {
+      _pendingRequest = null;
+    }
+  }
+
+  bool get isNavigationReady => _navigationReady;
+
+  void _storePending(DeepLinkRequest request) {
+    final pending = _pendingRequest;
+    if (pending != null && pending.uri == request.uri) {
+      _pendingRequest = DeepLinkRequest(
+        uri: request.uri,
+        useReplacement: pending.useReplacement || request.useReplacement,
+      );
+      return;
+    }
+    _pendingRequest = request;
+  }
+
+  Future<void> _drainPending({
+    required bool isAuthenticated,
+    required DeepLinkDispatch dispatch,
+  }) async {
+    while (_navigationReady && isAuthenticated && !_isDispatching) {
+      final request = _pendingRequest;
+      if (request == null) return;
+      _pendingRequest = null;
+      await _dispatch(request, dispatch);
+    }
+  }
+
+  Future<void> _dispatch(
+    DeepLinkRequest request,
+    DeepLinkDispatch dispatch,
+  ) async {
+    final now = _now();
+    _recentlyDispatched.removeWhere(
+      (_, timestamp) => now.difference(timestamp) >= _duplicateWindow,
+    );
+    final key = request.uri.toString();
+    final lastDispatched = _recentlyDispatched[key];
+    if (lastDispatched != null &&
+        now.difference(lastDispatched) < _duplicateWindow) {
+      return;
+    }
+
+    _recentlyDispatched[key] = now;
+    _isDispatching = true;
+    try {
+      await dispatch(request);
+    } finally {
+      _isDispatching = false;
+    }
+  }
+
+  void reset() {
+    _pendingRequest = null;
+    _navigationReady = false;
+    _isDispatching = false;
+    _recentlyDispatched.clear();
+  }
+}
+
 class DeepLinkService {
   static final AppLinks _appLinks = AppLinks();
   static StreamSubscription<Uri>? _linkSubscription;
@@ -32,8 +220,11 @@ class DeepLinkService {
   static GlobalKey<NavigatorState>? _navigatorKey;
   static const _deepLinkChannel = MethodChannel('com.bookgolas.app/deep_link');
   static final Set<String> _handledAuthUrls = {};
-  static final Map<String, DateTime> _recentlyHandledDeepLinks = {};
-  static bool _isProcessingDeepLink = false;
+  static final DeepLinkIntentCoordinator _intentCoordinator =
+      DeepLinkIntentCoordinator();
+  static final DeepLinkBookResolver _bookResolver = DeepLinkBookResolver();
+  static bool _isInitialized = false;
+  static int _navigationGeneration = 0;
 
   static DeepLinkResult? parseUri(Uri uri) {
     if (uri.scheme != 'bookgolas') return null;
@@ -87,12 +278,14 @@ class DeepLinkService {
     return uri.pathSegments;
   }
 
-  static Future<void> init(
-    BuildContext context, {
+  static Future<void> init({
     GlobalKey<NavigatorState>? navigatorKey,
   }) async {
     _navigatorKey = navigatorKey;
+    if (_isInitialized) return;
+    _isInitialized = true;
     _setupNativeDeepLinkChannel();
+    await _consumePendingNativeDeepLink();
     await _initWidgetClickHandler();
     await _initAppLinks();
   }
@@ -100,12 +293,46 @@ class DeepLinkService {
   static void _setupNativeDeepLinkChannel() {
     _deepLinkChannel.setMethodCallHandler((call) async {
       if (call.method == 'onDeepLink') {
-        final urlString = call.arguments as String;
-        final uri = Uri.parse(urlString);
-        debugPrint('📱 네이티브 딥링크 수신: $uri');
-        await _handleDeepLink(uri);
+        final request = DeepLinkRequest.fromNativePayload(call.arguments);
+        if (request == null) return;
+        await _handleNativeDeepLink(request);
       }
     });
+  }
+
+  static Future<void> _consumePendingNativeDeepLink() async {
+    try {
+      final payload = await _deepLinkChannel
+          .invokeMethod<Object?>('consumePendingDeepLink');
+      final request = DeepLinkRequest.fromNativePayload(payload);
+      if (request != null) {
+        await _handleNativeDeepLink(request);
+      }
+    } catch (e) {
+      debugPrint('📱 네이티브 대기 딥링크 확인 실패: $e');
+    }
+  }
+
+  static Future<void> _handleNativeDeepLink(DeepLinkRequest request) async {
+    debugPrint('📱 네이티브 딥링크 수신: ${request.uri}');
+    try {
+      await _handleDeepLink(
+        request.uri,
+        useReplacement: request.useReplacement,
+      );
+    } finally {
+      try {
+        await _deepLinkChannel.invokeMethod<void>(
+          'acknowledgeDeepLink',
+          {
+            'url': request.uri.toString(),
+            'useReplacement': request.useReplacement,
+          },
+        );
+      } catch (e) {
+        debugPrint('📱 네이티브 딥링크 확인 응답 실패: $e');
+      }
+    }
   }
 
   static NavigatorState? get _navigator => _navigatorKey?.currentState;
@@ -158,32 +385,32 @@ class DeepLinkService {
     );
   }
 
-  static Future<String?> _resolveBookId(String? bookId) async {
+  static Future<String?> _resolveBookId(
+    String? bookId, {
+    required String userId,
+  }) async {
     if (bookId == null) return null;
     if (bookId != 'current') return bookId;
 
     try {
+      final response = await Supabase.instance.client
+          .from('books')
+          .select('id')
+          .eq('user_id', userId)
+          .eq('status', 'reading')
+          .isFilter('deleted_at', null)
+          .order('updated_at', ascending: false)
+          .limit(1);
+      if ((response as List).isNotEmpty) {
+        final id = response.first['id'] as String;
+        debugPrint('🔗 "current" → DB 첫 reading 책 ID: $id');
+        return id;
+      }
+
       final storedId = await HomeWidget.getWidgetData<String>('book_id');
       if (storedId != null && storedId.isNotEmpty) {
         debugPrint('🔗 "current" → 위젯 저장 책 ID: $storedId');
         return storedId;
-      }
-
-      final userId = Supabase.instance.client.auth.currentUser?.id;
-      if (userId != null) {
-        final response = await Supabase.instance.client
-            .from('books')
-            .select('id')
-            .eq('user_id', userId)
-            .eq('status', 'reading')
-            .isFilter('deleted_at', null)
-            .order('updated_at', ascending: false)
-            .limit(1);
-        if ((response as List).isNotEmpty) {
-          final id = response.first['id'] as String;
-          debugPrint('🔗 "current" → DB 첫 reading 책 ID: $id');
-          return id;
-        }
       }
     } catch (e) {
       debugPrint('🔗 "current" bookId 해석 실패: $e');
@@ -194,139 +421,200 @@ class DeepLinkService {
   static Future<void> _handleDeepLink(Uri uri,
       {bool useReplacement = false}) async {
     debugPrint('🔗 딥링크 수신: $uri (useReplacement=$useReplacement)');
-
-    if (_isProcessingDeepLink) {
-      debugPrint('🔗 딥링크 처리 중 — 중복 요청 무시: $uri');
+    if (uri.host == 'login-callback' || uri.host == 'reset-callback') {
+      if (uri.query.contains('error=') || uri.fragment.contains('error=')) {
+        debugPrint('🔗 인증 콜백 에러 파라미터 감지 — 무시: $uri');
+        return;
+      }
+      final urlKey = uri.toString();
+      if (_handledAuthUrls.contains(urlKey)) {
+        debugPrint('🔗 이미 처리된 인증 콜백 — 무시: $uri');
+        return;
+      }
+      _handledAuthUrls.add(urlKey);
+      debugPrint('🔗 Supabase 인증 콜백: $uri');
+      try {
+        await Supabase.instance.client.auth.getSessionFromUrl(uri);
+        debugPrint('🔗 Supabase 인증 콜백 완료');
+      } catch (e) {
+        debugPrint('🔗 Supabase 인증 콜백 실패: $e');
+      }
       return;
     }
 
-    final uriKey = uri.toString();
-    final now = DateTime.now();
-    final lastHandled = _recentlyHandledDeepLinks[uriKey];
-    if (lastHandled != null &&
-        now.difference(lastHandled).inMilliseconds < 2000) {
-      debugPrint(
-          '🔗 중복 딥링크 무시 (${now.difference(lastHandled).inMilliseconds}ms 이내): $uri');
+    if (parseUri(uri) == null) {
+      debugPrint('🔗 유효하지 않은 딥링크: $uri');
       return;
     }
-    _recentlyHandledDeepLinks[uriKey] = now;
-    _isProcessingDeepLink = true;
 
-    try {
-      if (uri.host == 'login-callback' || uri.host == 'reset-callback') {
-        if (uri.query.contains('error=') || uri.fragment.contains('error=')) {
-          debugPrint('🔗 인증 콜백 에러 파라미터 감지 — 무시: $uri');
+    await _intentCoordinator.receive(
+      DeepLinkRequest(uri: uri, useReplacement: useReplacement),
+      isAuthenticated: Supabase.instance.client.auth.currentUser != null,
+      dispatch: _dispatchDeepLink,
+    );
+  }
+
+  static Future<void> _dispatchDeepLink(DeepLinkRequest request) async {
+    final navigator = _navigator;
+    if (navigator == null) {
+      markNavigationUnavailable();
+      if (_isInitialized && Supabase.instance.client.auth.currentUser != null) {
+        await _intentCoordinator.receive(
+          request,
+          isAuthenticated: true,
+          dispatch: _dispatchDeepLink,
+        );
+      }
+      return;
+    }
+
+    final result = parseUri(request.uri);
+    if (result == null) return;
+    final userId = Supabase.instance.client.auth.currentUser?.id;
+    if (userId == null) return;
+    final guard = DeepLinkDispatchGuard(
+      userId: userId,
+      navigationGeneration: _navigationGeneration,
+    );
+
+    bool canComplete() {
+      return _isInitialized &&
+          identical(_navigator, navigator) &&
+          guard.canComplete(
+            currentUserId: Supabase.instance.client.auth.currentUser?.id,
+            currentNavigationGeneration: _navigationGeneration,
+            navigationReady: _intentCoordinator.isNavigationReady,
+          );
+    }
+
+    switch (result.action) {
+      case DeepLinkAction.search:
+        if (!canComplete()) return;
+        final searchRoute = MaterialPageRoute<void>(
+          builder: (context) => const ReadingStartScreen(),
+        );
+        DeepLinkNavigator.open(
+          navigator,
+          searchRoute,
+          useReplacement: request.useReplacement,
+        );
+        break;
+
+      case DeepLinkAction.bookDetail:
+        final resolvedId = await _resolveBookId(
+          result.bookId,
+          userId: userId,
+        );
+        if (!canComplete()) return;
+        if (resolvedId == null) return;
+        final book = await _fetchBook(resolvedId, userId: userId);
+        if (!canComplete()) return;
+        if (book == null) {
+          debugPrint('🔗 책을 찾을 수 없음: $resolvedId');
           return;
         }
-        final urlKey = uri.toString();
-        if (_handledAuthUrls.contains(urlKey)) {
-          debugPrint('🔗 이미 처리된 인증 콜백 — 무시: $uri');
+        final detailRoute = MaterialPageRoute<void>(
+          builder: (context) => BookDetailScreen(book: book),
+        );
+        DeepLinkNavigator.open(
+          navigator,
+          detailRoute,
+          useReplacement: request.useReplacement,
+        );
+        break;
+
+      case DeepLinkAction.bookRecord:
+        final resolvedRecordId = await _resolveBookId(
+          result.bookId,
+          userId: userId,
+        );
+        if (!canComplete()) return;
+        if (resolvedRecordId == null) return;
+        final recordBook = await _fetchBook(
+          resolvedRecordId,
+          userId: userId,
+        );
+        if (!canComplete()) return;
+        if (recordBook == null) {
+          debugPrint('🔗 책을 찾을 수 없음: $resolvedRecordId');
           return;
         }
-        _handledAuthUrls.add(urlKey);
-        debugPrint('🔗 Supabase 인증 콜백: $uri');
-        try {
-          await Supabase.instance.client.auth.getSessionFromUrl(uri);
-          debugPrint('🔗 Supabase 인증 콜백 완료');
-        } catch (e) {
-          debugPrint('🔗 Supabase 인증 콜백 실패: $e');
+        final recordRoute = MaterialPageRoute<void>(
+          builder: (context) => BookDetailScreen(
+            book: recordBook,
+            initialTabIndex: 1,
+          ),
+        );
+        DeepLinkNavigator.open(
+          navigator,
+          recordRoute,
+          useReplacement: request.useReplacement,
+        );
+        break;
+
+      case DeepLinkAction.bookScan:
+        final resolvedScanId = await _resolveBookId(
+          result.bookId,
+          userId: userId,
+        );
+        if (!canComplete()) return;
+        if (resolvedScanId == null) return;
+        final scanBook = await _fetchBook(
+          resolvedScanId,
+          userId: userId,
+        );
+        if (!canComplete()) return;
+        if (scanBook == null) {
+          debugPrint('🔗 책을 찾을 수 없음: $resolvedScanId');
+          return;
         }
-        return;
-      }
-
-      final navigator = _navigator;
-      if (navigator == null) {
-        debugPrint('🔗 Navigator 없음 — 딥링크 무시');
-        return;
-      }
-
-      final result = parseUri(uri);
-      if (result == null) {
-        debugPrint('🔗 유효하지 않은 딥링크: $uri');
-        return;
-      }
-
-      switch (result.action) {
-        case DeepLinkAction.search:
-          final searchRoute = MaterialPageRoute(
-            builder: (context) => const ReadingStartScreen(),
-          );
-          if (useReplacement) {
-            navigator.pushReplacement(searchRoute);
-          } else {
-            navigator.push(searchRoute);
-          }
-          break;
-
-        case DeepLinkAction.bookDetail:
-          final resolvedId = await _resolveBookId(result.bookId);
-          if (resolvedId == null) return;
-          final book = await _fetchBook(resolvedId);
-          if (book == null) {
-            debugPrint('🔗 책을 찾을 수 없음: $resolvedId');
-            return;
-          }
-          final detailRoute = MaterialPageRoute(
-            builder: (context) => BookDetailScreen(book: book),
-          );
-          if (useReplacement) {
-            navigator.pushReplacement(detailRoute);
-          } else {
-            navigator.push(detailRoute);
-          }
-          break;
-
-        case DeepLinkAction.bookRecord:
-          final resolvedRecordId = await _resolveBookId(result.bookId);
-          if (resolvedRecordId == null) return;
-          final recordBook = await _fetchBook(resolvedRecordId);
-          if (recordBook == null) {
-            debugPrint('🔗 책을 찾을 수 없음: $resolvedRecordId');
-            return;
-          }
-          final recordRoute = MaterialPageRoute(
-            builder: (context) => BookDetailScreen(
-              book: recordBook,
-              initialTabIndex: 1,
-            ),
-          );
-          if (useReplacement) {
-            navigator.pushReplacement(recordRoute);
-          } else {
-            navigator.push(recordRoute);
-          }
-          break;
-
-        case DeepLinkAction.bookScan:
-          final resolvedScanId = await _resolveBookId(result.bookId);
-          if (resolvedScanId == null) return;
-          final scanBook = await _fetchBook(resolvedScanId);
-          if (scanBook == null) {
-            debugPrint('🔗 책을 찾을 수 없음: $resolvedScanId');
-            return;
-          }
-          final scanRoute = MaterialPageRoute(
-            builder: (context) => BookDetailScreen(
-              book: scanBook,
-              autoOpenScan: true,
-            ),
-          );
-          if (useReplacement) {
-            navigator.pushReplacement(scanRoute);
-          } else {
-            navigator.push(scanRoute);
-          }
-          break;
-      }
-    } finally {
-      _isProcessingDeepLink = false;
+        final scanRoute = MaterialPageRoute<void>(
+          builder: (context) => BookDetailScreen(
+            book: scanBook,
+            autoOpenScan: true,
+          ),
+        );
+        DeepLinkNavigator.open(
+          navigator,
+          scanRoute,
+          useReplacement: request.useReplacement,
+        );
+        break;
     }
   }
 
-  static Future<Book?> _fetchBook(String bookId) async {
+  static Future<void> markNavigationReady() async {
+    _navigationGeneration += 1;
+    await _intentCoordinator.markNavigationReady(
+      isAuthenticated: Supabase.instance.client.auth.currentUser != null,
+      dispatch: _dispatchDeepLink,
+    );
+  }
+
+  static void markNavigationUnavailable() {
+    _navigationGeneration += 1;
+    _intentCoordinator.markNavigationUnavailable(clearPending: true);
+  }
+
+  static Future<Book?> _fetchBook(
+    String bookId, {
+    required String userId,
+  }) async {
     try {
-      final bookService = BookService();
-      return await bookService.getBookById(bookId);
+      return await _bookResolver.fetchOwnedBook(
+        userId: userId,
+        bookId: bookId,
+        fetch: (userId, ownedBookId) async {
+          final response = await Supabase.instance.client
+              .from('books')
+              .select()
+              .eq('id', ownedBookId)
+              .eq('user_id', userId)
+              .isFilter('deleted_at', null)
+              .maybeSingle();
+          return response == null ? null : Book.fromJson(response);
+        },
+      );
     } catch (e) {
       debugPrint('🔗 딥링크 책 조회 실패: $e');
       return null;
@@ -338,7 +626,10 @@ class DeepLinkService {
     _linkSubscription = null;
     _widgetClickSubscription?.cancel();
     _widgetClickSubscription = null;
+    _deepLinkChannel.setMethodCallHandler(null);
     _navigatorKey = null;
-    _recentlyHandledDeepLinks.clear();
+    _isInitialized = false;
+    _navigationGeneration += 1;
+    _intentCoordinator.reset();
   }
 }

--- a/app/lib/data/services/deep_link_service.dart
+++ b/app/lib/data/services/deep_link_service.dart
@@ -27,6 +27,31 @@ class DeepLinkResult {
   const DeepLinkResult({required this.action, this.bookId});
 }
 
+class DeepLinkAuthConfiguration {
+  static const supabaseOptions = FlutterAuthClientOptions(
+    detectSessionInUri: false,
+  );
+}
+
+class DeepLinkContentNormalizer {
+  static Uri normalize(DeepLinkResult result) {
+    final action = switch (result.action) {
+      DeepLinkAction.search => 'search',
+      DeepLinkAction.bookDetail => 'detail',
+      DeepLinkAction.bookRecord => 'record',
+      DeepLinkAction.bookScan => 'scan',
+    };
+    return Uri(
+      scheme: 'bookgolas',
+      host: 'book',
+      pathSegments: [
+        action,
+        if (result.bookId case final bookId?) bookId,
+      ],
+    );
+  }
+}
+
 class DeepLinkRequest {
   final Uri uri;
   final bool useReplacement;
@@ -124,12 +149,54 @@ class DeepLinkCallbackDeduplicator {
   }
 }
 
+enum DeepLinkAuthCallbackOutcome {
+  completed,
+  duplicate,
+  rejected,
+  failed,
+}
+
+class DeepLinkAuthCallbackProcessor {
+  final DeepLinkCallbackDeduplicator _deduplicator;
+
+  DeepLinkAuthCallbackProcessor({DeepLinkCallbackDeduplicator? deduplicator})
+      : _deduplicator = deduplicator ?? DeepLinkCallbackDeduplicator();
+
+  Future<DeepLinkAuthCallbackOutcome> process(
+    Uri uri, {
+    required Future<void> Function(Uri uri) exchange,
+  }) async {
+    final hasQueryError = uri.queryParameters.containsKey('error') ||
+        uri.queryParameters.containsKey('error_description');
+    final hasFragmentError = RegExp(
+      r'(^|&)(error|error_description)=',
+    ).hasMatch(uri.fragment);
+    if (hasQueryError || hasFragmentError) {
+      return DeepLinkAuthCallbackOutcome.rejected;
+    }
+    if (!_deduplicator.markIfNew(uri)) {
+      return DeepLinkAuthCallbackOutcome.duplicate;
+    }
+    try {
+      await exchange(uri);
+      return DeepLinkAuthCallbackOutcome.completed;
+    } catch (_) {
+      return DeepLinkAuthCallbackOutcome.failed;
+    }
+  }
+
+  void clear() {
+    _deduplicator.clear();
+  }
+}
+
 class DeepLinkLogSanitizer {
   static String describe(Uri uri) {
-    if (uri.host == 'login-callback' || uri.host == 'reset-callback') {
-      return '${uri.scheme}://${uri.host}${uri.path}';
+    final origin = '${uri.scheme}://${uri.host}';
+    if (uri.host == 'book' && uri.pathSegments.isNotEmpty) {
+      return '$origin/${uri.pathSegments.first}';
     }
-    return uri.toString();
+    return origin;
   }
 }
 
@@ -251,8 +318,8 @@ class DeepLinkService {
   static StreamSubscription<Uri?>? _widgetClickSubscription;
   static GlobalKey<NavigatorState>? _navigatorKey;
   static const _deepLinkChannel = MethodChannel('com.bookgolas.app/deep_link');
-  static final DeepLinkCallbackDeduplicator _authCallbackDeduplicator =
-      DeepLinkCallbackDeduplicator();
+  static final DeepLinkAuthCallbackProcessor _authCallbackProcessor =
+      DeepLinkAuthCallbackProcessor();
   static final DeepLinkIntentCoordinator _intentCoordinator =
       DeepLinkIntentCoordinator();
   static final DeepLinkBookResolver _bookResolver = DeepLinkBookResolver();
@@ -378,7 +445,10 @@ class DeepLinkService {
       final initialWidgetUri =
           await HomeWidget.initiallyLaunchedFromHomeWidget();
       if (initialWidgetUri != null) {
-        debugPrint('📱 위젯 콜드스타트 딥링크: $initialWidgetUri');
+        debugPrint(
+          '📱 위젯 콜드스타트 딥링크: '
+          '${DeepLinkLogSanitizer.describe(initialWidgetUri)}',
+        );
         await _handleDeepLink(initialWidgetUri, useReplacement: true);
       }
     } catch (e) {
@@ -389,7 +459,10 @@ class DeepLinkService {
     _widgetClickSubscription = HomeWidget.widgetClicked.listen(
       (Uri? uri) {
         if (uri != null) {
-          debugPrint('📱 위젯 클릭 딥링크: $uri');
+          debugPrint(
+            '📱 위젯 클릭 딥링크: '
+            '${DeepLinkLogSanitizer.describe(uri)}',
+          );
           _handleDeepLink(uri, useReplacement: true);
         }
       },
@@ -457,33 +530,45 @@ class DeepLinkService {
   static Future<void> _handleDeepLink(Uri uri,
       {bool useReplacement = false}) async {
     if (uri.host == 'login-callback' || uri.host == 'reset-callback') {
-      if (uri.query.contains('error=') || uri.fragment.contains('error=')) {
-        debugPrint('🔗 인증 콜백 에러 파라미터 감지 — 무시');
-        return;
-      }
-      if (!_authCallbackDeduplicator.markIfNew(uri)) {
-        debugPrint('🔗 이미 처리된 인증 콜백 — 무시');
-        return;
-      }
       debugPrint('🔗 Supabase 인증 콜백 수신');
-      try {
-        await Supabase.instance.client.auth.getSessionFromUrl(uri);
-        debugPrint('🔗 Supabase 인증 콜백 완료');
-      } catch (e) {
-        debugPrint('🔗 Supabase 인증 콜백 실패: $e');
+      final outcome = await _authCallbackProcessor.process(
+        uri,
+        exchange: (callbackUri) async {
+          await Supabase.instance.client.auth.getSessionFromUrl(callbackUri);
+        },
+      );
+      switch (outcome) {
+        case DeepLinkAuthCallbackOutcome.completed:
+          debugPrint('🔗 Supabase 인증 콜백 완료');
+          break;
+        case DeepLinkAuthCallbackOutcome.duplicate:
+          debugPrint('🔗 이미 처리된 인증 콜백 — 무시');
+          break;
+        case DeepLinkAuthCallbackOutcome.rejected:
+          debugPrint('🔗 인증 콜백 에러 파라미터 감지 — 무시');
+          break;
+        case DeepLinkAuthCallbackOutcome.failed:
+          debugPrint('🔗 Supabase 인증 콜백 실패');
+          break;
       }
       return;
     }
 
-    debugPrint('🔗 딥링크 수신: $uri (useReplacement=$useReplacement)');
-
-    if (parseUri(uri) == null) {
-      debugPrint('🔗 유효하지 않은 딥링크: $uri');
+    final result = parseUri(uri);
+    if (result == null) {
+      debugPrint(
+        '🔗 유효하지 않은 딥링크: ${DeepLinkLogSanitizer.describe(uri)}',
+      );
       return;
     }
+    final normalizedUri = DeepLinkContentNormalizer.normalize(result);
+    debugPrint(
+      '🔗 딥링크 수신: ${DeepLinkLogSanitizer.describe(normalizedUri)} '
+      '(useReplacement=$useReplacement)',
+    );
 
     await _intentCoordinator.receive(
-      DeepLinkRequest(uri: uri, useReplacement: useReplacement),
+      DeepLinkRequest(uri: normalizedUri, useReplacement: useReplacement),
       isAuthenticated: Supabase.instance.client.auth.currentUser != null,
       dispatch: _dispatchDeepLink,
     );
@@ -653,7 +738,7 @@ class DeepLinkService {
     _navigatorKey = null;
     _isInitialized = false;
     _navigationGeneration += 1;
-    _authCallbackDeduplicator.clear();
+    _authCallbackProcessor.clear();
     _intentCoordinator.reset();
   }
 }

--- a/app/lib/data/services/deep_link_service.dart
+++ b/app/lib/data/services/deep_link_service.dart
@@ -200,6 +200,13 @@ class DeepLinkLogSanitizer {
   }
 }
 
+class DeepLinkLogMessages {
+  static const currentBookResolvedFromDatabase =
+      '🔗 "current" → DB reading 책 확인';
+  static const currentBookResolvedFromWidget = '🔗 "current" → 위젯 저장 책 확인';
+  static const targetBookNotFound = '🔗 딥링크 대상 책을 찾을 수 없음';
+}
+
 class DeepLinkIntentCoordinator {
   final DateTime Function() _now;
   final Duration _duplicateWindow;
@@ -512,13 +519,13 @@ class DeepLinkService {
           .limit(1);
       if ((response as List).isNotEmpty) {
         final id = response.first['id'] as String;
-        debugPrint('🔗 "current" → DB 첫 reading 책 ID: $id');
+        debugPrint(DeepLinkLogMessages.currentBookResolvedFromDatabase);
         return id;
       }
 
       final storedId = await HomeWidget.getWidgetData<String>('book_id');
       if (storedId != null && storedId.isNotEmpty) {
-        debugPrint('🔗 "current" → 위젯 저장 책 ID: $storedId');
+        debugPrint(DeepLinkLogMessages.currentBookResolvedFromWidget);
         return storedId;
       }
     } catch (e) {
@@ -681,7 +688,7 @@ class DeepLinkService {
     final book = await _fetchBook(resolvedId, userId: userId);
     if (!canComplete()) return;
     if (book == null) {
-      debugPrint('🔗 책을 찾을 수 없음: $resolvedId');
+      debugPrint(DeepLinkLogMessages.targetBookNotFound);
       return;
     }
     DeepLinkNavigator.open(

--- a/app/lib/data/services/deep_link_service.dart
+++ b/app/lib/data/services/deep_link_service.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
+import 'dart:collection';
+import 'dart:convert';
 
 import 'package:app_links/app_links.dart';
+import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:home_widget/home_widget.dart';
@@ -98,6 +101,35 @@ class DeepLinkDispatchGuard {
     return navigationReady &&
         currentUserId == userId &&
         currentNavigationGeneration == navigationGeneration;
+  }
+}
+
+class DeepLinkCallbackDeduplicator {
+  final int maxEntries;
+  final LinkedHashSet<String> _handledDigests = LinkedHashSet<String>();
+
+  DeepLinkCallbackDeduplicator({this.maxEntries = 64}) : assert(maxEntries > 0);
+
+  bool markIfNew(Uri uri) {
+    final digest = sha256.convert(utf8.encode(uri.toString())).toString();
+    if (!_handledDigests.add(digest)) return false;
+    if (_handledDigests.length > maxEntries) {
+      _handledDigests.remove(_handledDigests.first);
+    }
+    return true;
+  }
+
+  void clear() {
+    _handledDigests.clear();
+  }
+}
+
+class DeepLinkLogSanitizer {
+  static String describe(Uri uri) {
+    if (uri.host == 'login-callback' || uri.host == 'reset-callback') {
+      return '${uri.scheme}://${uri.host}${uri.path}';
+    }
+    return uri.toString();
   }
 }
 
@@ -219,7 +251,8 @@ class DeepLinkService {
   static StreamSubscription<Uri?>? _widgetClickSubscription;
   static GlobalKey<NavigatorState>? _navigatorKey;
   static const _deepLinkChannel = MethodChannel('com.bookgolas.app/deep_link');
-  static final Set<String> _handledAuthUrls = {};
+  static final DeepLinkCallbackDeduplicator _authCallbackDeduplicator =
+      DeepLinkCallbackDeduplicator();
   static final DeepLinkIntentCoordinator _intentCoordinator =
       DeepLinkIntentCoordinator();
   static final DeepLinkBookResolver _bookResolver = DeepLinkBookResolver();
@@ -314,7 +347,10 @@ class DeepLinkService {
   }
 
   static Future<void> _handleNativeDeepLink(DeepLinkRequest request) async {
-    debugPrint('📱 네이티브 딥링크 수신: ${request.uri}');
+    debugPrint(
+      '📱 네이티브 딥링크 수신: '
+      '${DeepLinkLogSanitizer.describe(request.uri)}',
+    );
     try {
       await _handleDeepLink(
         request.uri,
@@ -420,19 +456,16 @@ class DeepLinkService {
 
   static Future<void> _handleDeepLink(Uri uri,
       {bool useReplacement = false}) async {
-    debugPrint('🔗 딥링크 수신: $uri (useReplacement=$useReplacement)');
     if (uri.host == 'login-callback' || uri.host == 'reset-callback') {
       if (uri.query.contains('error=') || uri.fragment.contains('error=')) {
-        debugPrint('🔗 인증 콜백 에러 파라미터 감지 — 무시: $uri');
+        debugPrint('🔗 인증 콜백 에러 파라미터 감지 — 무시');
         return;
       }
-      final urlKey = uri.toString();
-      if (_handledAuthUrls.contains(urlKey)) {
-        debugPrint('🔗 이미 처리된 인증 콜백 — 무시: $uri');
+      if (!_authCallbackDeduplicator.markIfNew(uri)) {
+        debugPrint('🔗 이미 처리된 인증 콜백 — 무시');
         return;
       }
-      _handledAuthUrls.add(urlKey);
-      debugPrint('🔗 Supabase 인증 콜백: $uri');
+      debugPrint('🔗 Supabase 인증 콜백 수신');
       try {
         await Supabase.instance.client.auth.getSessionFromUrl(uri);
         debugPrint('🔗 Supabase 인증 콜백 완료');
@@ -441,6 +474,8 @@ class DeepLinkService {
       }
       return;
     }
+
+    debugPrint('🔗 딥링크 수신: $uri (useReplacement=$useReplacement)');
 
     if (parseUri(uri) == null) {
       debugPrint('🔗 유효하지 않은 딥링크: $uri');
@@ -501,86 +536,74 @@ class DeepLinkService {
         break;
 
       case DeepLinkAction.bookDetail:
-        final resolvedId = await _resolveBookId(
-          result.bookId,
-          userId: userId,
-        );
-        if (!canComplete()) return;
-        if (resolvedId == null) return;
-        final book = await _fetchBook(resolvedId, userId: userId);
-        if (!canComplete()) return;
-        if (book == null) {
-          debugPrint('🔗 책을 찾을 수 없음: $resolvedId');
-          return;
-        }
-        final detailRoute = MaterialPageRoute<void>(
-          builder: (context) => BookDetailScreen(book: book),
-        );
-        DeepLinkNavigator.open(
+        await _openBookRoute(
           navigator,
-          detailRoute,
-          useReplacement: request.useReplacement,
+          request,
+          bookId: result.bookId,
+          userId: userId,
+          canComplete: canComplete,
+          buildRoute: (book) => MaterialPageRoute<void>(
+            builder: (context) => BookDetailScreen(book: book),
+          ),
         );
         break;
 
       case DeepLinkAction.bookRecord:
-        final resolvedRecordId = await _resolveBookId(
-          result.bookId,
-          userId: userId,
-        );
-        if (!canComplete()) return;
-        if (resolvedRecordId == null) return;
-        final recordBook = await _fetchBook(
-          resolvedRecordId,
-          userId: userId,
-        );
-        if (!canComplete()) return;
-        if (recordBook == null) {
-          debugPrint('🔗 책을 찾을 수 없음: $resolvedRecordId');
-          return;
-        }
-        final recordRoute = MaterialPageRoute<void>(
-          builder: (context) => BookDetailScreen(
-            book: recordBook,
-            initialTabIndex: 1,
-          ),
-        );
-        DeepLinkNavigator.open(
+        await _openBookRoute(
           navigator,
-          recordRoute,
-          useReplacement: request.useReplacement,
+          request,
+          bookId: result.bookId,
+          userId: userId,
+          canComplete: canComplete,
+          buildRoute: (book) => MaterialPageRoute<void>(
+            builder: (context) => BookDetailScreen(
+              book: book,
+              initialTabIndex: 1,
+            ),
+          ),
         );
         break;
 
       case DeepLinkAction.bookScan:
-        final resolvedScanId = await _resolveBookId(
-          result.bookId,
-          userId: userId,
-        );
-        if (!canComplete()) return;
-        if (resolvedScanId == null) return;
-        final scanBook = await _fetchBook(
-          resolvedScanId,
-          userId: userId,
-        );
-        if (!canComplete()) return;
-        if (scanBook == null) {
-          debugPrint('🔗 책을 찾을 수 없음: $resolvedScanId');
-          return;
-        }
-        final scanRoute = MaterialPageRoute<void>(
-          builder: (context) => BookDetailScreen(
-            book: scanBook,
-            autoOpenScan: true,
-          ),
-        );
-        DeepLinkNavigator.open(
+        await _openBookRoute(
           navigator,
-          scanRoute,
-          useReplacement: request.useReplacement,
+          request,
+          bookId: result.bookId,
+          userId: userId,
+          canComplete: canComplete,
+          buildRoute: (book) => MaterialPageRoute<void>(
+            builder: (context) => BookDetailScreen(
+              book: book,
+              autoOpenScan: true,
+            ),
+          ),
         );
         break;
     }
+  }
+
+  static Future<void> _openBookRoute(
+    NavigatorState navigator,
+    DeepLinkRequest request, {
+    required String? bookId,
+    required String userId,
+    required bool Function() canComplete,
+    required Route<void> Function(Book book) buildRoute,
+  }) async {
+    final resolvedId = await _resolveBookId(bookId, userId: userId);
+    if (!canComplete()) return;
+    if (resolvedId == null) return;
+    final book = await _fetchBook(resolvedId, userId: userId);
+    if (!canComplete()) return;
+    if (book == null) {
+      debugPrint('🔗 책을 찾을 수 없음: $resolvedId');
+      return;
+    }
+    DeepLinkNavigator.open(
+      navigator,
+      buildRoute(book),
+      useReplacement: request.useReplacement,
+    );
   }
 
   static Future<void> markNavigationReady() async {
@@ -630,6 +653,7 @@ class DeepLinkService {
     _navigatorKey = null;
     _isInitialized = false;
     _navigationGeneration += 1;
+    _authCallbackDeduplicator.clear();
     _intentCoordinator.reset();
   }
 }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -142,6 +142,7 @@ class AppBootstrap extends StatelessWidget {
       await Supabase.initialize(
         url: AppConfig.supabaseUrl,
         anonKey: AppConfig.supabaseAnonKey,
+        authOptions: DeepLinkAuthConfiguration.supabaseOptions,
         realtimeClientOptions: RealtimeClientOptions(
           logLevel: AppConfig.isProduction
               ? RealtimeLogLevel.error

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -350,6 +350,20 @@ class AuthWrapper extends StatefulWidget {
 
 class _AuthWrapperState extends State<AuthWrapper> {
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      DeepLinkService.init(navigatorKey: navigatorKey);
+    });
+  }
+
+  @override
+  void dispose() {
+    DeepLinkService.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Consumer2<AuthViewModel, OnboardingViewModel>(
       builder: (context, authViewModel, onboardingViewModel, _) {
@@ -396,6 +410,7 @@ class _MainScreenState extends State<MainScreen>
 
   @override
   void dispose() {
+    DeepLinkService.markNavigationUnavailable();
     WidgetsBinding.instance.removeObserver(this);
     routeObserver.unsubscribe(this);
     super.dispose();
@@ -427,14 +442,13 @@ class _MainScreenState extends State<MainScreen>
     // 인증 완료 후 BookListViewModel 초기화 및 FCM 초기화
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       context.read<BookListViewModel>().initialize();
-
-      DeepLinkService.init(context, navigatorKey: navigatorKey);
-
       final subscriptionService = context.read<SubscriptionService>();
       final subscriptionViewModel = context.read<SubscriptionViewModel>();
       final adViewModel = context.read<AdViewModel>();
       final notificationSettingsService =
           context.read<NotificationSettingsService>();
+
+      await DeepLinkService.markNavigationReady();
 
       if (FeatureFlags.paidSubscriptionsEnabled) {
         final userId = Supabase.instance.client.auth.currentUser?.id;

--- a/app/test/deep_link_service_test.dart
+++ b/app/test/deep_link_service_test.dart
@@ -1,7 +1,465 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:book_golas/data/services/deep_link_service.dart';
 
 void main() {
+  testWidgets('deep-link replacement preserves the root app shell',
+      (tester) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: const Scaffold(body: Text('home')),
+      ),
+    );
+
+    showDialog<void>(
+      context: navigatorKey.currentContext!,
+      barrierDismissible: false,
+      builder: (context) => const AlertDialog(
+        content: Text('blocking-popup'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('blocking-popup'), findsOneWidget);
+
+    DeepLinkNavigator.open(
+      navigatorKey.currentState!,
+      MaterialPageRoute<void>(
+        builder: (context) => const Scaffold(
+          body: Text('first-deep-link-destination'),
+        ),
+      ),
+      useReplacement: true,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('blocking-popup'), findsNothing);
+    expect(find.text('first-deep-link-destination'), findsOneWidget);
+
+    DeepLinkNavigator.open(
+      navigatorKey.currentState!,
+      MaterialPageRoute<void>(
+        builder: (context) => const Scaffold(
+          body: Text('second-deep-link-destination'),
+        ),
+      ),
+      useReplacement: true,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('first-deep-link-destination'), findsNothing);
+    expect(find.text('second-deep-link-destination'), findsOneWidget);
+
+    navigatorKey.currentState!.pop();
+    await tester.pumpAndSettle();
+
+    expect(find.text('home'), findsOneWidget);
+    expect(find.text('second-deep-link-destination'), findsNothing);
+  });
+
+  test('dispatch guard rejects delayed completion after session loss',
+      () async {
+    const guard = DeepLinkDispatchGuard(
+      userId: 'user-1',
+      navigationGeneration: 7,
+    );
+    final delayedFetch = Completer<void>();
+    String? currentUserId = 'user-1';
+    var currentGeneration = 7;
+    var navigationReady = true;
+
+    final canCompleteAfterFetch = delayedFetch.future.then((_) {
+      return guard.canComplete(
+        currentUserId: currentUserId,
+        currentNavigationGeneration: currentGeneration,
+        navigationReady: navigationReady,
+      );
+    });
+    currentUserId = null;
+    currentGeneration += 1;
+    navigationReady = false;
+    delayedFetch.complete();
+
+    expect(await canCompleteAfterFetch, isFalse);
+  });
+
+  test('dispatch guard rejects completion after an account switch', () {
+    const guard = DeepLinkDispatchGuard(
+      userId: 'user-1',
+      navigationGeneration: 3,
+    );
+
+    expect(
+      guard.canComplete(
+        currentUserId: 'user-2',
+        currentNavigationGeneration: 3,
+        navigationReady: true,
+      ),
+      isFalse,
+    );
+  });
+
+  group('DeepLinkBookResolver', () {
+    test('does not query a book before authentication', () async {
+      final resolver = DeepLinkBookResolver();
+      var wasCalled = false;
+
+      final book = await resolver.fetchOwnedBook(
+        userId: null,
+        bookId: 'book-1',
+        fetch: (userId, bookId) async {
+          wasCalled = true;
+          return null;
+        },
+      );
+
+      expect(book, isNull);
+      expect(wasCalled, isFalse);
+    });
+
+    test('passes the authenticated owner to the book query', () async {
+      final resolver = DeepLinkBookResolver();
+      String? queriedUserId;
+      String? queriedBookId;
+
+      await resolver.fetchOwnedBook(
+        userId: 'user-1',
+        bookId: 'book-1',
+        fetch: (userId, bookId) async {
+          queriedUserId = userId;
+          queriedBookId = bookId;
+          return null;
+        },
+      );
+
+      expect(queriedUserId, 'user-1');
+      expect(queriedBookId, 'book-1');
+    });
+
+    test('keeps the deep-link query explicitly user scoped', () async {
+      final source =
+          await File('lib/data/services/deep_link_service.dart').readAsString();
+
+      expect(source, contains(".eq('id', ownedBookId)"));
+      expect(source, contains(".eq('user_id', userId)"));
+    });
+  });
+
+  group('DeepLinkIntentCoordinator', () {
+    test('replays a pre-auth cold-start intent exactly once when ready',
+        () async {
+      final coordinator = DeepLinkIntentCoordinator();
+      final dispatched = <DeepLinkRequest>[];
+      final request = DeepLinkRequest(
+        uri: Uri.parse('bookgolas://book/search'),
+        useReplacement: true,
+      );
+
+      await coordinator.receive(
+        request,
+        isAuthenticated: false,
+        dispatch: dispatched.add,
+      );
+      expect(dispatched, isEmpty);
+
+      await coordinator.markNavigationReady(
+        isAuthenticated: true,
+        dispatch: dispatched.add,
+      );
+      await coordinator.markNavigationReady(
+        isAuthenticated: true,
+        dispatch: dispatched.add,
+      );
+
+      expect(dispatched, [request]);
+    });
+
+    test('preserves current-book action and replacement mode before login',
+        () async {
+      final coordinator = DeepLinkIntentCoordinator();
+      final dispatched = <DeepLinkRequest>[];
+      final request = DeepLinkRequest(
+        uri: Uri.parse('bookgolas://book/scan/current'),
+        useReplacement: true,
+      );
+
+      await coordinator.receive(
+        request,
+        isAuthenticated: false,
+        dispatch: dispatched.add,
+      );
+      await coordinator.markNavigationReady(
+        isAuthenticated: true,
+        dispatch: dispatched.add,
+      );
+
+      expect(dispatched.single.uri, request.uri);
+      expect(dispatched.single.useReplacement, isTrue);
+    });
+
+    test('dispatches supported warm-start intents immediately', () async {
+      final coordinator = DeepLinkIntentCoordinator();
+      final dispatched = <DeepLinkRequest>[];
+      await coordinator.markNavigationReady(
+        isAuthenticated: true,
+        dispatch: dispatched.add,
+      );
+      final requests = [
+        DeepLinkRequest(uri: Uri.parse('bookgolas://book/search')),
+        DeepLinkRequest(uri: Uri.parse('bookgolas://book/detail/current')),
+        DeepLinkRequest(uri: Uri.parse('bookgolas://book/record/current')),
+        DeepLinkRequest(uri: Uri.parse('bookgolas://book/scan/current')),
+      ];
+
+      for (final request in requests) {
+        await coordinator.receive(
+          request,
+          isAuthenticated: true,
+          dispatch: dispatched.add,
+        );
+      }
+
+      expect(dispatched, requests);
+    });
+
+    test('suppresses duplicate native and plugin deliveries', () async {
+      var now = DateTime(2026, 8, 1, 12);
+      final coordinator = DeepLinkIntentCoordinator(now: () => now);
+      final dispatched = <DeepLinkRequest>[];
+      final request = DeepLinkRequest(
+        uri: Uri.parse('bookgolas://book/detail/current'),
+      );
+      await coordinator.markNavigationReady(
+        isAuthenticated: true,
+        dispatch: dispatched.add,
+      );
+
+      await coordinator.receive(
+        request,
+        isAuthenticated: true,
+        dispatch: dispatched.add,
+      );
+      now = now.add(const Duration(milliseconds: 500));
+      await coordinator.receive(
+        request,
+        isAuthenticated: true,
+        dispatch: dispatched.add,
+      );
+
+      expect(dispatched, [request]);
+    });
+
+    test('keeps the latest intent received while login is required', () async {
+      final coordinator = DeepLinkIntentCoordinator();
+      final dispatched = <DeepLinkRequest>[];
+      final first = DeepLinkRequest(
+        uri: Uri.parse('bookgolas://book/search'),
+      );
+      final latest = DeepLinkRequest(
+        uri: Uri.parse('bookgolas://book/detail/current'),
+      );
+
+      await coordinator.receive(
+        first,
+        isAuthenticated: false,
+        dispatch: dispatched.add,
+      );
+      await coordinator.receive(
+        latest,
+        isAuthenticated: false,
+        dispatch: dispatched.add,
+      );
+      await coordinator.markNavigationReady(
+        isAuthenticated: true,
+        dispatch: dispatched.add,
+      );
+
+      expect(dispatched, [latest]);
+    });
+
+    test('keeps replacement navigation for duplicate pending widget intent',
+        () async {
+      final coordinator = DeepLinkIntentCoordinator();
+      final dispatched = <DeepLinkRequest>[];
+      final uri = Uri.parse(
+        'bookgolas://book/detail/current?homeWidget=true',
+      );
+
+      await coordinator.receive(
+        DeepLinkRequest(uri: uri, useReplacement: true),
+        isAuthenticated: false,
+        dispatch: dispatched.add,
+      );
+      await coordinator.receive(
+        DeepLinkRequest(uri: uri),
+        isAuthenticated: false,
+        dispatch: dispatched.add,
+      );
+      await coordinator.markNavigationReady(
+        isAuthenticated: true,
+        dispatch: dispatched.add,
+      );
+
+      expect(dispatched.single.useReplacement, isTrue);
+    });
+
+    test('drains an intent received while the cold-start replay is running',
+        () async {
+      final coordinator = DeepLinkIntentCoordinator();
+      final firstDispatchStarted = Completer<void>();
+      final finishFirstDispatch = Completer<void>();
+      final dispatched = <DeepLinkRequest>[];
+      final first = DeepLinkRequest(
+        uri: Uri.parse('bookgolas://book/search'),
+      );
+      final second = DeepLinkRequest(
+        uri: Uri.parse('bookgolas://book/detail/current'),
+      );
+
+      await coordinator.receive(
+        first,
+        isAuthenticated: false,
+        dispatch: dispatched.add,
+      );
+      final ready = coordinator.markNavigationReady(
+        isAuthenticated: true,
+        dispatch: (request) async {
+          dispatched.add(request);
+          if (request == first) {
+            firstDispatchStarted.complete();
+            await finishFirstDispatch.future;
+          }
+        },
+      );
+      await firstDispatchStarted.future;
+      await coordinator.receive(
+        second,
+        isAuthenticated: true,
+        dispatch: dispatched.add,
+      );
+      finishFirstDispatch.complete();
+      await ready;
+
+      expect(dispatched, [first, second]);
+    });
+
+    test('drops session-bound pending work when navigation becomes unavailable',
+        () async {
+      final coordinator = DeepLinkIntentCoordinator();
+      final firstDispatchStarted = Completer<void>();
+      final finishFirstDispatch = Completer<void>();
+      final dispatched = <DeepLinkRequest>[];
+      final first = DeepLinkRequest(
+        uri: Uri.parse('bookgolas://book/detail/current'),
+      );
+      final queuedDuringDispatch = DeepLinkRequest(
+        uri: Uri.parse('bookgolas://book/scan/current'),
+      );
+      await coordinator.markNavigationReady(
+        isAuthenticated: true,
+        dispatch: dispatched.add,
+      );
+
+      final firstDispatch = coordinator.receive(
+        first,
+        isAuthenticated: true,
+        dispatch: (request) async {
+          dispatched.add(request);
+          firstDispatchStarted.complete();
+          await finishFirstDispatch.future;
+        },
+      );
+      await firstDispatchStarted.future;
+      await coordinator.receive(
+        queuedDuringDispatch,
+        isAuthenticated: true,
+        dispatch: dispatched.add,
+      );
+      coordinator.markNavigationUnavailable(clearPending: true);
+      finishFirstDispatch.complete();
+      await firstDispatch;
+      await coordinator.markNavigationReady(
+        isAuthenticated: true,
+        dispatch: dispatched.add,
+      );
+
+      expect(dispatched, [first]);
+    });
+  });
+
+  group('DeepLinkRequest native payload', () {
+    test('parses replacement policy from a native payload map', () {
+      final request = DeepLinkRequest.fromNativePayload({
+        'url': 'bookgolas://book/scan/current?homeWidget=true',
+        'useReplacement': true,
+      });
+
+      expect(request?.uri.path, '/scan/current');
+      expect(request?.useReplacement, isTrue);
+    });
+
+    test('supports a legacy native URL string without replacement', () {
+      final request = DeepLinkRequest.fromNativePayload(
+        'bookgolas://book/search',
+      );
+
+      expect(request?.uri, Uri.parse('bookgolas://book/search'));
+      expect(request?.useReplacement, isFalse);
+    });
+
+    test('rejects malformed native payloads', () {
+      expect(DeepLinkRequest.fromNativePayload(null), isNull);
+      expect(DeepLinkRequest.fromNativePayload({'url': 42}), isNull);
+    });
+  });
+
+  group('iOS deep link delivery contract', () {
+    test('disables Flutter routing while app_links owns delivery', () async {
+      final plist = await File('ios/Runner/Info.plist').readAsString();
+
+      expect(
+        plist,
+        contains('<key>FlutterDeepLinkingEnabled</key>\n\t\t<false/>'),
+      );
+    });
+
+    test('buffers native URLs and handles cold-start quick actions', () async {
+      final appDelegate =
+          await File('ios/Runner/AppDelegate.swift').readAsString();
+
+      expect(appDelegate, contains('pendingDeepLink'));
+      expect(appDelegate, contains('consumePendingDeepLink'));
+      expect(appDelegate, contains('acknowledgeDeepLink'));
+      expect(appDelegate, contains('launchOptions?[.shortcutItem]'));
+      expect(appDelegate, contains('let didFinish = super.application'));
+      expect(appDelegate, contains('return didFinish'));
+      expect(
+        RegExp(
+          r'launchOptions\?\[\.shortcutItem\][\s\S]*?sendDeepLink\(urlString, useReplacement: true\)[\s\S]*?return false',
+        ).hasMatch(appDelegate),
+        isTrue,
+      );
+      expect(appDelegate, contains('return true'));
+    });
+
+    test('marks every WidgetKit book URL for home_widget delivery', () async {
+      final widgetSource =
+          await File('ios/BookgolasWidget/BookgolasWidget.swift')
+              .readAsString();
+      final urls = RegExp(r'"bookgolas://book/[^"\n]+"')
+          .allMatches(widgetSource)
+          .map((match) => match.group(0)!)
+          .toList();
+
+      expect(urls, isNotEmpty);
+      expect(urls.every((url) => url.contains('homeWidget=true')), isTrue);
+    });
+  });
+
   group('DeepLinkService.parseUri - search', () {
     test('should parse search URI as search action', () {
       final uri = Uri.parse('bookgolas://book/search');
@@ -19,6 +477,13 @@ void main() {
       expect(result, isNotNull);
       expect(result!.action, DeepLinkAction.search);
       expect(result.bookId, isNull);
+    });
+
+    test('should ignore the home widget query marker', () {
+      final uri = Uri.parse('bookgolas://book/search?homeWidget=true');
+      final result = DeepLinkService.parseUri(uri);
+
+      expect(result?.action, DeepLinkAction.search);
     });
   });
 

--- a/app/test/deep_link_service_test.dart
+++ b/app/test/deep_link_service_test.dart
@@ -103,6 +103,36 @@ void main() {
     );
   });
 
+  test('auth callback deduplication is bounded and can be cleared', () {
+    final deduplicator = DeepLinkCallbackDeduplicator(maxEntries: 2);
+    final callback = Uri.parse(
+      'bookgolas://login-callback?access_token=sensitive-token',
+    );
+    final second = Uri.parse('bookgolas://login-callback?code=second');
+    final third = Uri.parse('bookgolas://reset-callback?code=third');
+
+    expect(deduplicator.markIfNew(callback), isTrue);
+    expect(deduplicator.markIfNew(callback), isFalse);
+    expect(deduplicator.markIfNew(second), isTrue);
+    expect(deduplicator.markIfNew(third), isTrue);
+    expect(deduplicator.markIfNew(callback), isTrue);
+
+    deduplicator.clear();
+
+    expect(deduplicator.markIfNew(callback), isTrue);
+  });
+
+  test('auth callback logging strips query and fragment credentials', () {
+    final callback = Uri.parse(
+      'bookgolas://login-callback?code=secret#access_token=secret-token',
+    );
+
+    final description = DeepLinkLogSanitizer.describe(callback);
+
+    expect(description, 'bookgolas://login-callback');
+    expect(description, isNot(contains('secret')));
+  });
+
   group('DeepLinkBookResolver', () {
     test('does not query a book before authentication', () async {
       final resolver = DeepLinkBookResolver();
@@ -138,14 +168,6 @@ void main() {
 
       expect(queriedUserId, 'user-1');
       expect(queriedBookId, 'book-1');
-    });
-
-    test('keeps the deep-link query explicitly user scoped', () async {
-      final source =
-          await File('lib/data/services/deep_link_service.dart').readAsString();
-
-      expect(source, contains(".eq('id', ownedBookId)"));
-      expect(source, contains(".eq('user_id', userId)"));
     });
   });
 
@@ -423,7 +445,11 @@ void main() {
 
       expect(
         plist,
-        contains('<key>FlutterDeepLinkingEnabled</key>\n\t\t<false/>'),
+        matches(
+          RegExp(
+            r'<key>FlutterDeepLinkingEnabled</key>\s*<false\s*/>',
+          ),
+        ),
       );
     });
 
@@ -443,7 +469,6 @@ void main() {
         ).hasMatch(appDelegate),
         isTrue,
       );
-      expect(appDelegate, contains('return true'));
     });
 
     test('marks every WidgetKit book URL for home_widget delivery', () async {

--- a/app/test/deep_link_service_test.dart
+++ b/app/test/deep_link_service_test.dart
@@ -196,6 +196,20 @@ void main() {
     expect(description, isNot(contains('credential')));
   });
 
+  test('content resolution log branches use fixed classifications', () {
+    const messages = [
+      DeepLinkLogMessages.currentBookResolvedFromDatabase,
+      DeepLinkLogMessages.currentBookResolvedFromWidget,
+      DeepLinkLogMessages.targetBookNotFound,
+    ];
+
+    for (final message in messages) {
+      expect(message, isNot(contains('private-book')));
+      expect(message, isNot(contains('secret')));
+      expect(message, isNot(contains('current-book-id')));
+    }
+  });
+
   test('content deep links normalize to supported semantic fields', () {
     final raw = Uri.parse(
       'bookgolas://book/scan/current?homeWidget=true&token=secret#credential',

--- a/app/test/deep_link_service_test.dart
+++ b/app/test/deep_link_service_test.dart
@@ -133,6 +133,82 @@ void main() {
     expect(description, isNot(contains('secret')));
   });
 
+  test('custom deep-link handler is the single auth callback owner', () {
+    expect(
+      DeepLinkAuthConfiguration.supabaseOptions.detectSessionInUri,
+      isFalse,
+    );
+  });
+
+  test('cold and warm auth callback delivery exchanges a session once',
+      () async {
+    final processor = DeepLinkAuthCallbackProcessor();
+    final callback = Uri.parse('bookgolas://login-callback?code=secret-code');
+    var exchangeCount = 0;
+
+    final coldStart = await processor.process(
+      callback,
+      exchange: (_) async {
+        exchangeCount += 1;
+      },
+    );
+    final warmStartDuplicate = await processor.process(
+      callback,
+      exchange: (_) async {
+        exchangeCount += 1;
+      },
+    );
+
+    expect(coldStart, DeepLinkAuthCallbackOutcome.completed);
+    expect(warmStartDuplicate, DeepLinkAuthCallbackOutcome.duplicate);
+    expect(exchangeCount, 1);
+  });
+
+  test('callback-controlled errors are rejected before session exchange',
+      () async {
+    final processor = DeepLinkAuthCallbackProcessor();
+    final callback = Uri.parse(
+      'bookgolas://login-callback#error_description=secret',
+    );
+    var exchangeCount = 0;
+
+    final outcome = await processor.process(
+      callback,
+      exchange: (_) async {
+        exchangeCount += 1;
+      },
+    );
+
+    expect(outcome, DeepLinkAuthCallbackOutcome.rejected);
+    expect(exchangeCount, 0);
+  });
+
+  test('content deep-link logging omits identifiers and untrusted data', () {
+    final uri = Uri.parse(
+      'bookgolas://book/detail/private-book?token=secret#credential',
+    );
+
+    final description = DeepLinkLogSanitizer.describe(uri);
+
+    expect(description, 'bookgolas://book/detail');
+    expect(description, isNot(contains('private-book')));
+    expect(description, isNot(contains('secret')));
+    expect(description, isNot(contains('credential')));
+  });
+
+  test('content deep links normalize to supported semantic fields', () {
+    final raw = Uri.parse(
+      'bookgolas://book/scan/current?homeWidget=true&token=secret#credential',
+    );
+    final result = DeepLinkService.parseUri(raw)!;
+
+    final normalized = DeepLinkContentNormalizer.normalize(result);
+
+    expect(normalized, Uri.parse('bookgolas://book/scan/current'));
+    expect(normalized.query, isEmpty);
+    expect(normalized.fragment, isEmpty);
+  });
+
   group('DeepLinkBookResolver', () {
     test('does not query a book before authentication', () async {
       final resolver = DeepLinkBookResolver();


### PR DESCRIPTION
## 목적

로그인 또는 Navigator 준비 전에 수신된 iOS 딥링크 의도를 보존하고, 인증 완료 후 원래 목적 화면으로 정확히 한 번 이동시킵니다.

## 주요 변경

- 네이티브 pending 딥링크 consume/acknowledge 계약과 Flutter intent coordinator를 추가했습니다.
- 위젯 링크에 전달 출처를 표시하고 홈 화면 빠른 실행의 cold/warm start를 일관되게 처리했습니다.
- replacement 이동 시 root AuthWrapper shell을 보존하고 팝업과 이전 딥링크 화면만 정리합니다.
- 사용자 소유권이 명시된 책 조회와 로그아웃·계정 전환 중 비동기 navigation guard를 적용했습니다.
- 인증 callback 중복 판별은 원문 URL 대신 bounded SHA-256 digest만 보관하고, query·fragment를 로그에서 제거했습니다.
- Supabase SDK 자동 callback observer를 비활성화해 커스텀 채널을 단일 소유자로 만들고, callback 오류 문자열은 로그에 남기지 않습니다.
- 콘텐츠 딥링크는 지원 action·book ID로 정규화한 뒤 보관해 비허용 query·fragment를 폐기합니다.
- Flutter 기본 route information 처리를 비활성화해 custom deep-link 처리와의 중복을 제거했습니다.
- cold/warm, pre/post-auth, 중복 전달, 세션 변경, root shell 보존 회귀 테스트를 추가했습니다.

## 배경

기존 구현은 DeepLinkService가 MainScreen 이후에만 초기화되어 로그인 전 수신 의도가 유실됐고, 네이티브 custom channel과 Flutter route information이 같은 URL을 중복 처리할 수 있었습니다. 위젯의 replacement 정책도 네이티브 경로에서 보존되지 않았습니다.

## 검증

- `flutter test test/deep_link_service_test.dart --reporter compact`: 53/53 통과
- `flutter test --reporter compact`: 363/363 통과
- 변경 파일 focused analyze: 0건
- full analyze: exit 0, 기존 info 133건 유지
- iOS dev simulator build, Info.plist lint, `git diff --check` 통과
- iPhone 17e / iOS 26.5 실제 SpringBoard `Add Book` 빠른 실행 UI test: 1/1 통과
- UI test id: `QuickActionUITests/testAddBookQuickAction()`
- 최종 exact head `82c61b8b36713dd150816b731d6856c540e01920`, base `46ca13a5a8426e74aea99a8bdbd66847f5d4fac9`와 결속한 원본 xcresult·summary·캡처·해시: Obsidian `project/bookgolas/evidence/BOK-379/exact-head-82c61b8/`
- GitHub Flutter Analyze and Test는 363 tests passed, Target Version Contract·Edge Function·Web·Vercel checks 통과
- 최종 head Product Designer·Quality·Legal/Privacy 재검토: 모두 `APPROVE_NEXT`

## 범위와 후속 작업

- 이 PR은 BOK-379의 iOS 딥링크 수명주기와 이동 계약만 다룹니다.
- 큰 글자 독서 상세 화면 오버플로는 별도 1.0.2 blocker BOK-382에서 추적합니다.
- 실제 기기의 모든 빠른 실행 변형과 물리 기기 동작은 이번 자동 증거 범위에 포함되지 않습니다.

## 관련 이슈

- BOK-379

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store
