### PR TITLE
fix(mobile): make book detail responsive to large text

### DIFF
--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -691,6 +691,7 @@
        "detailTabScheduleStartDate": "Start Date",
        "detailTabScheduleTargetDate": "Target Date",
        "detailTabAttempt": "Attempt {attemptCount} · {attemptEncouragement}",
+       "detailTabAttemptEncouragement": "Keep going!",
        "detailTabChangeButton": "Change",
        "detailTabGoalAchievement": "Goal Achievement",
        "detailTabAchievementStats": "{achievedCount} out of {passedDays} days achieved",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -128,6 +128,8 @@
    "bookDetailTabDetail": "Details",
    "bookDetailStartDate": "Start Date",
    "bookDetailTargetDate": "Target Date",
+   "bookDetailEditTargetDate": "Edit target date",
+   "@bookDetailEditTargetDate": {"description": "Accessible label for editing the target date"},
    "bookDetailReviewWritten": "Written",
    "bookDetailReviewNotWritten": "Not yet written",
    "bookDetailLegendAchieved": "Achieved",

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -1697,6 +1697,11 @@
          "attemptEncouragement": {"type": "String"}
        }
      },
+
+     "detailTabAttemptEncouragement": "끝까지 함께해요!",
+     "@detailTabAttemptEncouragement": {
+       "description": "Locale-specific encouragement shown beside a reread attempt"
+     },
      
      "detailTabChangeButton": "변경",
      "@detailTabChangeButton": {"description": "Change button"},

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -250,6 +250,9 @@
    
    "bookDetailTargetDate": "목표일",
    "@bookDetailTargetDate": {"description": "Target date label in book detail"},
+
+   "bookDetailEditTargetDate": "목표일 수정",
+   "@bookDetailEditTargetDate": {"description": "Accessible label for editing the target date"},
    
    "bookDetailReviewWritten": "작성됨",
    "@bookDetailReviewWritten": {"description": "Review written status in book detail"},

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -542,6 +542,12 @@ abstract class AppLocalizations {
   /// **'목표일'**
   String get bookDetailTargetDate;
 
+  /// Accessible label for editing the target date
+  ///
+  /// In ko, this message translates to:
+  /// **'목표일 수정'**
+  String get bookDetailEditTargetDate;
+
   /// Review written status in book detail
   ///
   /// In ko, this message translates to:

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -2998,6 +2998,12 @@ abstract class AppLocalizations {
   /// **'{attemptCount}번째 · {attemptEncouragement}'**
   String detailTabAttempt(int attemptCount, String attemptEncouragement);
 
+  /// Locale-specific encouragement shown beside a reread attempt
+  ///
+  /// In ko, this message translates to:
+  /// **'끝까지 함께해요!'**
+  String get detailTabAttemptEncouragement;
+
   /// Change button
   ///
   /// In ko, this message translates to:

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -268,6 +268,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get bookDetailTargetDate => 'Target Date';
 
   @override
+  String get bookDetailEditTargetDate => 'Edit target date';
+
+  @override
   String get bookDetailReviewWritten => 'Written';
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -1624,6 +1624,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get detailTabAttemptEncouragement => 'Keep going!';
+
+  @override
   String get detailTabChangeButton => 'Change';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -249,6 +249,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get bookDetailTargetDate => '목표일';
 
   @override
+  String get bookDetailEditTargetDate => '목표일 수정';
+
+  @override
   String get bookDetailReviewWritten => '작성됨';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -1568,6 +1568,9 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get detailTabAttemptEncouragement => '끝까지 함께해요!';
+
+  @override
   String get detailTabChangeButton => '변경';
 
   @override

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -454,6 +454,7 @@ class _BookDetailContentState extends State<_BookDetailContent>
                       SliverPersistentHeader(
                         pinned: true,
                         delegate: StickyTabBarDelegate(
+                          extent: CustomTabBar.extentFor(context),
                           child: CustomTabBar(
                             tabController: _tabController!,
                             tabLabels: _isBookCompleted(book)

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -544,7 +544,6 @@ class _BookDetailContentState extends State<_BookDetailContent>
                             DetailTab(
                               book: book,
                               attemptCount: bookVm.attemptCount,
-                              attemptEncouragement: bookVm.attemptEncouragement,
                               dailyAchievements: bookVm.dailyAchievements,
                               onTargetDateChange: () =>
                                   _showUpdateTargetDateDialog(bookVm),

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -271,6 +271,19 @@ class _BookDetailContentState extends State<_BookDetailContent>
         // TabController 길이 동기화 (책 완독 상태 변경 시)
         final shouldHaveReviewTab = _isBookCompleted(book);
         final targetLength = shouldHaveReviewTab ? 4 : 3;
+        final l10n = AppLocalizations.of(context);
+        final tabLabels = shouldHaveReviewTab
+            ? [
+                l10n.bookDetailTabRecord,
+                l10n.bookDetailTabHistory,
+                l10n.bookDetailTabReview,
+                l10n.bookDetailTabDetail,
+              ]
+            : [
+                l10n.bookDetailTabRecord,
+                l10n.bookDetailTabHistory,
+                l10n.bookDetailTabDetail,
+              ];
         if (_currentTabLength != targetLength) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (mounted) _updateTabControllerIfNeeded(book);
@@ -454,28 +467,10 @@ class _BookDetailContentState extends State<_BookDetailContent>
                       SliverPersistentHeader(
                         pinned: true,
                         delegate: StickyTabBarDelegate(
-                          extent: CustomTabBar.extentFor(context),
+                          extent: CustomTabBar.extentFor(context, tabLabels),
                           child: CustomTabBar(
                             tabController: _tabController!,
-                            tabLabels: _isBookCompleted(book)
-                                ? [
-                                    AppLocalizations.of(context)
-                                        .bookDetailTabRecord,
-                                    AppLocalizations.of(context)
-                                        .bookDetailTabHistory,
-                                    AppLocalizations.of(context)
-                                        .bookDetailTabReview,
-                                    AppLocalizations.of(context)
-                                        .bookDetailTabDetail,
-                                  ]
-                                : [
-                                    AppLocalizations.of(context)
-                                        .bookDetailTabRecord,
-                                    AppLocalizations.of(context)
-                                        .bookDetailTabHistory,
-                                    AppLocalizations.of(context)
-                                        .bookDetailTabDetail,
-                                  ],
+                            tabLabels: tabLabels,
                           ),
                           backgroundColor: isDark
                               ? BLabColors.scaffoldDark

--- a/app/lib/ui/book_detail/utils/sticky_tab_bar_delegate.dart
+++ b/app/lib/ui/book_detail/utils/sticky_tab_bar_delegate.dart
@@ -3,20 +3,23 @@ import 'package:flutter/material.dart';
 class StickyTabBarDelegate extends SliverPersistentHeaderDelegate {
   final Widget child;
   final Color backgroundColor;
+  final double extent;
 
   const StickyTabBarDelegate({
     required this.child,
     required this.backgroundColor,
+    this.extent = 56,
   });
 
   @override
-  double get minExtent => 56;
+  double get minExtent => extent;
 
   @override
-  double get maxExtent => 56;
+  double get maxExtent => extent;
 
   @override
-  Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
+  Widget build(
+      BuildContext context, double shrinkOffset, bool overlapsContent) {
     return SizedBox.expand(
       child: Container(
         color: backgroundColor,
@@ -27,6 +30,8 @@ class StickyTabBarDelegate extends SliverPersistentHeaderDelegate {
 
   @override
   bool shouldRebuild(covariant StickyTabBarDelegate oldDelegate) {
-    return child != oldDelegate.child || backgroundColor != oldDelegate.backgroundColor;
+    return child != oldDelegate.child ||
+        backgroundColor != oldDelegate.backgroundColor ||
+        extent != oldDelegate.extent;
   }
 }

--- a/app/lib/ui/book_detail/widgets/compact_reading_schedule.dart
+++ b/app/lib/ui/book_detail/widgets/compact_reading_schedule.dart
@@ -39,6 +39,7 @@ class CompactReadingSchedule extends StatelessWidget {
     final totalDays = targetDate.difference(startDate).inDays + 1;
 
     return Container(
+      key: const ValueKey('compact-reading-schedule'),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       decoration: BoxDecoration(
         color: isDark ? BLabColors.surfaceDark : Colors.white,
@@ -51,35 +52,141 @@ class CompactReadingSchedule extends StatelessWidget {
           ),
         ],
       ),
-      child: Row(
-        children: [
-          _buildDateColumn(l10n.bookDetailStartDate, startDateStr, isDark,
-              isBold: false),
-          const SizedBox(width: 12),
-          Icon(
-            CupertinoIcons.arrow_right,
-            size: 12,
-            color: isDark ? Colors.grey[500] : Colors.grey[400],
-          ),
-          const SizedBox(width: 12),
-          _buildDateColumn(l10n.bookDetailTargetDate, targetDateStr, isDark,
-              isBold: true),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final scaledDateSize = MediaQuery.textScalerOf(context).scale(13);
+          final useStackedLayout =
+              constraints.maxWidth < 360 || scaledDateSize > 18;
+          if (useStackedLayout) {
+            return _buildStackedLayout(
+              context,
+              l10n,
+              startDateStr,
+              targetDateStr,
+              totalDays,
+              isDark,
+            );
+          }
+          return _buildInlineLayout(
+            context,
+            l10n,
+            startDateStr,
+            targetDateStr,
+            totalDays,
+            isDark,
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildInlineLayout(
+    BuildContext context,
+    AppLocalizations l10n,
+    String startDateStr,
+    String targetDateStr,
+    int totalDays,
+    bool isDark,
+  ) {
+    return Row(
+      children: [
+        _buildDateColumn(
+          l10n.bookDetailStartDate,
+          startDateStr,
+          isDark,
+          isBold: false,
+        ),
+        const SizedBox(width: 12),
+        Icon(
+          CupertinoIcons.arrow_right,
+          size: 12,
+          color: isDark ? Colors.grey[500] : Colors.grey[400],
+        ),
+        const SizedBox(width: 12),
+        _buildDateColumn(
+          l10n.bookDetailTargetDate,
+          targetDateStr,
+          isDark,
+          isBold: true,
+        ),
+        const SizedBox(width: 8),
+        _buildTotalDays(l10n, totalDays, isDark),
+        if (attemptCount > 1) ...[
           const SizedBox(width: 8),
-          Text(
-            l10n.totalDaysFormat(totalDays),
-            style: TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w500,
-              color: isDark ? Colors.grey[500] : Colors.grey[500],
-            ),
-          ),
-          if (attemptCount > 1) ...[
-            const SizedBox(width: 8),
-            _buildAttemptBadge(l10n),
-          ],
-          const Spacer(),
-          if (showEditButton) _buildEditButton(isDark),
+          _buildAttemptBadge(l10n),
         ],
+        const Spacer(),
+        if (showEditButton) _buildEditButton(context),
+      ],
+    );
+  }
+
+  Widget _buildStackedLayout(
+    BuildContext context,
+    AppLocalizations l10n,
+    String startDateStr,
+    String targetDateStr,
+    int totalDays,
+    bool isDark,
+  ) {
+    return Column(
+      key: const ValueKey('compact-reading-schedule-stacked'),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildDateColumn(
+                    l10n.bookDetailStartDate,
+                    startDateStr,
+                    isDark,
+                    isBold: false,
+                  ),
+                  const SizedBox(height: 10),
+                  _buildDateColumn(
+                    l10n.bookDetailTargetDate,
+                    targetDateStr,
+                    isDark,
+                    isBold: true,
+                  ),
+                ],
+              ),
+            ),
+            if (showEditButton) ...[
+              const SizedBox(width: 12),
+              _buildEditButton(context),
+            ],
+          ],
+        ),
+        const SizedBox(height: 12),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            _buildTotalDays(l10n, totalDays, isDark),
+            if (attemptCount > 1) _buildAttemptBadge(l10n),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTotalDays(
+    AppLocalizations l10n,
+    int totalDays,
+    bool isDark,
+  ) {
+    return Text(
+      l10n.totalDaysFormat(totalDays),
+      style: TextStyle(
+        fontSize: 12,
+        fontWeight: FontWeight.w500,
+        color: isDark ? Colors.grey[500] : Colors.grey[500],
       ),
     );
   }
@@ -130,19 +237,29 @@ class CompactReadingSchedule extends StatelessWidget {
     );
   }
 
-  Widget _buildEditButton(bool isDark) {
-    return GestureDetector(
-      onTap: onEditTap,
-      child: Container(
-        padding: const EdgeInsets.all(8),
-        decoration: BoxDecoration(
-          color: BLabColors.primary.withValues(alpha: 0.1),
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: const Icon(
-          CupertinoIcons.pencil,
-          size: 16,
-          color: BLabColors.primary,
+  Widget _buildEditButton(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: AppLocalizations.of(context).bookDetailEditTargetDate,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onEditTap,
+        child: SizedBox(
+          width: 44,
+          height: 44,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: BLabColors.primary.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: const ExcludeSemantics(
+              child: Icon(
+                CupertinoIcons.pencil,
+                size: 16,
+                color: BLabColors.primary,
+              ),
+            ),
+          ),
         ),
       ),
     );

--- a/app/lib/ui/book_detail/widgets/compact_reading_schedule.dart
+++ b/app/lib/ui/book_detail/widgets/compact_reading_schedule.dart
@@ -56,7 +56,7 @@ class CompactReadingSchedule extends StatelessWidget {
         builder: (context, constraints) {
           final scaledDateSize = MediaQuery.textScalerOf(context).scale(13);
           final useStackedLayout =
-              constraints.maxWidth < 360 || scaledDateSize > 18;
+              constraints.maxWidth < 400 || scaledDateSize > 18;
           if (useStackedLayout) {
             return _buildStackedLayout(
               context,
@@ -100,7 +100,9 @@ class CompactReadingSchedule extends StatelessWidget {
         Icon(
           CupertinoIcons.arrow_right,
           size: 12,
-          color: isDark ? Colors.grey[500] : Colors.grey[400],
+          color: isDark
+              ? BLabColors.textTertiaryDark
+              : BLabColors.textTertiaryLight,
         ),
         const SizedBox(width: 12),
         _buildDateColumn(
@@ -113,7 +115,7 @@ class CompactReadingSchedule extends StatelessWidget {
         _buildTotalDays(l10n, totalDays, isDark),
         if (attemptCount > 1) ...[
           const SizedBox(width: 8),
-          _buildAttemptBadge(l10n),
+          _buildAttemptBadge(l10n, isDark),
         ],
         const Spacer(),
         if (showEditButton) _buildEditButton(context),
@@ -169,7 +171,7 @@ class CompactReadingSchedule extends StatelessWidget {
           crossAxisAlignment: WrapCrossAlignment.center,
           children: [
             _buildTotalDays(l10n, totalDays, isDark),
-            if (attemptCount > 1) _buildAttemptBadge(l10n),
+            if (attemptCount > 1) _buildAttemptBadge(l10n, isDark),
           ],
         ),
       ],
@@ -183,10 +185,12 @@ class CompactReadingSchedule extends StatelessWidget {
   ) {
     return Text(
       l10n.totalDaysFormat(totalDays),
+      key: const ValueKey('reading-schedule-total-days'),
       style: TextStyle(
         fontSize: 12,
         fontWeight: FontWeight.w500,
-        color: isDark ? Colors.grey[500] : Colors.grey[500],
+        color:
+            isDark ? BLabColors.textTertiaryDark : BLabColors.textTertiaryLight,
       ),
     );
   }
@@ -198,10 +202,15 @@ class CompactReadingSchedule extends StatelessWidget {
       children: [
         Text(
           label,
+          key: ValueKey(
+            'reading-schedule-date-label-${isBold ? 'target' : 'start'}',
+          ),
           style: TextStyle(
             fontSize: 10,
             fontWeight: FontWeight.w500,
-            color: isDark ? Colors.grey[500] : Colors.grey[500],
+            color: isDark
+                ? BLabColors.textTertiaryDark
+                : BLabColors.textTertiaryLight,
           ),
         ),
         const SizedBox(height: 2),
@@ -219,7 +228,7 @@ class CompactReadingSchedule extends StatelessWidget {
     );
   }
 
-  Widget _buildAttemptBadge(AppLocalizations l10n) {
+  Widget _buildAttemptBadge(AppLocalizations l10n, bool isDark) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
       decoration: BoxDecoration(
@@ -228,10 +237,11 @@ class CompactReadingSchedule extends StatelessWidget {
       ),
       child: Text(
         l10n.attemptOrdinal(attemptCount),
-        style: const TextStyle(
+        key: const ValueKey('reading-schedule-attempt-badge'),
+        style: TextStyle(
           fontSize: 10,
           fontWeight: FontWeight.w700,
-          color: BLabColors.warning,
+          color: isDark ? BLabColors.warning : BLabColors.textPrimaryLight,
         ),
       ),
     );

--- a/app/lib/ui/book_detail/widgets/compact_streak_row.dart
+++ b/app/lib/ui/book_detail/widgets/compact_streak_row.dart
@@ -70,7 +70,7 @@ class CompactStreakRow extends StatelessWidget {
       ),
       child: Column(
         children: [
-          _buildDaysRow(recentDays, isDark),
+          _buildDaysRow(context, recentDays, isDark),
           const SizedBox(height: 10),
           _buildStreakInfo(context, streak, isDark),
         ],
@@ -78,61 +78,86 @@ class CompactStreakRow extends StatelessWidget {
     );
   }
 
-  Widget _buildDaysRow(List<Map<String, dynamic>> recentDays, bool isDark) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: List.generate(7, (index) {
-        final dayInfo = recentDays[index];
-        final isAchieved = dayInfo['achieved'] as bool;
-        final dayLabel = dayInfo['dayLabel'] as String;
-        final isToday = dayInfo['isToday'] as bool;
+  Widget _buildDaysRow(
+    BuildContext context,
+    List<Map<String, dynamic>> recentDays,
+    bool isDark,
+  ) {
+    final useWrappedLayout = MediaQuery.textScalerOf(context).scale(11) > 18;
+    final dayItems = List.generate(
+      7,
+      (index) => _buildDayItem(recentDays[index], isDark, index),
+    );
 
-        return Container(
-          width: 38,
-          margin: EdgeInsets.only(left: index > 0 ? 6 : 0),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                dayLabel,
-                style: TextStyle(
-                  fontSize: 11,
-                  fontWeight: isToday ? FontWeight.w700 : FontWeight.w500,
-                  color: isToday
-                      ? BLabColors.primary
-                      : (isDark ? Colors.grey[400] : Colors.grey[500]),
-                ),
-              ),
-              const SizedBox(height: 6),
-              Container(
-                width: 20,
-                height: 20,
-                decoration: BoxDecoration(
-                  color: isAchieved
-                      ? BLabColors.success
-                      : (isDark
-                          ? Colors.white.withValues(alpha: 0.12)
-                          : Colors.grey[200]),
-                  shape: BoxShape.circle,
-                  border: isToday
-                      ? Border.all(
-                          color: BLabColors.primary,
-                          width: 2,
-                        )
-                      : null,
-                ),
-                child: isAchieved
-                    ? const Icon(
-                        CupertinoIcons.checkmark,
-                        size: 12,
-                        color: Colors.white,
-                      )
-                    : null,
-              ),
-            ],
+    if (useWrappedLayout) {
+      return Wrap(
+        key: const ValueKey('compact-streak-days-wrapped'),
+        alignment: WrapAlignment.center,
+        spacing: 12,
+        runSpacing: 12,
+        children:
+            dayItems.map((item) => SizedBox(width: 64, child: item)).toList(),
+      );
+    }
+
+    return Row(
+      children: dayItems.map((item) => Expanded(child: item)).toList(),
+    );
+  }
+
+  Widget _buildDayItem(
+    Map<String, dynamic> dayInfo,
+    bool isDark,
+    int index,
+  ) {
+    final isAchieved = dayInfo['achieved'] as bool;
+    final dayLabel = dayInfo['dayLabel'] as String;
+    final isToday = dayInfo['isToday'] as bool;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          dayLabel,
+          key: ValueKey('compact-streak-day-label-$index'),
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: isToday ? FontWeight.w700 : FontWeight.w500,
+            color: isToday
+                ? BLabColors.primary
+                : (isDark
+                    ? BLabColors.textSecondaryDark
+                    : BLabColors.textSecondaryLight),
           ),
-        );
-      }),
+        ),
+        const SizedBox(height: 6),
+        Container(
+          width: 20,
+          height: 20,
+          decoration: BoxDecoration(
+            color: isAchieved
+                ? BLabColors.success
+                : (isDark
+                    ? Colors.white.withValues(alpha: 0.12)
+                    : Colors.grey[200]),
+            shape: BoxShape.circle,
+            border: isToday
+                ? Border.all(
+                    color: BLabColors.primary,
+                    width: 2,
+                  )
+                : null,
+          ),
+          child: isAchieved
+              ? const Icon(
+                  CupertinoIcons.checkmark,
+                  size: 12,
+                  color: Colors.white,
+                )
+              : null,
+        ),
+      ],
     );
   }
 
@@ -149,14 +174,24 @@ class CompactStreakRow extends StatelessWidget {
               : (isDark ? Colors.grey[500] : Colors.grey[400]),
         ),
         const SizedBox(width: 4),
-        Text(
-          streak > 0 ? l10n.streakDaysAchieved(streak) : l10n.streakFirstRecord,
-          style: TextStyle(
-            fontSize: 13,
-            fontWeight: FontWeight.w600,
-            color: streak > 0
-                ? (isDark ? Colors.white : Colors.grey[800])
-                : (isDark ? Colors.grey[400] : Colors.grey[500]),
+        Flexible(
+          child: Text(
+            streak > 0
+                ? l10n.streakDaysAchieved(streak)
+                : l10n.streakFirstRecord,
+            key: const ValueKey('compact-streak-message'),
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: streak > 0
+                  ? (isDark
+                      ? BLabColors.textPrimaryDark
+                      : BLabColors.textPrimaryLight)
+                  : (isDark
+                      ? BLabColors.textSecondaryDark
+                      : BLabColors.textSecondaryLight),
+            ),
           ),
         ),
       ],

--- a/app/lib/ui/book_detail/widgets/custom_tab_bar.dart
+++ b/app/lib/ui/book_detail/widgets/custom_tab_bar.dart
@@ -40,6 +40,7 @@ class CustomTabBar extends StatelessWidget {
 
     final backgroundColor =
         isDark ? BLabColors.surfaceDark : BLabColors.surfaceLight;
+    final tabBarHeight = extentFor(context, tabLabels);
 
     return AnimatedBuilder(
       animation: tabController,
@@ -62,7 +63,7 @@ class CustomTabBar extends StatelessWidget {
             tabs: tabLabels,
             selectedIndex: tabController.index,
             tabWidth: 44,
-            height: extentFor(context, tabLabels),
+            height: tabBarHeight,
             backgroundColor: backgroundColor,
             indicatorColor: BLabColors.textPrimary(context),
             selectedTextColor: BLabColors.textPrimary(context),

--- a/app/lib/ui/book_detail/widgets/custom_tab_bar.dart
+++ b/app/lib/ui/book_detail/widgets/custom_tab_bar.dart
@@ -11,19 +11,27 @@ class CustomTabBar extends StatelessWidget {
     this.tabLabels = const ['기록', '히스토리', '상세'],
   });
 
-  static double extentFor(BuildContext context) {
-    final textPainter = TextPainter(
-      text: TextSpan(
-        text: 'Ag',
-        style: DefaultTextStyle.of(
-          context,
-        ).style.merge(const TextStyle(fontSize: 14)),
-      ),
-      maxLines: 1,
-      textDirection: Directionality.of(context),
-      textScaler: MediaQuery.textScalerOf(context),
-    )..layout();
-    final contentHeight = textPainter.height + 36;
+  static double extentFor(BuildContext context, List<String> tabLabels) {
+    final availableWidth = MediaQuery.sizeOf(context).width - 40;
+    final tabWidth = availableWidth / tabLabels.length;
+    final textStyle = DefaultTextStyle.of(context).style.merge(
+          const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+        );
+    var maxTextHeight = 0.0;
+
+    for (final label in tabLabels) {
+      final textPainter = TextPainter(
+        text: TextSpan(text: label, style: textStyle),
+        textAlign: TextAlign.center,
+        textDirection: Directionality.of(context),
+        textScaler: MediaQuery.textScalerOf(context),
+      )..layout(maxWidth: tabWidth);
+      if (textPainter.height > maxTextHeight) {
+        maxTextHeight = textPainter.height;
+      }
+    }
+
+    final contentHeight = maxTextHeight + 36;
     return contentHeight < 56 ? 56 : contentHeight;
   }
 

--- a/app/lib/ui/book_detail/widgets/custom_tab_bar.dart
+++ b/app/lib/ui/book_detail/widgets/custom_tab_bar.dart
@@ -11,6 +11,22 @@ class CustomTabBar extends StatelessWidget {
     this.tabLabels = const ['기록', '히스토리', '상세'],
   });
 
+  static double extentFor(BuildContext context) {
+    final textPainter = TextPainter(
+      text: TextSpan(
+        text: 'Ag',
+        style: DefaultTextStyle.of(
+          context,
+        ).style.merge(const TextStyle(fontSize: 14)),
+      ),
+      maxLines: 1,
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+    )..layout();
+    final contentHeight = textPainter.height + 36;
+    return contentHeight < 56 ? 56 : contentHeight;
+  }
+
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;

--- a/app/lib/ui/book_detail/widgets/custom_tab_bar.dart
+++ b/app/lib/ui/book_detail/widgets/custom_tab_bar.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+
 import 'package:book_golas/ui/core/theme/design_system.dart';
+import 'package:book_golas/ui/core/widgets/scrollable_tab_bar.dart';
 
 class CustomTabBar extends StatelessWidget {
   final TabController tabController;
@@ -12,11 +14,7 @@ class CustomTabBar extends StatelessWidget {
   });
 
   static double extentFor(BuildContext context, List<String> tabLabels) {
-    final availableWidth = MediaQuery.sizeOf(context).width - 40;
-    final tabWidth = availableWidth / tabLabels.length;
-    final textStyle = DefaultTextStyle.of(context).style.merge(
-          const TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
-        );
+    const textStyle = AppTypography.labelLarge;
     var maxTextHeight = 0.0;
 
     for (final label in tabLabels) {
@@ -25,13 +23,14 @@ class CustomTabBar extends StatelessWidget {
         textAlign: TextAlign.center,
         textDirection: Directionality.of(context),
         textScaler: MediaQuery.textScalerOf(context),
-      )..layout(maxWidth: tabWidth);
+        maxLines: 1,
+      )..layout();
       if (textPainter.height > maxTextHeight) {
         maxTextHeight = textPainter.height;
       }
     }
 
-    final contentHeight = maxTextHeight + 36;
+    final contentHeight = maxTextHeight + 26;
     return contentHeight < 56 ? 56 : contentHeight;
   }
 
@@ -39,84 +38,38 @@ class CustomTabBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 20),
-      decoration: BoxDecoration(
-        color: isDark ? BLabColors.surfaceDark : Colors.white,
-        borderRadius: BorderRadius.circular(8),
-        border: Border(
-          bottom: BorderSide(
-            color: isDark ? Colors.grey[800]! : Colors.grey[200]!,
-            width: 1,
-          ),
-        ),
-      ),
-      child: Stack(
-        children: [
-          Row(
-            children: List.generate(tabLabels.length, (index) {
-              return Expanded(
-                child: GestureDetector(
-                  onTap: () {
-                    tabController.animateTo(index);
-                  },
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(vertical: 14),
-                    child: Text(
-                      tabLabels[index],
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        fontSize: 14,
-                        fontWeight: tabController.index == index
-                            ? FontWeight.w600
-                            : FontWeight.w400,
-                        color: tabController.index == index
-                            ? (isDark ? Colors.white : Colors.black)
-                            : (isDark ? Colors.grey[400] : Colors.grey[600]),
-                      ),
-                    ),
-                  ),
-                ),
-              );
-            }),
-          ),
-          Positioned(
-            bottom: 0,
-            left: 0,
-            right: 0,
-            height: 2,
-            child: LayoutBuilder(
-              builder: (context, constraints) {
-                final tabWidth = constraints.maxWidth / tabLabels.length;
-                final indicatorWidth = tabWidth * 0.5;
-                return AnimatedBuilder(
-                  animation: tabController.animation!,
-                  builder: (context, child) {
-                    final animValue = tabController.animation!.value;
-                    final centerPosition =
-                        tabWidth * animValue + (tabWidth - indicatorWidth) / 2;
-                    return Stack(
-                      children: [
-                        Positioned(
-                          left: centerPosition,
-                          child: Container(
-                            width: indicatorWidth,
-                            height: 2,
-                            decoration: BoxDecoration(
-                              color: isDark ? Colors.white : Colors.black,
-                              borderRadius: BorderRadius.circular(1),
-                            ),
-                          ),
-                        ),
-                      ],
-                    );
-                  },
-                );
-              },
+    final backgroundColor =
+        isDark ? BLabColors.surfaceDark : BLabColors.surfaceLight;
+
+    return AnimatedBuilder(
+      animation: tabController,
+      builder: (context, child) {
+        return Container(
+          margin: const EdgeInsets.symmetric(horizontal: 20),
+          clipBehavior: Clip.antiAlias,
+          decoration: BoxDecoration(
+            color: backgroundColor,
+            borderRadius: BorderRadius.circular(8),
+            border: Border(
+              bottom: BorderSide(
+                color: isDark ? Colors.grey[800]! : Colors.grey[200]!,
+                width: 1,
+              ),
             ),
           ),
-        ],
-      ),
+          child: ScrollableTabBar(
+            controller: tabController,
+            tabs: tabLabels,
+            selectedIndex: tabController.index,
+            tabWidth: 44,
+            height: extentFor(context, tabLabels),
+            backgroundColor: backgroundColor,
+            indicatorColor: BLabColors.textPrimary(context),
+            selectedTextColor: BLabColors.textPrimary(context),
+            unselectedTextColor: BLabColors.textSecondary(context),
+          ),
+        );
+      },
     );
   }
 }

--- a/app/lib/ui/book_detail/widgets/dashboard_progress_widget.dart
+++ b/app/lib/ui/book_detail/widgets/dashboard_progress_widget.dart
@@ -35,77 +35,80 @@ class DashboardProgressWidget extends StatelessWidget {
     final isOverdue = daysLeft < 0;
 
     return Container(
+      key: const ValueKey('dashboard-progress'),
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
         color: isDark ? BLabColors.surfaceDark : Colors.white,
         borderRadius: BorderRadius.circular(20),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(isDark ? 0.3 : 0.06),
+            color: Colors.black.withValues(alpha: isDark ? 0.3 : 0.06),
             blurRadius: 16,
             offset: const Offset(0, 4),
           ),
         ],
       ),
-      child: Row(
-        children: [
-          Expanded(
-            child: _buildProgressColumn(context, isDark, progressPercent),
-          ),
-          Container(
-            width: 1,
-            height: 100,
-            color: isDark ? Colors.grey[700] : Colors.grey[200],
-          ),
-          Expanded(
-            child: Column(
+      child: LayoutBuilder(
+        builder: (context, _) {
+          final scaledBodySize = MediaQuery.textScalerOf(context).scale(14);
+          final useStackedLayout = scaledBodySize > 20;
+          if (useStackedLayout) {
+            return Column(
+              key: const ValueKey('dashboard-progress-stacked'),
               children: [
-                Text(
-                  isOverdue ? 'D+${daysLeft.abs()}' : 'D-$daysLeft',
-                  style: TextStyle(
-                    fontSize: 32,
-                    fontWeight: FontWeight.w800,
-                    color: isOverdue || daysLeft <= 3
-                        ? BLabColors.errorAlt
-                        : BLabColors.primary,
-                    letterSpacing: -1,
-                  ),
+                _buildProgressColumn(
+                  context,
+                  isDark,
+                  progressPercent,
+                  diameter: 144,
                 ),
-                const SizedBox(height: 8),
-                Text(
-                  AppLocalizations.of(context).pagesRemaining(pagesLeft),
-                  style: TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w600,
-                    color: isDark ? Colors.grey[300] : Colors.grey[700],
-                  ),
+                Divider(
+                  height: 32,
+                  color: isDark ? Colors.grey[700] : Colors.grey[200],
                 ),
-                const SizedBox(height: 4),
-                _buildDailyTargetButton(context, isDark),
+                _buildRemainingColumn(context, isDark, isOverdue),
               ],
-            ),
-          ),
-        ],
+            );
+          }
+          return Row(
+            children: [
+              Expanded(
+                child: _buildProgressColumn(
+                  context,
+                  isDark,
+                  progressPercent,
+                  diameter: 100,
+                ),
+              ),
+              Container(
+                width: 1,
+                height: 100,
+                color: isDark ? Colors.grey[700] : Colors.grey[200],
+              ),
+              Expanded(
+                child: _buildRemainingColumn(context, isDark, isOverdue),
+              ),
+            ],
+          );
+        },
       ),
     );
   }
 
   Widget _buildProgressColumn(
-    BuildContext context,
-    bool isDark,
-    String progressPercent,
-  ) {
+      BuildContext context, bool isDark, String progressPercent,
+      {required double diameter}) {
     return Column(
       children: [
         SizedBox(
-          width: 100,
-          height: 100,
+          width: diameter,
+          height: diameter,
           child: Stack(
             alignment: Alignment.center,
             children: [
               SizedBox(
-                width: 100,
-                height: 100,
+                width: diameter,
+                height: diameter,
                 child: CustomPaint(
                   painter: CircularProgressPainter(
                     progress: animatedProgress.clamp(0.0, 1.0),
@@ -122,6 +125,8 @@ class DashboardProgressWidget extends StatelessWidget {
                 children: [
                   Text(
                     '$progressPercent%',
+                    maxLines: 1,
+                    softWrap: false,
                     style: TextStyle(
                       fontSize: 24,
                       fontWeight: FontWeight.w800,
@@ -137,6 +142,7 @@ class DashboardProgressWidget extends StatelessWidget {
         const SizedBox(height: 8),
         Text(
           '$currentPage / ${totalPages}p',
+          textAlign: TextAlign.center,
           style: TextStyle(
             fontSize: 14,
             fontWeight: FontWeight.w600,
@@ -147,48 +153,97 @@ class DashboardProgressWidget extends StatelessWidget {
     );
   }
 
+  Widget _buildRemainingColumn(
+    BuildContext context,
+    bool isDark,
+    bool isOverdue,
+  ) {
+    return Column(
+      children: [
+        Text(
+          isOverdue ? 'D+${daysLeft.abs()}' : 'D-$daysLeft',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 32,
+            fontWeight: FontWeight.w800,
+            color: isOverdue || daysLeft <= 3
+                ? BLabColors.errorAlt
+                : BLabColors.primary,
+            letterSpacing: -1,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          AppLocalizations.of(context).pagesRemaining(pagesLeft),
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+            color: isDark ? Colors.grey[300] : Colors.grey[700],
+          ),
+        ),
+        const SizedBox(height: 8),
+        _buildDailyTargetButton(context, isDark),
+      ],
+    );
+  }
+
   Widget _buildDailyTargetButton(BuildContext context, bool isDark) {
-    final dailyTarget =
-        dailyTargetPages ??
+    final dailyTarget = dailyTargetPages ??
         (daysLeft > 0 ? (pagesLeft / daysLeft).ceil() : pagesLeft);
     if (dailyTarget <= 0) return const SizedBox.shrink();
 
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        GestureDetector(
-          onTap: onDailyTargetTap,
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-            decoration: BoxDecoration(
-              color: BLabColors.success.withValues(alpha: 0.1),
-              borderRadius: BorderRadius.circular(10),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Flexible(
-                  child: Text(
-                    AppLocalizations.of(
-                      context,
-                    ).todayGoalWithPages(dailyTarget),
-                    style: const TextStyle(
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                      color: BLabColors.success,
-                    ),
-                    maxLines: 1,
-                    softWrap: false,
-                    overflow: TextOverflow.visible,
+        Semantics(
+          button: true,
+          label: AppLocalizations.of(context).todayGoalWithPages(dailyTarget),
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: onDailyTargetTap,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: 44),
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: BLabColors.success.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 6,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Flexible(
+                        child: ExcludeSemantics(
+                          child: Text(
+                            AppLocalizations.of(
+                              context,
+                            ).todayGoalWithPages(dailyTarget),
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w600,
+                              color: BLabColors.success,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 6),
+                      const ExcludeSemantics(
+                        child: Icon(
+                          CupertinoIcons.pencil,
+                          size: 13,
+                          color: BLabColors.success,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
-                const SizedBox(width: 6),
-                const Icon(
-                  CupertinoIcons.pencil,
-                  size: 13,
-                  color: BLabColors.success,
-                ),
-              ],
+              ),
             ),
           ),
         ),
@@ -200,15 +255,16 @@ class DashboardProgressWidget extends StatelessWidget {
               color: BLabColors.gold.withValues(alpha: 0.15),
               borderRadius: BorderRadius.circular(6),
             ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
+            child: Wrap(
+              alignment: WrapAlignment.center,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              spacing: 4,
               children: [
                 const Icon(
                   CupertinoIcons.checkmark_seal_fill,
                   size: 12,
                   color: BLabColors.gold,
                 ),
-                const SizedBox(width: 4),
                 Text(
                   AppLocalizations.of(context).bookDetailGoalAchieved,
                   style: const TextStyle(

--- a/app/lib/ui/book_detail/widgets/dashboard_progress_widget.dart
+++ b/app/lib/ui/book_detail/widgets/dashboard_progress_widget.dart
@@ -203,7 +203,7 @@ class DashboardProgressWidget extends StatelessWidget {
             behavior: HitTestBehavior.opaque,
             onTap: onDailyTargetTap,
             child: ConstrainedBox(
-              constraints: const BoxConstraints(minHeight: 44),
+              constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
               child: DecoratedBox(
                 decoration: BoxDecoration(
                   color: BLabColors.success.withValues(alpha: 0.1),
@@ -223,21 +223,28 @@ class DashboardProgressWidget extends StatelessWidget {
                             AppLocalizations.of(
                               context,
                             ).todayGoalWithPages(dailyTarget),
+                            key: const ValueKey(
+                              'dashboard-progress-daily-target',
+                            ),
                             textAlign: TextAlign.center,
-                            style: const TextStyle(
+                            style: TextStyle(
                               fontSize: 14,
                               fontWeight: FontWeight.w600,
-                              color: BLabColors.success,
+                              color: isDark
+                                  ? BLabColors.success
+                                  : BLabColors.textPrimaryLight,
                             ),
                           ),
                         ),
                       ),
                       const SizedBox(width: 6),
-                      const ExcludeSemantics(
+                      ExcludeSemantics(
                         child: Icon(
                           CupertinoIcons.pencil,
                           size: 13,
-                          color: BLabColors.success,
+                          color: isDark
+                              ? BLabColors.success
+                              : BLabColors.textPrimaryLight,
                         ),
                       ),
                     ],
@@ -260,17 +267,19 @@ class DashboardProgressWidget extends StatelessWidget {
               crossAxisAlignment: WrapCrossAlignment.center,
               spacing: 4,
               children: [
-                const Icon(
+                Icon(
                   CupertinoIcons.checkmark_seal_fill,
                   size: 12,
-                  color: BLabColors.gold,
+                  color: isDark ? BLabColors.gold : BLabColors.textPrimaryLight,
                 ),
                 Text(
                   AppLocalizations.of(context).bookDetailGoalAchieved,
-                  style: const TextStyle(
+                  key: const ValueKey('dashboard-progress-goal-achieved'),
+                  style: TextStyle(
                     fontSize: 11,
                     fontWeight: FontWeight.w600,
-                    color: BLabColors.gold,
+                    color:
+                        isDark ? BLabColors.gold : BLabColors.textPrimaryLight,
                   ),
                 ),
               ],

--- a/app/lib/ui/book_detail/widgets/tabs/detail_tab.dart
+++ b/app/lib/ui/book_detail/widgets/tabs/detail_tab.dart
@@ -45,7 +45,7 @@ class DetailTab extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           if (_isCompleted && onReviewTap != null) ...[
-            _buildReviewPreviewCard(isDark),
+            _buildReviewPreviewCard(context, isDark),
             const SizedBox(height: 16),
           ],
           _buildReadingScheduleCard(context, isDark),
@@ -85,6 +85,7 @@ class DetailTab extends StatelessWidget {
   }
 
   Widget _buildReadingActionsButton(BuildContext context, bool isDark) {
+    final l10n = AppLocalizations.of(context);
     return GestureDetector(
       onTap: () => _showReadingActionsSheet(context),
       child: Container(
@@ -120,7 +121,7 @@ class DetailTab extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    '독서 관리',
+                    l10n.detailTabManagement,
                     style: TextStyle(
                       fontSize: 15,
                       fontWeight: FontWeight.w600,
@@ -129,7 +130,7 @@ class DetailTab extends StatelessWidget {
                   ),
                   const SizedBox(height: 2),
                   Text(
-                    '쉬어가기, 삭제 등',
+                    l10n.detailTabManagementDesc,
                     style: TextStyle(
                       fontSize: 12,
                       color: isDark ? Colors.grey[500] : Colors.grey[600],
@@ -151,6 +152,7 @@ class DetailTab extends StatelessWidget {
 
   Widget _buildDeleteButton(BuildContext context, bool isDark) {
     final l10n = AppLocalizations.of(context);
+    final useStackedLayout = MediaQuery.textScalerOf(context).scale(14) > 20;
     return GestureDetector(
       onTap: onDelete,
       child: Container(
@@ -163,7 +165,14 @@ class DetailTab extends StatelessWidget {
             width: 1,
           ),
         ),
-        child: Row(
+        child: Flex(
+          key: ValueKey(
+            useStackedLayout
+                ? 'detail-tab-delete-stacked'
+                : 'detail-tab-delete-inline',
+          ),
+          direction: useStackedLayout ? Axis.vertical : Axis.horizontal,
+          mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             const Icon(
@@ -171,22 +180,40 @@ class DetailTab extends StatelessWidget {
               color: BLabColors.errorAlt,
               size: 18,
             ),
-            const SizedBox(width: 8),
-            Text(
-              l10n.bookDetailDeleteReading,
-              style: const TextStyle(
-                fontSize: 14,
-                fontWeight: FontWeight.w500,
-                color: BLabColors.errorAlt,
-              ),
+            SizedBox(
+              width: useStackedLayout ? 0 : 8,
+              height: useStackedLayout ? 8 : 0,
             ),
+            if (useStackedLayout)
+              Text(
+                l10n.detailTabDeleteReading,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w500,
+                  color: BLabColors.errorAlt,
+                ),
+              )
+            else
+              Flexible(
+                child: Text(
+                  l10n.detailTabDeleteReading,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                    color: BLabColors.errorAlt,
+                  ),
+                ),
+              ),
           ],
         ),
       ),
     );
   }
 
-  Widget _buildReviewPreviewCard(bool isDark) {
+  Widget _buildReviewPreviewCard(BuildContext context, bool isDark) {
+    final l10n = AppLocalizations.of(context);
     final hasReview = book.longReview != null && book.longReview!.isNotEmpty;
 
     return GestureDetector(
@@ -227,16 +254,19 @@ class DetailTab extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        '독후감',
+                        l10n.detailTabReview,
                         style: TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w700,
-                          color: isDark ? Colors.white : BLabColors.scaffoldDark,
+                          color:
+                              isDark ? Colors.white : BLabColors.scaffoldDark,
                         ),
                       ),
                       const SizedBox(height: 2),
                       Text(
-                        hasReview ? '작성됨' : '아직 작성되지 않음',
+                        hasReview
+                            ? l10n.detailTabReviewWritten
+                            : l10n.detailTabReviewNotWritten,
                         style: TextStyle(
                           fontSize: 12,
                           color: hasReview
@@ -280,7 +310,7 @@ class DetailTab extends StatelessWidget {
             ] else ...[
               const SizedBox(height: 12),
               Text(
-                '책을 읽고 느낀 점을 기록해보세요',
+                l10n.detailTabReviewDescription,
                 style: TextStyle(
                   fontSize: 13,
                   color: isDark ? Colors.grey[500] : Colors.grey[600],
@@ -326,102 +356,150 @@ class DetailTab extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: 12),
-              Text(
-                l10n.bookDetailSchedule,
-                style: const TextStyle(
-                  fontSize: 17,
-                  fontWeight: FontWeight.bold,
+              Expanded(
+                child: Text(
+                  l10n.detailTabSchedule,
+                  key: const ValueKey('detail-tab-schedule-title'),
+                  style: const TextStyle(
+                    fontSize: 17,
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
               ),
             ],
           ),
           const SizedBox(height: 16),
           _buildScheduleRow(
-            l10n.bookDetailStartDate,
+            context,
+            l10n.detailTabScheduleStartDate,
             book.startDate.toString().substring(0, 10).replaceAll('-', '.'),
             CupertinoIcons.play_circle,
             isDark: isDark,
           ),
           const SizedBox(height: 12),
-          Row(
-            children: [
-              Icon(
-                CupertinoIcons.flag_fill,
-                size: 16,
-                color: Colors.grey[600],
-              ),
-              const SizedBox(width: 8),
-              Text(
-                l10n.bookDetailTargetDate,
-                style: TextStyle(
-                  fontSize: 14,
-                  color: Colors.grey[600],
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Row(
-                  children: [
-                    Text(
-                      book.targetDate
-                          .toString()
-                          .substring(0, 10)
-                          .replaceAll('-', '.'),
-                      style: TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w600,
-                        color: isDark ? Colors.white : Colors.black87,
-                      ),
-                    ),
-                    if (attemptCount > 1) ...[
-                      const SizedBox(width: 8),
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 8, vertical: 3),
-                        decoration: BoxDecoration(
-                          color: BLabColors.warning.withValues(alpha: 0.12),
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Text(
-                          '$attemptCount번째 · $attemptEncouragement',
-                          style: const TextStyle(
-                            fontSize: 11,
-                            fontWeight: FontWeight.w700,
-                            color: BLabColors.warning,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ],
-                ),
-              ),
-              TextButton(
-                onPressed: onTargetDateChange,
-                style: TextButton.styleFrom(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                  minimumSize: Size.zero,
-                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                ),
-                child: const Text(
-                  '변경',
-                  style: TextStyle(
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ),
-            ],
-          ),
+          _buildTargetScheduleRow(context, l10n, isDark),
         ],
       ),
     );
   }
 
-  Widget _buildScheduleRow(String label, String value, IconData icon,
-      {Widget? trailing, bool isDark = false}) {
+  Widget _buildTargetScheduleRow(
+    BuildContext context,
+    AppLocalizations l10n,
+    bool isDark,
+  ) {
+    final targetDate =
+        book.targetDate.toString().substring(0, 10).replaceAll('-', '.');
+    final attempt = attemptCount > 1
+        ? l10n.detailTabAttempt(attemptCount, attemptEncouragement)
+        : null;
+    final useStackedLayout = MediaQuery.textScalerOf(context).scale(14) > 20;
+
+    final details = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n.detailTabScheduleTargetDate,
+          style: TextStyle(
+            fontSize: 14,
+            color: isDark ? Colors.grey[400] : Colors.grey[600],
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          targetDate,
+          style: TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+            color: isDark ? Colors.white : Colors.black87,
+          ),
+        ),
+        if (attempt != null) ...[
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+            decoration: BoxDecoration(
+              color: BLabColors.warning.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Text(
+              attempt,
+              style: const TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                color: BLabColors.warning,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+
+    final changeButton = TextButton(
+      onPressed: onTargetDateChange,
+      style: TextButton.styleFrom(
+        minimumSize: const Size(44, 44),
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      ),
+      child: Text(
+        l10n.detailTabChangeButton,
+        style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+      ),
+    );
+
     return Row(
+      key: ValueKey(
+        useStackedLayout
+            ? 'detail-tab-target-date-stacked'
+            : 'detail-tab-target-date-inline',
+      ),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(
+          CupertinoIcons.flag_fill,
+          size: 16,
+          color: isDark ? Colors.grey[400] : Colors.grey[600],
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: useStackedLayout
+              ? Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    details,
+                    const SizedBox(height: 8),
+                    changeButton,
+                  ],
+                )
+              : Row(
+                  children: [
+                    Expanded(child: details),
+                    const SizedBox(width: 8),
+                    changeButton,
+                  ],
+                ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildScheduleRow(
+    BuildContext context,
+    String label,
+    String value,
+    IconData icon, {
+    Widget? trailing,
+    bool isDark = false,
+  }) {
+    final useStackedLayout = MediaQuery.textScalerOf(context).scale(14) > 20;
+    return Row(
+      key: ValueKey(
+        useStackedLayout
+            ? 'detail-tab-schedule-row-stacked'
+            : 'detail-tab-schedule-row-inline',
+      ),
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Icon(
           icon,
@@ -429,24 +507,53 @@ class DetailTab extends StatelessWidget {
           color: isDark ? Colors.grey[400] : Colors.grey[600],
         ),
         const SizedBox(width: 8),
-        Text(
-          label,
-          style: TextStyle(
-            fontSize: 14,
-            color: isDark ? Colors.grey[400] : Colors.grey[600],
-            fontWeight: FontWeight.w500,
-          ),
-        ),
-        const SizedBox(width: 12),
         Expanded(
-          child: Text(
-            value,
-            style: TextStyle(
-              fontSize: 15,
-              fontWeight: FontWeight.w600,
-              color: isDark ? Colors.white : Colors.black87,
-            ),
-          ),
+          child: useStackedLayout
+              ? Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      label,
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: isDark ? Colors.grey[400] : Colors.grey[600],
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      value,
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                        color: isDark ? Colors.white : Colors.black87,
+                      ),
+                    ),
+                  ],
+                )
+              : Row(
+                  children: [
+                    Text(
+                      label,
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: isDark ? Colors.grey[400] : Colors.grey[600],
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        value,
+                        style: TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                          color: isDark ? Colors.white : Colors.black87,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
         ),
         if (trailing != null) trailing,
       ],
@@ -500,48 +607,70 @@ class DetailTab extends StatelessWidget {
   Widget _buildGoalHeader(BuildContext context, int passedDays,
       int achievedCount, int achievementRate, bool isDark) {
     final l10n = AppLocalizations.of(context);
-    return Row(
+    final useStackedLayout = MediaQuery.textScalerOf(context).scale(14) > 20;
+    final title = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Container(
-          padding: const EdgeInsets.all(10),
-          decoration: BoxDecoration(
-            gradient: const LinearGradient(
-              colors: [BLabColors.success, BLabColors.success],
-            ),
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: const Icon(
-            CupertinoIcons.flame_fill,
-            size: 20,
-            color: Colors.white,
+        Text(
+          l10n.detailTabGoalAchievement,
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w700,
+            color: isDark ? Colors.white : BLabColors.scaffoldDark,
           ),
         ),
-        const SizedBox(width: 12),
-        Expanded(
-          child: Column(
+        const SizedBox(height: 2),
+        Text(
+          l10n.detailTabAchievementStats(passedDays, achievedCount),
+          style: TextStyle(
+            fontSize: 12,
+            color: isDark
+                ? Colors.white.withValues(alpha: 0.6)
+                : Colors.grey[500]!,
+          ),
+        ),
+      ],
+    );
+    final icon = Container(
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          colors: [BLabColors.success, BLabColors.success],
+        ),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: const Icon(
+        CupertinoIcons.flame_fill,
+        size: 20,
+        color: Colors.white,
+      ),
+    );
+
+    if (useStackedLayout) {
+      return Column(
+        key: const ValueKey('detail-tab-goal-header-stacked'),
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                l10n.bookDetailGoalProgress,
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w700,
-                  color: isDark ? Colors.white : BLabColors.scaffoldDark,
-                ),
-              ),
-              const SizedBox(height: 2),
-              Text(
-                l10n.bookDetailAchievementStatus(passedDays, achievedCount),
-                style: TextStyle(
-                  fontSize: 12,
-                  color: isDark
-                      ? Colors.white.withValues(alpha: 0.6)
-                      : Colors.grey[500]!,
-                ),
-              ),
+              icon,
+              const SizedBox(width: 12),
+              Expanded(child: title),
             ],
           ),
-        ),
+          const SizedBox(height: 12),
+          _buildAchievementBadge(achievementRate),
+        ],
+      );
+    }
+
+    return Row(
+      key: const ValueKey('detail-tab-goal-header-inline'),
+      children: [
+        icon,
+        const SizedBox(width: 12),
+        Expanded(child: title),
         _buildAchievementBadge(achievementRate),
       ],
     );
@@ -666,27 +795,66 @@ class DetailTab extends StatelessWidget {
 
   Widget _buildLegendRow(BuildContext context, bool isDark) {
     final l10n = AppLocalizations.of(context);
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        _buildLegendItem(
-            l10n.bookDetailLegendAchieved, BLabColors.success, isDark),
-        const SizedBox(width: 16),
-        _buildLegendItem(
-            l10n.bookDetailLegendMissed, BLabColors.errorLight, isDark),
-        const SizedBox(width: 16),
-        _buildLegendItem(
-            l10n.bookDetailLegendScheduled,
-            isDark
-                ? Colors.white.withValues(alpha: 0.1)
-                : BLabColors.grey100Light,
-            isDark),
-      ],
+    final useStackedLayout = MediaQuery.textScalerOf(context).scale(12) > 18;
+    final items = [
+      _buildLegendItem(
+        l10n.detailTabLegendAchieved,
+        BLabColors.success,
+        isDark,
+        expandLabel: useStackedLayout,
+      ),
+      _buildLegendItem(
+        l10n.detailTabLegendMissed,
+        BLabColors.errorLight,
+        isDark,
+        expandLabel: useStackedLayout,
+      ),
+      _buildLegendItem(
+        l10n.detailTabLegendScheduled,
+        isDark ? Colors.white.withValues(alpha: 0.1) : BLabColors.grey100Light,
+        isDark,
+        expandLabel: useStackedLayout,
+      ),
+    ];
+
+    if (useStackedLayout) {
+      return Column(
+        key: const ValueKey('detail-tab-legend-wrap'),
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (var index = 0; index < items.length; index++) ...[
+            if (index > 0) const SizedBox(height: 8),
+            items[index],
+          ],
+        ],
+      );
+    }
+
+    return Wrap(
+      key: const ValueKey('detail-tab-legend-wrap'),
+      alignment: WrapAlignment.center,
+      spacing: 16,
+      runSpacing: 8,
+      children: items,
     );
   }
 
-  Widget _buildLegendItem(String label, Color color, bool isDark) {
+  Widget _buildLegendItem(
+    String label,
+    Color color,
+    bool isDark, {
+    bool expandLabel = false,
+  }) {
+    final labelText = Text(
+      label,
+      style: TextStyle(
+        fontSize: 12,
+        color: isDark ? Colors.grey[400] : Colors.grey[600],
+        fontWeight: FontWeight.w500,
+      ),
+    );
     return Row(
+      mainAxisSize: expandLabel ? MainAxisSize.max : MainAxisSize.min,
       children: [
         Container(
           width: 16,
@@ -697,14 +865,7 @@ class DetailTab extends StatelessWidget {
           ),
         ),
         const SizedBox(width: 6),
-        Text(
-          label,
-          style: TextStyle(
-            fontSize: 12,
-            color: isDark ? Colors.grey[400] : Colors.grey[600],
-            fontWeight: FontWeight.w500,
-          ),
-        ),
+        if (expandLabel) Expanded(child: labelText) else labelText,
       ],
     );
   }

--- a/app/lib/ui/book_detail/widgets/tabs/detail_tab.dart
+++ b/app/lib/ui/book_detail/widgets/tabs/detail_tab.dart
@@ -9,7 +9,6 @@ import 'package:book_golas/ui/core/theme/design_system.dart';
 class DetailTab extends StatelessWidget {
   final Book book;
   final int attemptCount;
-  final String attemptEncouragement;
   final Map<String, bool> dailyAchievements;
   final VoidCallback onTargetDateChange;
   final VoidCallback? onPauseReading;
@@ -20,7 +19,6 @@ class DetailTab extends StatelessWidget {
     super.key,
     required this.book,
     required this.attemptCount,
-    required this.attemptEncouragement,
     required this.dailyAchievements,
     required this.onTargetDateChange,
     this.onPauseReading,
@@ -391,7 +389,10 @@ class DetailTab extends StatelessWidget {
     final targetDate =
         book.targetDate.toString().substring(0, 10).replaceAll('-', '.');
     final attempt = attemptCount > 1
-        ? l10n.detailTabAttempt(attemptCount, attemptEncouragement)
+        ? l10n.detailTabAttempt(
+            attemptCount,
+            l10n.detailTabAttemptEncouragement,
+          )
         : null;
     final useStackedLayout = MediaQuery.textScalerOf(context).scale(14) > 20;
 

--- a/app/lib/ui/book_detail/widgets/tabs/detail_tab.dart
+++ b/app/lib/ui/book_detail/widgets/tabs/detail_tab.dart
@@ -820,7 +820,7 @@ class DetailTab extends StatelessWidget {
 
     if (useStackedLayout) {
       return Column(
-        key: const ValueKey('detail-tab-legend-wrap'),
+        key: const ValueKey('detail-tab-legend-stacked'),
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           for (var index = 0; index < items.length; index++) ...[

--- a/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
+++ b/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
@@ -235,7 +235,7 @@ void main() {
         findsOneWidget,
       );
       expect(
-        find.byKey(const ValueKey('detail-tab-legend-wrap')),
+        find.byKey(const ValueKey('detail-tab-legend-stacked')),
         findsOneWidget,
       );
 

--- a/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
+++ b/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:book_golas/domain/models/book.dart';
 import 'package:book_golas/l10n/app_localizations.dart';
 import 'package:book_golas/ui/book_detail/utils/sticky_tab_bar_delegate.dart';
 import 'package:book_golas/ui/book_detail/widgets/compact_reading_schedule.dart';
@@ -9,6 +10,7 @@ import 'package:book_golas/ui/book_detail/widgets/custom_tab_bar.dart';
 import 'package:book_golas/ui/book_detail/widgets/dashboard_progress_widget.dart';
 import 'package:book_golas/ui/book_detail/widgets/floating_action_bar.dart'
     as book_detail;
+import 'package:book_golas/ui/book_detail/widgets/tabs/detail_tab.dart';
 import 'package:book_golas/ui/core/theme/design_system.dart';
 import 'package:book_golas/ui/core/widgets/scrollable_tab_bar.dart';
 
@@ -212,6 +214,41 @@ void main() {
         testCase.themeMode,
       );
     });
+
+    testWidgets('completed detail tab fits at 200 percent text scale in $label',
+        (
+      tester,
+    ) async {
+      await _pumpDetailTabAtLargeText(tester, testCase: testCase);
+
+      expect(tester.takeException(), isNull);
+      expect(
+        find.byKey(const ValueKey('detail-tab-schedule-row-stacked')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('detail-tab-target-date-stacked')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('detail-tab-goal-header-stacked')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('detail-tab-legend-wrap')),
+        findsOneWidget,
+      );
+
+      final scheduleTitle =
+          testCase.locale.languageCode == 'ko' ? '독서 일정' : 'Reading Schedule';
+      final reviewTitle =
+          testCase.locale.languageCode == 'ko' ? '독후감' : 'Review';
+      final changeLabel =
+          testCase.locale.languageCode == 'ko' ? '변경' : 'Change';
+      expect(find.text(scheduleTitle), findsOneWidget);
+      expect(find.text(reviewTitle), findsOneWidget);
+      expect(find.text(changeLabel), findsOneWidget);
+    });
   }
 
   testWidgets('reading schedule stacks at phone width and standard text size', (
@@ -319,6 +356,57 @@ void main() {
       findsNothing,
     );
   });
+}
+
+Future<void> _pumpDetailTabAtLargeText(
+  WidgetTester tester, {
+  required ({Locale locale, ThemeMode themeMode, double width}) testCase,
+}) async {
+  tester.view.physicalSize = Size(testCase.width, 852);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final today = DateTime(2026, 8, 2);
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: testCase.locale,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      theme: BLabTheme.light,
+      darkTheme: BLabTheme.dark,
+      themeMode: testCase.themeMode,
+      builder: (context, appChild) => MediaQuery(
+        data: MediaQuery.of(
+          context,
+        ).copyWith(textScaler: const TextScaler.linear(2)),
+        child: appChild!,
+      ),
+      home: Scaffold(
+        body: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: DetailTab(
+            book: Book(
+              title: 'The Little Prince',
+              author: 'Antoine de Saint-Exupéry',
+              startDate: today,
+              targetDate: today.add(const Duration(days: 13)),
+              currentPage: 144,
+              totalPages: 144,
+              status: BookStatus.completed.value,
+            ),
+            attemptCount: 12,
+            attemptEncouragement: 'Keep going',
+            dailyAchievements: const {},
+            onTargetDateChange: () {},
+            onDelete: () {},
+            onReviewTap: () {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
 }
 
 void _expectTextContrast(

--- a/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
+++ b/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
@@ -245,9 +245,13 @@ void main() {
           testCase.locale.languageCode == 'ko' ? '독후감' : 'Review';
       final changeLabel =
           testCase.locale.languageCode == 'ko' ? '변경' : 'Change';
+      final attemptLabel = testCase.locale.languageCode == 'ko'
+          ? '12번째 · 끝까지 함께해요!'
+          : 'Attempt 12 · Keep going!';
       expect(find.text(scheduleTitle), findsOneWidget);
       expect(find.text(reviewTitle), findsOneWidget);
       expect(find.text(changeLabel), findsOneWidget);
+      expect(find.text(attemptLabel), findsOneWidget);
     });
   }
 
@@ -396,7 +400,6 @@ Future<void> _pumpDetailTabAtLargeText(
               status: BookStatus.completed.value,
             ),
             attemptCount: 12,
-            attemptEncouragement: 'Keep going',
             dailyAchievements: const {},
             onTargetDateChange: () {},
             onDelete: () {},

--- a/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
+++ b/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:book_golas/l10n/app_localizations.dart';
 import 'package:book_golas/ui/book_detail/utils/sticky_tab_bar_delegate.dart';
 import 'package:book_golas/ui/book_detail/widgets/compact_reading_schedule.dart';
+import 'package:book_golas/ui/book_detail/widgets/compact_streak_row.dart';
 import 'package:book_golas/ui/book_detail/widgets/custom_tab_bar.dart';
 import 'package:book_golas/ui/book_detail/widgets/dashboard_progress_widget.dart';
 import 'package:book_golas/ui/book_detail/widgets/floating_action_bar.dart'
@@ -140,6 +141,32 @@ void main() {
       await _pumpStickyTabBarAtLargeText(tester, testCase: testCase);
 
       expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('streak card fits at 200 percent text scale in $label', (
+      tester,
+    ) async {
+      await _pumpAtLargeText(
+        tester,
+        testCase: testCase,
+        child: const CompactStreakRow(dailyAchievements: {}),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(
+        find.byKey(const ValueKey('compact-streak-days-wrapped')),
+        findsOneWidget,
+      );
+      _expectTextContrast(
+        tester,
+        const ValueKey('compact-streak-day-label-0'),
+        testCase.themeMode,
+      );
+      _expectTextContrast(
+        tester,
+        const ValueKey('compact-streak-message'),
+        testCase.themeMode,
+      );
     });
   }
 

--- a/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
+++ b/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
@@ -10,6 +10,7 @@ import 'package:book_golas/ui/book_detail/widgets/dashboard_progress_widget.dart
 import 'package:book_golas/ui/book_detail/widgets/floating_action_bar.dart'
     as book_detail;
 import 'package:book_golas/ui/core/theme/design_system.dart';
+import 'package:book_golas/ui/core/widgets/scrollable_tab_bar.dart';
 
 void main() {
   final testCases = <({Locale locale, ThemeMode themeMode, double width})>[
@@ -146,20 +147,43 @@ void main() {
     testWidgets(
       'completed-book tab bar fits at 200 percent text scale in $label',
       (tester) async {
+        final semantics = tester.ensureSemantics();
         await _pumpStickyTabBarAtLargeText(
           tester,
           testCase: testCase,
-          tabLabels: const ['Record', 'History', 'Review', 'Details'],
+          completed: true,
         );
 
         expect(tester.takeException(), isNull);
         final tabBarRect = tester.getRect(find.byType(CustomTabBar));
-        expect(tabBarRect.height, greaterThan(56));
-        for (final label in const ['Record', 'History', 'Review', 'Details']) {
-          final labelRect = tester.getRect(find.text(label));
-          expect(labelRect.top, greaterThanOrEqualTo(tabBarRect.top));
-          expect(labelRect.bottom, lessThanOrEqualTo(tabBarRect.bottom));
+        expect(tabBarRect.height, greaterThanOrEqualTo(56));
+        expect(find.byType(ScrollableTabBar), findsOneWidget);
+
+        final labels = testCase.locale.languageCode == 'ko'
+            ? const ['기록', '히스토리', '독후감', '상세']
+            : const ['Record', 'History', 'Review', 'Details'];
+        for (final tabLabel in labels) {
+          expect(find.semantics.byLabel(tabLabel), findsOneWidget);
+          final labelText = tester.widget<Text>(find.text(tabLabel));
+          expect(labelText.maxLines, 1);
+          expect(labelText.softWrap, isFalse);
         }
+
+        final scrollView = tester.widget<SingleChildScrollView>(
+          find.byKey(const ValueKey('scrollable-tab-bar-scroll-view')),
+        );
+        expect(scrollView.controller, isNotNull);
+        expect(scrollView.controller!.position.maxScrollExtent, greaterThan(0));
+
+        tester.semantics.tap(find.semantics.byLabel(labels.last));
+        await tester.pumpAndSettle();
+        expect(scrollView.controller!.offset, greaterThan(0));
+        final lastLabelRect = tester.getRect(find.text(labels.last));
+        expect(lastLabelRect.left, greaterThanOrEqualTo(tabBarRect.left));
+        expect(lastLabelRect.right, lessThanOrEqualTo(tabBarRect.right));
+        expect(lastLabelRect.top, greaterThanOrEqualTo(tabBarRect.top));
+        expect(lastLabelRect.bottom, lessThanOrEqualTo(tabBarRect.bottom));
+        semantics.dispose();
       },
     );
 
@@ -340,7 +364,7 @@ double _contrastRatio(Color foreground, Color background) {
 Future<void> _pumpStickyTabBarAtLargeText(
   WidgetTester tester, {
   required ({Locale locale, ThemeMode themeMode, double width}) testCase,
-  List<String> tabLabels = const ['Record', 'History', 'Detail'],
+  bool completed = false,
 }) async {
   tester.view.physicalSize = Size(testCase.width, 852);
   tester.view.devicePixelRatio = 1;
@@ -361,31 +385,48 @@ Future<void> _pumpStickyTabBarAtLargeText(
         ).copyWith(textScaler: const TextScaler.linear(2)),
         child: appChild!,
       ),
-      home: DefaultTabController(
-        length: 3,
-        child: Builder(
-          builder: (context) {
-            final tabController = DefaultTabController.of(context);
-            return CustomScrollView(
-              slivers: [
-                SliverPersistentHeader(
-                  pinned: true,
-                  delegate: StickyTabBarDelegate(
-                    extent: CustomTabBar.extentFor(context, tabLabels),
-                    backgroundColor: testCase.themeMode == ThemeMode.dark
-                        ? BLabColors.scaffoldDark
-                        : BLabColors.elevatedLight,
-                    child: CustomTabBar(
-                      tabController: tabController,
-                      tabLabels: tabLabels,
+      home: Builder(
+        builder: (context) {
+          final l10n = AppLocalizations.of(context);
+          final tabLabels = completed
+              ? [
+                  l10n.bookDetailTabRecord,
+                  l10n.bookDetailTabHistory,
+                  l10n.bookDetailTabReview,
+                  l10n.bookDetailTabDetail,
+                ]
+              : [
+                  l10n.bookDetailTabRecord,
+                  l10n.bookDetailTabHistory,
+                  l10n.bookDetailTabDetail,
+                ];
+          return DefaultTabController(
+            length: tabLabels.length,
+            child: Builder(
+              builder: (context) {
+                final tabController = DefaultTabController.of(context);
+                return CustomScrollView(
+                  slivers: [
+                    SliverPersistentHeader(
+                      pinned: true,
+                      delegate: StickyTabBarDelegate(
+                        extent: CustomTabBar.extentFor(context, tabLabels),
+                        backgroundColor: testCase.themeMode == ThemeMode.dark
+                            ? BLabColors.scaffoldDark
+                            : BLabColors.elevatedLight,
+                        child: CustomTabBar(
+                          tabController: tabController,
+                          tabLabels: tabLabels,
+                        ),
+                      ),
                     ),
-                  ),
-                ),
-                const SliverFillRemaining(child: SizedBox.expand()),
-              ],
-            );
-          },
-        ),
+                    const SliverFillRemaining(child: SizedBox.expand()),
+                  ],
+                );
+              },
+            ),
+          );
+        },
       ),
     ),
   );

--- a/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
+++ b/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_detail/widgets/compact_reading_schedule.dart';
+import 'package:book_golas/ui/book_detail/widgets/dashboard_progress_widget.dart';
+import 'package:book_golas/ui/core/theme/design_system.dart';
+
+void main() {
+  final testCases = <({Locale locale, ThemeMode themeMode, double width})>[
+    for (final locale in const [Locale('ko'), Locale('en')])
+      for (final themeMode in const [ThemeMode.light, ThemeMode.dark])
+        for (final width in const [320.0, 393.0])
+          (locale: locale, themeMode: themeMode, width: width),
+  ];
+
+  for (final testCase in testCases) {
+    final label =
+        '${testCase.locale.languageCode} ${testCase.themeMode.name} ${testCase.width.toInt()}px';
+
+    testWidgets('reading schedule fits at 200 percent text scale in $label', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      var editCount = 0;
+
+      await _pumpAtLargeText(
+        tester,
+        testCase: testCase,
+        child: CompactReadingSchedule(
+          startDate: DateTime(2026, 1, 1),
+          targetDate: DateTime(2026, 12, 31),
+          attemptCount: 12,
+          onEditTap: () => editCount += 1,
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      final editLabel =
+          testCase.locale.languageCode == 'ko' ? '목표일 수정' : 'Edit target date';
+      final editFinder = find.semantics.byLabel(editLabel);
+      expect(editFinder, findsOneWidget);
+      expect(
+          tester.getSize(find.byType(GestureDetector).last).shortestSide, 44);
+      tester.semantics.tap(editFinder);
+      await tester.pump();
+      expect(editCount, 1);
+      semantics.dispose();
+    });
+
+    testWidgets('progress dashboard fits at 200 percent text scale in $label', (
+      tester,
+    ) async {
+      var targetCount = 0;
+
+      await _pumpAtLargeText(
+        tester,
+        testCase: testCase,
+        child: DashboardProgressWidget(
+          animatedProgress: 0.42,
+          currentPage: 123,
+          totalPages: 1234,
+          daysLeft: 128,
+          pagesLeft: 1111,
+          dailyTargetPages: 123,
+          isTodayGoalAchieved: true,
+          onDailyTargetTap: () => targetCount += 1,
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      await tester.tap(find.textContaining('123p').last);
+      await tester.pump();
+      expect(targetCount, 1);
+    });
+  }
+
+  testWidgets('reading schedule stacks at phone width and standard text size', (
+    tester,
+  ) async {
+    await _pumpAtTextScale(
+      tester,
+      locale: const Locale('ko'),
+      themeMode: ThemeMode.light,
+      width: 393,
+      textScale: 1,
+      child: CompactReadingSchedule(
+        startDate: DateTime(2026, 1, 1),
+        targetDate: DateTime(2026, 12, 31),
+        attemptCount: 2,
+        onEditTap: () {},
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(
+      find.byKey(const ValueKey('compact-reading-schedule-stacked')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('reading schedule keeps the inline layout on a wide screen', (
+    tester,
+  ) async {
+    await _pumpAtTextScale(
+      tester,
+      locale: const Locale('ko'),
+      themeMode: ThemeMode.light,
+      width: 600,
+      textScale: 1,
+      child: CompactReadingSchedule(
+        startDate: DateTime(2026, 1, 1),
+        targetDate: DateTime(2026, 12, 31),
+        attemptCount: 2,
+        onEditTap: () {},
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(
+      find.byKey(const ValueKey('compact-reading-schedule-stacked')),
+      findsNothing,
+    );
+  });
+
+  testWidgets(
+      'progress dashboard keeps the inline layout at standard text size', (
+    tester,
+  ) async {
+    await _pumpAtTextScale(
+      tester,
+      locale: const Locale('ko'),
+      themeMode: ThemeMode.light,
+      width: 393,
+      textScale: 1,
+      child: DashboardProgressWidget(
+        animatedProgress: 0.42,
+        currentPage: 123,
+        totalPages: 1234,
+        daysLeft: 128,
+        pagesLeft: 1111,
+        dailyTargetPages: 123,
+        isTodayGoalAchieved: true,
+        onDailyTargetTap: () {},
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(
+      find.byKey(const ValueKey('dashboard-progress-stacked')),
+      findsNothing,
+    );
+  });
+}
+
+Future<void> _pumpAtLargeText(
+  WidgetTester tester, {
+  required ({Locale locale, ThemeMode themeMode, double width}) testCase,
+  required Widget child,
+}) async {
+  await _pumpAtTextScale(
+    tester,
+    locale: testCase.locale,
+    themeMode: testCase.themeMode,
+    width: testCase.width,
+    textScale: 2,
+    child: child,
+  );
+}
+
+Future<void> _pumpAtTextScale(
+  WidgetTester tester, {
+  required Locale locale,
+  required ThemeMode themeMode,
+  required double width,
+  required double textScale,
+  required Widget child,
+}) async {
+  tester.view.physicalSize = Size(width, 852);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: locale,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      theme: BLabTheme.light,
+      darkTheme: BLabTheme.dark,
+      themeMode: themeMode,
+      builder: (context, appChild) => MediaQuery(
+        data: MediaQuery.of(
+          context,
+        ).copyWith(textScaler: TextScaler.linear(textScale)),
+        child: appChild!,
+      ),
+      home: Scaffold(
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+          child: child,
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}

--- a/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
+++ b/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
@@ -143,6 +143,26 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets(
+      'completed-book tab bar fits at 200 percent text scale in $label',
+      (tester) async {
+        await _pumpStickyTabBarAtLargeText(
+          tester,
+          testCase: testCase,
+          tabLabels: const ['Record', 'History', 'Review', 'Details'],
+        );
+
+        expect(tester.takeException(), isNull);
+        final tabBarRect = tester.getRect(find.byType(CustomTabBar));
+        expect(tabBarRect.height, greaterThan(56));
+        for (final label in const ['Record', 'History', 'Review', 'Details']) {
+          final labelRect = tester.getRect(find.text(label));
+          expect(labelRect.top, greaterThanOrEqualTo(tabBarRect.top));
+          expect(labelRect.bottom, lessThanOrEqualTo(tabBarRect.bottom));
+        }
+      },
+    );
+
     testWidgets('streak card fits at 200 percent text scale in $label', (
       tester,
     ) async {
@@ -320,6 +340,7 @@ double _contrastRatio(Color foreground, Color background) {
 Future<void> _pumpStickyTabBarAtLargeText(
   WidgetTester tester, {
   required ({Locale locale, ThemeMode themeMode, double width}) testCase,
+  List<String> tabLabels = const ['Record', 'History', 'Detail'],
 }) async {
   tester.view.physicalSize = Size(testCase.width, 852);
   tester.view.devicePixelRatio = 1;
@@ -350,13 +371,13 @@ Future<void> _pumpStickyTabBarAtLargeText(
                 SliverPersistentHeader(
                   pinned: true,
                   delegate: StickyTabBarDelegate(
-                    extent: CustomTabBar.extentFor(context),
+                    extent: CustomTabBar.extentFor(context, tabLabels),
                     backgroundColor: testCase.themeMode == ThemeMode.dark
                         ? BLabColors.scaffoldDark
                         : BLabColors.elevatedLight,
                     child: CustomTabBar(
                       tabController: tabController,
-                      tabLabels: const ['Record', 'History', 'Detail'],
+                      tabLabels: tabLabels,
                     ),
                   ),
                 ),

--- a/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
+++ b/app/test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart
@@ -2,8 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_detail/utils/sticky_tab_bar_delegate.dart';
 import 'package:book_golas/ui/book_detail/widgets/compact_reading_schedule.dart';
+import 'package:book_golas/ui/book_detail/widgets/custom_tab_bar.dart';
 import 'package:book_golas/ui/book_detail/widgets/dashboard_progress_widget.dart';
+import 'package:book_golas/ui/book_detail/widgets/floating_action_bar.dart'
+    as book_detail;
 import 'package:book_golas/ui/core/theme/design_system.dart';
 
 void main() {
@@ -45,12 +49,34 @@ void main() {
       tester.semantics.tap(editFinder);
       await tester.pump();
       expect(editCount, 1);
+      _expectTextContrast(
+        tester,
+        const ValueKey('reading-schedule-date-label-start'),
+        testCase.themeMode,
+      );
+      _expectTextContrast(
+        tester,
+        const ValueKey('reading-schedule-date-label-target'),
+        testCase.themeMode,
+      );
+      _expectTextContrast(
+        tester,
+        const ValueKey('reading-schedule-total-days'),
+        testCase.themeMode,
+      );
+      _expectStatusTextContrast(
+        tester,
+        const ValueKey('reading-schedule-attempt-badge'),
+        testCase.themeMode,
+        BLabColors.warning.withValues(alpha: 0.12),
+      );
       semantics.dispose();
     });
 
     testWidgets('progress dashboard fits at 200 percent text scale in $label', (
       tester,
     ) async {
+      final semantics = tester.ensureSemantics();
       var targetCount = 0;
 
       await _pumpAtLargeText(
@@ -69,9 +95,51 @@ void main() {
       );
 
       expect(tester.takeException(), isNull);
-      await tester.tap(find.textContaining('123p').last);
+      final targetTextFinder = find.byKey(
+        const ValueKey('dashboard-progress-daily-target'),
+      );
+      final targetText = tester.widget<Text>(targetTextFinder);
+      final targetSemantics = find.semantics.byLabel(targetText.data!);
+      expect(targetSemantics, findsOneWidget);
+      final targetGesture = find.ancestor(
+        of: targetTextFinder,
+        matching: find.byType(GestureDetector),
+      );
+      expect(
+          tester.getSize(targetGesture).shortestSide, greaterThanOrEqualTo(44));
+      _expectStatusTextContrast(
+        tester,
+        const ValueKey('dashboard-progress-daily-target'),
+        testCase.themeMode,
+        BLabColors.success.withValues(alpha: 0.1),
+      );
+      _expectStatusTextContrast(
+        tester,
+        const ValueKey('dashboard-progress-goal-achieved'),
+        testCase.themeMode,
+        BLabColors.gold.withValues(alpha: 0.15),
+      );
+      tester.semantics.tap(targetSemantics);
       await tester.pump();
       expect(targetCount, 1);
+      semantics.dispose();
+    });
+
+    testWidgets('floating action bar fits at 200 percent text scale in $label',
+        (
+      tester,
+    ) async {
+      await _pumpFloatingActionBarAtLargeText(tester, testCase: testCase);
+
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('sticky tab bar fits at 200 percent text scale in $label', (
+      tester,
+    ) async {
+      await _pumpStickyTabBarAtLargeText(tester, testCase: testCase);
+
+      expect(tester.takeException(), isNull);
     });
   }
 
@@ -123,6 +191,35 @@ void main() {
     );
   });
 
+  for (final locale in const [Locale('ko'), Locale('en')]) {
+    for (final textScale in const [1.0, 2.0]) {
+      testWidgets(
+        'reading schedule stacks at 440px boundary in ${locale.languageCode} ${textScale}x',
+        (tester) async {
+          await _pumpAtTextScale(
+            tester,
+            locale: locale,
+            themeMode: ThemeMode.light,
+            width: 440,
+            textScale: textScale,
+            child: CompactReadingSchedule(
+              startDate: DateTime(2026, 1, 1),
+              targetDate: DateTime(2026, 12, 31),
+              attemptCount: 12,
+              onEditTap: () {},
+            ),
+          );
+
+          expect(tester.takeException(), isNull);
+          expect(
+            find.byKey(const ValueKey('compact-reading-schedule-stacked')),
+            findsOneWidget,
+          );
+        },
+      );
+    }
+  }
+
   testWidgets(
       'progress dashboard keeps the inline layout at standard text size', (
     tester,
@@ -151,6 +248,138 @@ void main() {
       findsNothing,
     );
   });
+}
+
+void _expectTextContrast(
+  WidgetTester tester,
+  Key key,
+  ThemeMode themeMode,
+) {
+  final text = tester.widget<Text>(find.byKey(key));
+  final background = themeMode == ThemeMode.dark
+      ? BLabColors.surfaceDark
+      : BLabColors.surfaceLight;
+  expect(_contrastRatio(text.style!.color!, background),
+      greaterThanOrEqualTo(4.5));
+}
+
+void _expectStatusTextContrast(
+  WidgetTester tester,
+  Key key,
+  ThemeMode themeMode,
+  Color overlay,
+) {
+  final text = tester.widget<Text>(find.byKey(key));
+  final surface = themeMode == ThemeMode.dark
+      ? BLabColors.surfaceDark
+      : BLabColors.surfaceLight;
+  final background = Color.alphaBlend(overlay, surface);
+  expect(_contrastRatio(text.style!.color!, background),
+      greaterThanOrEqualTo(4.5));
+}
+
+double _contrastRatio(Color foreground, Color background) {
+  final opaqueForeground = Color.alphaBlend(foreground, background);
+  final lighter =
+      opaqueForeground.computeLuminance() > background.computeLuminance()
+          ? opaqueForeground
+          : background;
+  final darker =
+      identical(lighter, opaqueForeground) ? background : opaqueForeground;
+  return (lighter.computeLuminance() + 0.05) /
+      (darker.computeLuminance() + 0.05);
+}
+
+Future<void> _pumpStickyTabBarAtLargeText(
+  WidgetTester tester, {
+  required ({Locale locale, ThemeMode themeMode, double width}) testCase,
+}) async {
+  tester.view.physicalSize = Size(testCase.width, 852);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: testCase.locale,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      theme: BLabTheme.light,
+      darkTheme: BLabTheme.dark,
+      themeMode: testCase.themeMode,
+      builder: (context, appChild) => MediaQuery(
+        data: MediaQuery.of(
+          context,
+        ).copyWith(textScaler: const TextScaler.linear(2)),
+        child: appChild!,
+      ),
+      home: DefaultTabController(
+        length: 3,
+        child: Builder(
+          builder: (context) {
+            final tabController = DefaultTabController.of(context);
+            return CustomScrollView(
+              slivers: [
+                SliverPersistentHeader(
+                  pinned: true,
+                  delegate: StickyTabBarDelegate(
+                    extent: CustomTabBar.extentFor(context),
+                    backgroundColor: testCase.themeMode == ThemeMode.dark
+                        ? BLabColors.scaffoldDark
+                        : BLabColors.elevatedLight,
+                    child: CustomTabBar(
+                      tabController: tabController,
+                      tabLabels: const ['Record', 'History', 'Detail'],
+                    ),
+                  ),
+                ),
+                const SliverFillRemaining(child: SizedBox.expand()),
+              ],
+            );
+          },
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+Future<void> _pumpFloatingActionBarAtLargeText(
+  WidgetTester tester, {
+  required ({Locale locale, ThemeMode themeMode, double width}) testCase,
+}) async {
+  tester.view.physicalSize = Size(testCase.width, 852);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: testCase.locale,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      theme: BLabTheme.light,
+      darkTheme: BLabTheme.dark,
+      themeMode: testCase.themeMode,
+      builder: (context, appChild) => MediaQuery(
+        data: MediaQuery.of(
+          context,
+        ).copyWith(textScaler: const TextScaler.linear(2)),
+        child: appChild!,
+      ),
+      home: Scaffold(
+        body: Stack(
+          children: [
+            book_detail.FloatingActionBar(
+              onUpdatePageTap: () {},
+              onAddMemorablePageTap: () {},
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
 }
 
 Future<void> _pumpAtLargeText(


### PR DESCRIPTION
## 목적

독서 상세의 일정·진행·주간 기록 영역이 대형 글자에서 가로로 넘치던 1.0.2 출시 차단 결함을 수정합니다.

## 주요 변경

- 휴대폰 폭 또는 대형 글자에서 독서 일정을 세로형 정보 구조로 전환
- 대형 글자에서 진행률과 남은 목표를 전체 너비 세로 구조로 전환
- 완독 상태의 네 개 탭을 한 줄 가로 스크롤 구조로 전환하고 선택 탭 자동 노출 및 좌우 탐색 표시 적용
- 완독 상세 탭의 일정·목표 달성·범례·삭제 액션을 대형 글자에서 세로 재배치
- 완독 상세 탭의 하드코딩 한국어를 기존 한국어·영어 번역 문자열로 전환
- 재독 횟수 옆 격려 문구를 현재 한국어·영어 로케일에서 직접 가져오도록 전환
- 실제 글자 높이에 맞춰 고정 탭 영역의 높이를 동적으로 계산
- 탭 높이 측정을 전환 애니메이션 밖에서 한 번만 수행하도록 최적화
- 주간 기록을 대형 글자에서 4+3 구조로 재배치하고 안내 문구 줄바꿈 보장
- 목표일 수정·오늘 목표 동작에 접근성 이름과 최소 44pt 터치 영역 적용
- 라이트·다크 의미 색상 대비 교정
- 한국어·영어, light·dark, 320px·393px, 200% 회귀 테스트 추가
- 대형 글자 범례가 실제 세로 분기를 선택했는지 고유 키로 검증

## 배경

BOK-379 통합 검증에서 CompactReadingSchedule과 인접 진행 정보의 RenderFlex overflow가 확인됐습니다. 후속 exact-head 검증에서 고정 탭 영역, 영어 주간 기록 카드, 완독 상세 탭 일정·목표 카드의 추가 오버플로를 실제 사용자 경로에서 확인해 함께 교정했습니다.

## 검증

- 대형 글자 집중 레이아웃 테스트 63건 통과
- 도서 상세 테스트 114건 통과
- 전체 Flutter 테스트 426건 통과
- 수정 라인에서 새 analyzer 진단 0건(동일 화면의 기존 비동기 context info 4건은 이번 diff 밖)
- iPhone 17e iOS 26.5 accessibility-large 영어 dark 완료 도서 실제 경로에서 Record → Details 탭 자동 노출·전환 및 상세 일정 카드 overflow 해소 확인
- exact head `68c5d9ced4373c7c714522da207d874e0e87b241`
- GitHub exact-head Flutter·Target Version·Web·Edge·Vercel 검사 통과
- 독립 Product Designer·품질 재리뷰 진행 중

## 관련 이슈

- BOK-382
- 인접 후속: BOK-384, BOK-385, BOK-386, BOK-387, BOK-388, BOK-389, BOK-390

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store
