### PR TITLE
fix(mobile): make page update modal keyboard-safe

### DIFF
--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -566,6 +566,8 @@
        "pageUpdateCurrentPage": "Currently {currentPage}p",
        "pageUpdateTotalPages": " / Total {totalPages}p",
        "pageUpdateNewPageLabel": "New Page Number",
+       "pageAbbreviation": "p",
+       "@pageAbbreviation": {"description": "Abbreviated page unit shown beside page number inputs"},
        "pageUpdateCancel": "Cancel",
        "pageUpdateButton": "Update",
        "timerDidNotRead": "I didn't read",

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -1240,6 +1240,9 @@
      
      "pageUpdateNewPageLabel": "새 페이지 번호",
      "@pageUpdateNewPageLabel": {"description": "New page number label"},
+
+     "pageAbbreviation": "p",
+     "@pageAbbreviation": {"description": "Abbreviated page unit shown beside page number inputs"},
      
      "pageUpdateCancel": "취소",
      "@pageUpdateCancel": {"description": "Cancel button"},

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -2244,6 +2244,12 @@ abstract class AppLocalizations {
   /// **'새 페이지 번호'**
   String get pageUpdateNewPageLabel;
 
+  /// Abbreviated page unit shown beside page number inputs
+  ///
+  /// In ko, this message translates to:
+  /// **'p'**
+  String get pageAbbreviation;
+
   /// Cancel button
   ///
   /// In ko, this message translates to:

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -1209,6 +1209,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pageUpdateNewPageLabel => 'New Page Number';
 
   @override
+  String get pageAbbreviation => 'p';
+
+  @override
   String get pageUpdateCancel => 'Cancel';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -1159,6 +1159,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get pageUpdateNewPageLabel => '새 페이지 번호';
 
   @override
+  String get pageAbbreviation => 'p';
+
+  @override
   String get pageUpdateCancel => '취소';
 
   @override

--- a/app/lib/ui/core/widgets/liquid_glass_text_field.dart
+++ b/app/lib/ui/core/widgets/liquid_glass_text_field.dart
@@ -21,6 +21,7 @@ class BLabTextField extends StatefulWidget {
   final String? suffixText;
   final TextStyle? suffixStyle;
   final bool showClearButton;
+  final String? semanticLabel;
 
   const BLabTextField({
     super.key,
@@ -42,6 +43,7 @@ class BLabTextField extends StatefulWidget {
     this.suffixText,
     this.suffixStyle,
     this.showClearButton = true,
+    this.semanticLabel,
   });
 
   @override
@@ -91,6 +93,37 @@ class _BLabTextFieldState extends State<BLabTextField> {
     final hintColor = isDark
         ? Colors.white.withValues(alpha: 0.5)
         : Colors.black.withValues(alpha: 0.5);
+    final textField = TextField(
+      controller: widget.controller,
+      readOnly: widget.readOnly,
+      obscureText: widget.obscureText,
+      onTap: widget.onTap,
+      maxLines: widget.obscureText ? 1 : widget.maxLines,
+      keyboardType: widget.keyboardType,
+      autofocus: widget.autofocus,
+      textAlign: widget.textAlign,
+      onChanged: widget.onChanged,
+      onSubmitted: widget.onSubmitted,
+      style: widget.textStyle ?? TextStyle(color: textColor, fontSize: 16),
+      cursorColor: textColor,
+      decoration: InputDecoration(
+        hintText: widget.hintText,
+        hintStyle: TextStyle(color: hintColor, fontSize: 16),
+        filled: false,
+        border: InputBorder.none,
+        enabledBorder: InputBorder.none,
+        focusedBorder: InputBorder.none,
+        isDense: true,
+        errorText: widget.errorText,
+        suffixText: widget.suffixText,
+        suffixStyle: widget.suffixStyle,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 14,
+        ),
+        suffixIcon: _buildSuffixIcon(isDark),
+      ),
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -116,38 +149,14 @@ class _BLabTextFieldState extends State<BLabTextField> {
                 borderRadius: BorderRadius.circular(12),
                 border: Border.all(color: borderColor, width: 0.5),
               ),
-              child: TextField(
-                controller: widget.controller,
-                readOnly: widget.readOnly,
-                obscureText: widget.obscureText,
-                onTap: widget.onTap,
-                maxLines: widget.obscureText ? 1 : widget.maxLines,
-                keyboardType: widget.keyboardType,
-                autofocus: widget.autofocus,
-                textAlign: widget.textAlign,
-                onChanged: widget.onChanged,
-                onSubmitted: widget.onSubmitted,
-                style: widget.textStyle ??
-                    TextStyle(color: textColor, fontSize: 16),
-                cursorColor: textColor,
-                decoration: InputDecoration(
-                  hintText: widget.hintText,
-                  hintStyle: TextStyle(color: hintColor, fontSize: 16),
-                  filled: false,
-                  border: InputBorder.none,
-                  enabledBorder: InputBorder.none,
-                  focusedBorder: InputBorder.none,
-                  isDense: true,
-                  errorText: widget.errorText,
-                  suffixText: widget.suffixText,
-                  suffixStyle: widget.suffixStyle,
-                  contentPadding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 14,
-                  ),
-                  suffixIcon: _buildSuffixIcon(isDark),
-                ),
-              ),
+              child: widget.semanticLabel == null
+                  ? textField
+                  : MergeSemantics(
+                      child: Semantics(
+                        label: widget.semanticLabel,
+                        child: textField,
+                      ),
+                    ),
             ),
           ),
         ),

--- a/app/lib/ui/core/widgets/liquid_glass_text_field.dart
+++ b/app/lib/ui/core/widgets/liquid_glass_text_field.dart
@@ -11,6 +11,16 @@ class BLabTextField extends StatefulWidget {
   final VoidCallback? onTap;
   final Widget? suffixIcon;
   final int maxLines;
+  final TextInputType? keyboardType;
+  final bool autofocus;
+  final TextAlign textAlign;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+  final TextStyle? textStyle;
+  final String? errorText;
+  final String? suffixText;
+  final TextStyle? suffixStyle;
+  final bool showClearButton;
 
   const BLabTextField({
     super.key,
@@ -22,6 +32,16 @@ class BLabTextField extends StatefulWidget {
     this.onTap,
     this.suffixIcon,
     this.maxLines = 1,
+    this.keyboardType,
+    this.autofocus = false,
+    this.textAlign = TextAlign.start,
+    this.onChanged,
+    this.onSubmitted,
+    this.textStyle,
+    this.errorText,
+    this.suffixText,
+    this.suffixStyle,
+    this.showClearButton = true,
   });
 
   @override
@@ -94,10 +114,7 @@ class _BLabTextFieldState extends State<BLabTextField> {
               decoration: BoxDecoration(
                 color: glassColor,
                 borderRadius: BorderRadius.circular(12),
-                border: Border.all(
-                  color: borderColor,
-                  width: 0.5,
-                ),
+                border: Border.all(color: borderColor, width: 0.5),
               ),
               child: TextField(
                 controller: widget.controller,
@@ -105,22 +122,25 @@ class _BLabTextFieldState extends State<BLabTextField> {
                 obscureText: widget.obscureText,
                 onTap: widget.onTap,
                 maxLines: widget.obscureText ? 1 : widget.maxLines,
-                style: TextStyle(
-                  color: textColor,
-                  fontSize: 16,
-                ),
+                keyboardType: widget.keyboardType,
+                autofocus: widget.autofocus,
+                textAlign: widget.textAlign,
+                onChanged: widget.onChanged,
+                onSubmitted: widget.onSubmitted,
+                style: widget.textStyle ??
+                    TextStyle(color: textColor, fontSize: 16),
                 cursorColor: textColor,
                 decoration: InputDecoration(
                   hintText: widget.hintText,
-                  hintStyle: TextStyle(
-                    color: hintColor,
-                    fontSize: 16,
-                  ),
+                  hintStyle: TextStyle(color: hintColor, fontSize: 16),
                   filled: false,
                   border: InputBorder.none,
                   enabledBorder: InputBorder.none,
                   focusedBorder: InputBorder.none,
                   isDense: true,
+                  errorText: widget.errorText,
+                  suffixText: widget.suffixText,
+                  suffixStyle: widget.suffixStyle,
                   contentPadding: const EdgeInsets.symmetric(
                     horizontal: 16,
                     vertical: 14,
@@ -140,7 +160,7 @@ class _BLabTextFieldState extends State<BLabTextField> {
       return widget.suffixIcon;
     }
 
-    if (!widget.readOnly && _hasText) {
+    if (widget.showClearButton && !widget.readOnly && _hasText) {
       return GestureDetector(
         onTap: _clearText,
         child: Padding(

--- a/app/lib/ui/core/widgets/page_update_modal.dart
+++ b/app/lib/ui/core/widgets/page_update_modal.dart
@@ -109,9 +109,10 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
   void initState() {
     super.initState();
     final start = (widget.currentPage ?? 0) + 1;
+    final hasPageInfo = widget.currentPage != null && widget.totalPages != null;
     _selectedPage = start;
     _pageController = TextEditingController(
-      text: widget.currentPage == null ? '' : start.toString(),
+      text: hasPageInfo ? start.toString() : '',
     );
     _wheelController = FixedExtentScrollController(initialItem: 0);
   }

--- a/app/lib/ui/core/widgets/page_update_modal.dart
+++ b/app/lib/ui/core/widgets/page_update_modal.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:book_golas/l10n/app_localizations.dart';
-import 'package:book_golas/ui/core/theme/app_colors.dart';
+import 'package:book_golas/ui/core/theme/design_system.dart';
+import 'package:book_golas/ui/core/widgets/liquid_glass_button.dart';
+import 'package:book_golas/ui/core/widgets/liquid_glass_text_field.dart';
 
 class PageUpdateResult {
   final int? page;
@@ -25,7 +27,6 @@ class PageUpdateModal {
     bool isTimerFlow = false,
   }) async {
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final TextEditingController pageController = TextEditingController();
     final l10n = AppLocalizations.of(context);
 
     final result = await showModalBottomSheet<PageUpdateResult>(
@@ -35,32 +36,40 @@ class PageUpdateModal {
       isDismissible: false,
       enableDrag: false,
       useRootNavigator: true,
-      builder: (sheetContext) => Padding(
-        padding: EdgeInsets.only(
-          bottom: MediaQuery.of(sheetContext).viewInsets.bottom,
-        ),
-        child: Container(
-          padding: EdgeInsets.fromLTRB(
-            24,
-            24,
-            24,
-            24 + MediaQuery.of(sheetContext).viewPadding.bottom,
+      builder: (sheetContext) {
+        final mediaQuery = MediaQuery.of(sheetContext);
+        final keyboardInset = mediaQuery.viewInsets.bottom;
+        final maxHeight =
+            (mediaQuery.size.height - keyboardInset - mediaQuery.padding.top)
+                .clamp(0.0, mediaQuery.size.height)
+                .toDouble();
+
+        return AnimatedPadding(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOutCubic,
+          padding: EdgeInsets.only(bottom: keyboardInset),
+          child: Container(
+            constraints: BoxConstraints(maxHeight: maxHeight),
+            decoration: BoxDecoration(
+              color: isDark ? _darkBg : Colors.white,
+              borderRadius: const BorderRadius.vertical(
+                top: Radius.circular(24),
+              ),
+            ),
+            child: SafeArea(
+              top: false,
+              child: _PageUpdateModalContent(
+                isDark: isDark,
+                l10n: l10n,
+                currentPage: currentPage,
+                totalPages: totalPages,
+                readingDuration: readingDuration,
+                isTimerFlow: isTimerFlow,
+              ),
+            ),
           ),
-          decoration: BoxDecoration(
-            color: isDark ? _darkBg : Colors.white,
-            borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-          ),
-          child: _PageUpdateModalContent(
-            isDark: isDark,
-            pageController: pageController,
-            l10n: l10n,
-            currentPage: currentPage,
-            totalPages: totalPages,
-            readingDuration: readingDuration,
-            isTimerFlow: isTimerFlow,
-          ),
-        ),
-      ),
+        );
+      },
     );
 
     return result ?? PageUpdateResult.cancelled;
@@ -69,7 +78,6 @@ class PageUpdateModal {
 
 class _PageUpdateModalContent extends StatefulWidget {
   final bool isDark;
-  final TextEditingController pageController;
   final AppLocalizations l10n;
   final int? currentPage;
   final int? totalPages;
@@ -78,7 +86,6 @@ class _PageUpdateModalContent extends StatefulWidget {
 
   const _PageUpdateModalContent({
     required this.isDark,
-    required this.pageController,
     required this.l10n,
     this.currentPage,
     this.totalPages,
@@ -93,6 +100,7 @@ class _PageUpdateModalContent extends StatefulWidget {
 
 class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
   String? _errorText;
+  late final TextEditingController _pageController;
   late FixedExtentScrollController _wheelController;
   int _selectedPage = 0;
   bool _updatingFromWheel = false;
@@ -102,11 +110,13 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
     super.initState();
     final start = (widget.currentPage ?? 0) + 1;
     _selectedPage = start;
+    _pageController = TextEditingController();
     _wheelController = FixedExtentScrollController(initialItem: 0);
   }
 
   @override
   void dispose() {
+    _pageController.dispose();
     _wheelController.dispose();
     super.dispose();
   }
@@ -143,7 +153,7 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
   }
 
   void _handleUpdate() {
-    final pageText = widget.pageController.text.trim();
+    final pageText = _pageController.text.trim();
     final page = int.tryParse(pageText);
 
     if (page == null || page <= 0) return;
@@ -154,8 +164,10 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
       return;
     }
 
-    Navigator.of(context, rootNavigator: true)
-        .pop(PageUpdateResult(page: page));
+    Navigator.of(
+      context,
+      rootNavigator: true,
+    ).pop(PageUpdateResult(page: page));
   }
 
   Widget _buildDialPicker() {
@@ -191,7 +203,7 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
                 _updatingFromWheel = true;
                 setState(() {
                   _selectedPage = value;
-                  widget.pageController.text = value.toString();
+                  _pageController.text = value.toString();
                   _errorText = _validatePage(value.toString());
                 });
                 _updatingFromWheel = false;
@@ -232,196 +244,157 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
   Widget build(BuildContext context) {
     final hasPageInfo = widget.currentPage != null && widget.totalPages != null;
 
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Container(
-          width: 40,
-          height: 4,
-          decoration: BoxDecoration(
-            color: widget.isDark ? Colors.grey[700] : Colors.grey[300],
-            borderRadius: BorderRadius.circular(2),
-          ),
-        ),
-        const SizedBox(height: 24),
-        if (widget.readingDuration != null) ...[
+    return SingleChildScrollView(
+      key: const ValueKey('page-update-modal-scroll'),
+      padding: const EdgeInsets.fromLTRB(24, 24, 24, 24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
           Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            width: 40,
+            height: 4,
             decoration: BoxDecoration(
-              color: Colors.green.withValues(alpha: 0.15),
-              borderRadius: BorderRadius.circular(20),
-            ),
-            child: Text(
-              _formatReadingComplete(widget.readingDuration!),
-              style: const TextStyle(
-                fontSize: 14,
-                fontWeight: FontWeight.w600,
-                color: Colors.green,
-              ),
+              color: widget.isDark ? Colors.grey[700] : Colors.grey[300],
+              borderRadius: BorderRadius.circular(2),
             ),
           ),
           const SizedBox(height: 24),
-        ],
-        Text(
-          widget.l10n.pageUpdateDialogTitle,
-          style: TextStyle(
-            fontSize: 18,
-            fontWeight: FontWeight.bold,
-            color: widget.isDark ? Colors.white : Colors.black,
-          ),
-        ),
-        const SizedBox(height: 8),
-        if (hasPageInfo)
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text(
-                widget.l10n.currentPageLabel(widget.currentPage!),
+          if (widget.readingDuration != null) ...[
+            Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 8,
+              ),
+              decoration: BoxDecoration(
+                color: Colors.green.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Text(
+                _formatReadingComplete(widget.readingDuration!),
                 style: const TextStyle(
                   fontSize: 14,
                   fontWeight: FontWeight.w600,
-                  color: BLabColors.primary,
+                  color: Colors.green,
                 ),
               ),
-              const SizedBox(width: 6),
-              Text(
-                widget.l10n.totalPageLabel(widget.totalPages!),
-                style: TextStyle(
-                  fontSize: 14,
-                  color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
-                ),
-              ),
-            ],
-          )
-        else
+            ),
+            const SizedBox(height: 24),
+          ],
           Text(
-            widget.l10n.pageUpdateValidationRequired,
-            textAlign: TextAlign.center,
+            widget.l10n.pageUpdateDialogTitle,
             style: TextStyle(
-              fontSize: 14,
-              color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+              color: widget.isDark ? Colors.white : Colors.black,
             ),
           ),
-        if (hasPageInfo) ...[
-          const SizedBox(height: 20),
-          _buildDialPicker(),
-        ],
-        const SizedBox(height: 16),
-        TextField(
-          controller: widget.pageController,
-          keyboardType: TextInputType.number,
-          autofocus: !hasPageInfo,
-          textAlign: TextAlign.center,
-          onChanged: (value) {
-            setState(() {
-              _errorText = _validatePage(value);
-            });
-            if (!_updatingFromWheel) {
-              final parsed = int.tryParse(value);
-              if (parsed != null && parsed >= _minPage && parsed <= _maxPage) {
-                _selectedPage = parsed;
-                _wheelController.jumpToItem(parsed - _minPage);
+          const SizedBox(height: 8),
+          if (hasPageInfo)
+            Wrap(
+              alignment: WrapAlignment.center,
+              spacing: 6,
+              runSpacing: 4,
+              children: [
+                Text(
+                  widget.l10n.currentPageLabel(widget.currentPage!),
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: BLabColors.primary,
+                  ),
+                ),
+                Text(
+                  widget.l10n.totalPageLabel(widget.totalPages!),
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
+                  ),
+                ),
+              ],
+            )
+          else
+            Text(
+              widget.l10n.pageUpdateValidationRequired,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 14,
+                color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
+              ),
+            ),
+          if (hasPageInfo) ...[
+            const SizedBox(height: 20),
+            _buildDialPicker(),
+          ],
+          const SizedBox(height: 16),
+          BLabTextField(
+            key: const ValueKey('page-update-input'),
+            controller: _pageController,
+            keyboardType: TextInputType.number,
+            autofocus: !hasPageInfo,
+            textAlign: TextAlign.center,
+            onChanged: (value) {
+              setState(() {
+                _errorText = _validatePage(value);
+              });
+              if (!_updatingFromWheel) {
+                final parsed = int.tryParse(value);
+                if (parsed != null &&
+                    parsed >= _minPage &&
+                    parsed <= _maxPage) {
+                  _selectedPage = parsed;
+                  _wheelController.jumpToItem(parsed - _minPage);
+                }
               }
-            }
-          },
-          onSubmitted: (_) => _handleUpdate(),
-          style: TextStyle(
-            fontSize: 24,
-            fontWeight: FontWeight.bold,
-            color: widget.isDark ? Colors.white : Colors.black,
-          ),
-          decoration: InputDecoration(
+            },
+            onSubmitted: (_) => _handleUpdate(),
+            textStyle: TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.bold,
+              color: widget.isDark ? Colors.white : Colors.black,
+            ),
             hintText: hasPageInfo
                 ? '${widget.currentPage! + 1} ~ ${widget.totalPages}'
                 : widget.l10n.pageInputHint,
-            hintStyle: TextStyle(
-              color: widget.isDark ? Colors.grey[600] : Colors.grey[400],
-            ),
+            errorText: _errorText,
             suffixText: 'p',
             suffixStyle: TextStyle(
               fontSize: 20,
               fontWeight: FontWeight.w600,
-              color: widget.isDark ? Colors.grey[500] : Colors.grey[500],
+              color: Colors.grey[500],
             ),
-            errorText: _errorText,
-            border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(
-                color: widget.isDark
-                    ? Colors.white.withValues(alpha: 0.2)
-                    : Colors.black.withValues(alpha: 0.1),
-              ),
-            ),
-            focusedBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(12),
-              borderSide: BorderSide(
-                color: _errorText != null ? Colors.red : BLabColors.primary,
-                width: 2,
-              ),
-            ),
-            errorBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(12),
-              borderSide: const BorderSide(color: Colors.red, width: 2),
-            ),
-            focusedErrorBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(12),
-              borderSide: const BorderSide(color: Colors.red, width: 2),
-            ),
+            showClearButton: false,
           ),
-        ),
-        const SizedBox(height: 24),
-        SizedBox(
-          width: double.infinity,
-          child: GestureDetector(
-            onTap: _handleUpdate,
-            child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 16),
-              decoration: BoxDecoration(
-                color: BLabColors.primary,
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Text(
-                widget.l10n.pageUpdateButton,
-                textAlign: TextAlign.center,
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: Colors.white,
-                ),
-              ),
-            ),
+          const SizedBox(height: 24),
+          BLabButton(
+            key: const ValueKey('page-update-submit'),
+            text: widget.l10n.pageUpdateButton,
+            onPressed: _handleUpdate,
+            isFullWidth: true,
           ),
-        ),
-        const SizedBox(height: 8),
-        SizedBox(
-          width: double.infinity,
-          child: GestureDetector(
-            onTap: () {
+          const SizedBox(height: 8),
+          BLabButton(
+            key: const ValueKey('page-update-cancel'),
+            text: widget.isTimerFlow
+                ? widget.l10n.timerDidNotRead
+                : widget.l10n.commonCancel,
+            onPressed: () {
               if (widget.isTimerFlow) {
-                Navigator.of(context, rootNavigator: true)
-                    .pop(PageUpdateResult.notRead);
+                Navigator.of(
+                  context,
+                  rootNavigator: true,
+                ).pop(PageUpdateResult.notRead);
               } else {
-                Navigator.of(context, rootNavigator: true)
-                    .pop(PageUpdateResult.cancelled);
+                Navigator.of(
+                  context,
+                  rootNavigator: true,
+                ).pop(PageUpdateResult.cancelled);
               }
             },
-            child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 16),
-              child: Text(
-                widget.isTimerFlow
-                    ? widget.l10n.timerDidNotRead
-                    : widget.l10n.commonCancel,
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
-                  color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
-                ),
-              ),
-            ),
+            variant: BLabButtonVariant.secondary,
+            isFullWidth: true,
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/app/lib/ui/core/widgets/page_update_modal.dart
+++ b/app/lib/ui/core/widgets/page_update_modal.dart
@@ -110,7 +110,9 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
     super.initState();
     final start = (widget.currentPage ?? 0) + 1;
     _selectedPage = start;
-    _pageController = TextEditingController();
+    _pageController = TextEditingController(
+      text: widget.currentPage == null ? '' : start.toString(),
+    );
     _wheelController = FixedExtentScrollController(initialItem: 0);
   }
 
@@ -172,6 +174,7 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
 
   Widget _buildDialPicker() {
     return Container(
+      key: const ValueKey('page-update-dial'),
       height: 120,
       decoration: BoxDecoration(
         color: widget.isDark ? BLabColors.subtleDark : Colors.grey[100],
@@ -243,6 +246,7 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
   @override
   Widget build(BuildContext context) {
     final hasPageInfo = widget.currentPage != null && widget.totalPages != null;
+    final isLargeText = MediaQuery.textScalerOf(context).scale(1) >= 1.5;
 
     return SingleChildScrollView(
       key: const ValueKey('page-update-modal-scroll'),
@@ -321,7 +325,7 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
                 color: widget.isDark ? Colors.grey[400] : Colors.grey[600],
               ),
             ),
-          if (hasPageInfo) ...[
+          if (hasPageInfo && !isLargeText) ...[
             const SizedBox(height: 20),
             _buildDialPicker(),
           ],
@@ -355,8 +359,9 @@ class _PageUpdateModalContentState extends State<_PageUpdateModalContent> {
             hintText: hasPageInfo
                 ? '${widget.currentPage! + 1} ~ ${widget.totalPages}'
                 : widget.l10n.pageInputHint,
+            semanticLabel: widget.l10n.pageUpdateNewPageLabel,
             errorText: _errorText,
-            suffixText: 'p',
+            suffixText: widget.l10n.pageAbbreviation,
             suffixStyle: TextStyle(
               fontSize: 20,
               fontWeight: FontWeight.w600,

--- a/app/test/ui/core/widgets/page_update_modal_test.dart
+++ b/app/test/ui/core/widgets/page_update_modal_test.dart
@@ -20,73 +20,78 @@ void main() {
             'keyboard $keyboardInset',
             (tester) async {
               final semantics = tester.ensureSemantics();
-              await _pumpModalHarness(
-                tester,
-                locale: locale,
-                brightness: brightness,
-                width: width,
-                keyboardInset: keyboardInset,
-              );
+              try {
+                await _pumpModalHarness(
+                  tester,
+                  locale: locale,
+                  brightness: brightness,
+                  width: width,
+                  keyboardInset: keyboardInset,
+                );
 
-              await tester.tap(find.text('open'));
-              await tester.pumpAndSettle();
-
-              expect(tester.takeException(), isNull);
-              expect(
-                find.byKey(const ValueKey('page-update-modal-scroll')),
-                findsOneWidget,
-              );
-              expect(
-                find.byKey(const ValueKey('page-update-input')),
-                findsOneWidget,
-              );
-              expect(
-                find.byKey(const ValueKey('page-update-dial')),
-                findsNothing,
-              );
-
-              for (final key in const [
-                ValueKey('page-update-submit'),
-                ValueKey('page-update-cancel'),
-              ]) {
-                final action = find.byKey(key);
-                await tester.ensureVisible(action);
+                await tester.tap(find.text('open'));
                 await tester.pumpAndSettle();
-                expect(action.hitTestable(), findsOneWidget);
-                expect(tester.takeException(), isNull);
-              }
 
-              final updateLabel =
-                  locale.languageCode == 'ko' ? '업데이트' : 'Update';
-              final cancelLabel = locale.languageCode == 'ko' ? '취소' : 'Cancel';
-              final inputLabel =
-                  locale.languageCode == 'ko' ? '새 페이지 번호' : 'New Page Number';
-              final inputSemantics = find.bySemanticsLabel(
-                RegExp(inputLabel),
-              );
-              final inputNode = tester.getSemantics(inputSemantics);
-              expect(inputNode.label, contains(inputLabel));
-              expect(inputNode.flagsCollection.isTextField, isTrue);
-              expect(
-                inputNode.flagsCollection.isEnabled,
-                Tristate.isTrue,
-              );
-              expect(
-                inputNode.flagsCollection.isFocused,
-                isNot(Tristate.none),
-              );
-              final inputData = inputNode.getSemanticsData();
-              expect(inputData.hasAction(SemanticsAction.tap), isTrue);
-              expect(inputData.hasAction(SemanticsAction.focus), isTrue);
-              expect(
-                find.semantics.byLabel(updateLabel),
-                findsOneWidget,
-              );
-              expect(
-                find.semantics.byLabel(cancelLabel),
-                findsOneWidget,
-              );
-              semantics.dispose();
+                expect(tester.takeException(), isNull);
+                expect(
+                  find.byKey(const ValueKey('page-update-modal-scroll')),
+                  findsOneWidget,
+                );
+                expect(
+                  find.byKey(const ValueKey('page-update-input')),
+                  findsOneWidget,
+                );
+                expect(
+                  find.byKey(const ValueKey('page-update-dial')),
+                  findsNothing,
+                );
+
+                for (final key in const [
+                  ValueKey('page-update-submit'),
+                  ValueKey('page-update-cancel'),
+                ]) {
+                  final action = find.byKey(key);
+                  await tester.ensureVisible(action);
+                  await tester.pumpAndSettle();
+                  expect(action.hitTestable(), findsOneWidget);
+                  expect(tester.takeException(), isNull);
+                }
+
+                final updateLabel =
+                    locale.languageCode == 'ko' ? '업데이트' : 'Update';
+                final cancelLabel =
+                    locale.languageCode == 'ko' ? '취소' : 'Cancel';
+                final inputLabel = locale.languageCode == 'ko'
+                    ? '새 페이지 번호'
+                    : 'New Page Number';
+                final inputSemantics = find.bySemanticsLabel(
+                  RegExp(inputLabel),
+                );
+                final inputNode = tester.getSemantics(inputSemantics);
+                expect(inputNode.label, contains(inputLabel));
+                expect(inputNode.flagsCollection.isTextField, isTrue);
+                expect(
+                  inputNode.flagsCollection.isEnabled,
+                  Tristate.isTrue,
+                );
+                expect(
+                  inputNode.flagsCollection.isFocused,
+                  isNot(Tristate.none),
+                );
+                final inputData = inputNode.getSemanticsData();
+                expect(inputData.hasAction(SemanticsAction.tap), isTrue);
+                expect(inputData.hasAction(SemanticsAction.focus), isTrue);
+                expect(
+                  find.semantics.byLabel(updateLabel),
+                  findsOneWidget,
+                );
+                expect(
+                  find.semantics.byLabel(cancelLabel),
+                  findsOneWidget,
+                );
+              } finally {
+                semantics.dispose();
+              }
             },
           );
         }
@@ -101,52 +106,55 @@ void main() {
         (tester) async {
           PageUpdateResult? result;
           final semantics = tester.ensureSemantics();
-          await _pumpModalHarness(
-            tester,
-            locale: const Locale('en'),
-            brightness: Brightness.dark,
-            width: width,
-            keyboardInset: 280,
-            onResult: (value) => result = value,
-          );
+          try {
+            await _pumpModalHarness(
+              tester,
+              locale: const Locale('en'),
+              brightness: Brightness.dark,
+              width: width,
+              keyboardInset: 280,
+              onResult: (value) => result = value,
+            );
 
-          await tester.tap(find.text('open'));
-          await tester.pumpAndSettle();
+            await tester.tap(find.text('open'));
+            await tester.pumpAndSettle();
 
-          final input = find.descendant(
-            of: find.byKey(const ValueKey('page-update-input')),
-            matching: find.byType(TextField),
-          );
-          await tester.ensureVisible(input);
-          await tester.enterText(input, '$page');
-          await tester.pump();
+            final input = find.descendant(
+              of: find.byKey(const ValueKey('page-update-input')),
+              matching: find.byType(TextField),
+            );
+            await tester.ensureVisible(input);
+            await tester.enterText(input, '$page');
+            await tester.pump();
 
-          final inputNode = tester.getSemantics(
-            find.bySemanticsLabel(RegExp('New Page Number')),
-          );
-          expect(inputNode.label, contains('New Page Number'));
-          expect(inputNode.value, '$page');
-          expect(inputNode.flagsCollection.isTextField, isTrue);
-          expect(inputNode.flagsCollection.isFocused, Tristate.isTrue);
-          expect(
-            inputNode.getSemanticsData().hasAction(SemanticsAction.setText),
-            isTrue,
-          );
+            final inputNode = tester.getSemantics(
+              find.bySemanticsLabel(RegExp('New Page Number')),
+            );
+            expect(inputNode.label, contains('New Page Number'));
+            expect(inputNode.value, '$page');
+            expect(inputNode.flagsCollection.isTextField, isTrue);
+            expect(inputNode.flagsCollection.isFocused, Tristate.isTrue);
+            expect(
+              inputNode.getSemanticsData().hasAction(SemanticsAction.setText),
+              isTrue,
+            );
 
-          final submit = find.byKey(const ValueKey('page-update-submit'));
-          await tester.ensureVisible(submit);
-          await tester.pumpAndSettle();
-          await tester.tap(submit);
-          await tester.pumpAndSettle();
+            final submit = find.byKey(const ValueKey('page-update-submit'));
+            await tester.ensureVisible(submit);
+            await tester.pumpAndSettle();
+            await tester.tap(submit);
+            await tester.pumpAndSettle();
 
-          expect(result?.page, page);
-          expect(result?.didNotRead, isFalse);
-          expect(
-            find.byKey(const ValueKey('page-update-modal-scroll')),
-            findsNothing,
-          );
-          expect(tester.takeException(), isNull);
-          semantics.dispose();
+            expect(result?.page, page);
+            expect(result?.didNotRead, isFalse);
+            expect(
+              find.byKey(const ValueKey('page-update-modal-scroll')),
+              findsNothing,
+            );
+            expect(tester.takeException(), isNull);
+          } finally {
+            semantics.dispose();
+          }
         },
       );
     }

--- a/app/test/ui/core/widgets/page_update_modal_test.dart
+++ b/app/test/ui/core/widgets/page_update_modal_test.dart
@@ -1,4 +1,4 @@
-import 'dart:ui' show SemanticsAction, Tristate;
+import 'dart:ui' show SemanticsAction, SemanticsFlag;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -69,15 +69,9 @@ void main() {
                 );
                 final inputNode = tester.getSemantics(inputSemantics);
                 expect(inputNode.label, contains(inputLabel));
-                expect(inputNode.flagsCollection.isTextField, isTrue);
-                expect(
-                  inputNode.flagsCollection.isEnabled,
-                  Tristate.isTrue,
-                );
-                expect(
-                  inputNode.flagsCollection.isFocused,
-                  isNot(Tristate.none),
-                );
+                expect(inputNode.hasFlag(SemanticsFlag.isTextField), isTrue);
+                expect(inputNode.hasFlag(SemanticsFlag.isEnabled), isTrue);
+                expect(inputNode.hasFlag(SemanticsFlag.isFocusable), isTrue);
                 final inputData = inputNode.getSemanticsData();
                 expect(inputData.hasAction(SemanticsAction.tap), isTrue);
                 expect(inputData.hasAction(SemanticsAction.focus), isTrue);
@@ -132,8 +126,8 @@ void main() {
             );
             expect(inputNode.label, contains('New Page Number'));
             expect(inputNode.value, '$page');
-            expect(inputNode.flagsCollection.isTextField, isTrue);
-            expect(inputNode.flagsCollection.isFocused, Tristate.isTrue);
+            expect(inputNode.hasFlag(SemanticsFlag.isTextField), isTrue);
+            expect(inputNode.hasFlag(SemanticsFlag.isFocused), isTrue);
             expect(
               inputNode.getSemanticsData().hasAction(SemanticsAction.setText),
               isTrue,

--- a/app/test/ui/core/widgets/page_update_modal_test.dart
+++ b/app/test/ui/core/widgets/page_update_modal_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/core/widgets/page_update_modal.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  for (final locale in const [Locale('ko'), Locale('en')]) {
+    for (final brightness in Brightness.values) {
+      for (final width in const [320.0, 393.0]) {
+        for (final keyboardInset in const [0.0, 280.0]) {
+          testWidgets(
+            'actions remain reachable at 200 percent in '
+            '${locale.languageCode} ${brightness.name} ${width}px '
+            'keyboard $keyboardInset',
+            (tester) async {
+              final semantics = tester.ensureSemantics();
+              await _pumpModalHarness(
+                tester,
+                locale: locale,
+                brightness: brightness,
+                width: width,
+                keyboardInset: keyboardInset,
+              );
+
+              await tester.tap(find.text('open'));
+              await tester.pumpAndSettle();
+
+              expect(tester.takeException(), isNull);
+              expect(
+                find.byKey(const ValueKey('page-update-modal-scroll')),
+                findsOneWidget,
+              );
+              expect(
+                find.byKey(const ValueKey('page-update-input')),
+                findsOneWidget,
+              );
+
+              for (final key in const [
+                ValueKey('page-update-submit'),
+                ValueKey('page-update-cancel'),
+              ]) {
+                final action = find.byKey(key);
+                await tester.ensureVisible(action);
+                await tester.pumpAndSettle();
+                expect(action.hitTestable(), findsOneWidget);
+                expect(tester.takeException(), isNull);
+              }
+
+              final updateLabel =
+                  locale.languageCode == 'ko' ? '업데이트' : 'Update';
+              final cancelLabel = locale.languageCode == 'ko' ? '취소' : 'Cancel';
+              expect(
+                find.semantics.byLabel(updateLabel),
+                findsOneWidget,
+              );
+              expect(
+                find.semantics.byLabel(cancelLabel),
+                findsOneWidget,
+              );
+              semantics.dispose();
+            },
+          );
+        }
+      }
+    }
+  }
+
+  testWidgets('direct input submits while the keyboard inset is visible',
+      (tester) async {
+    PageUpdateResult? result;
+    await _pumpModalHarness(
+      tester,
+      locale: const Locale('en'),
+      brightness: Brightness.dark,
+      width: 320,
+      keyboardInset: 280,
+      onResult: (value) => result = value,
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    final input = find.descendant(
+      of: find.byKey(const ValueKey('page-update-input')),
+      matching: find.byType(TextField),
+    );
+    await tester.ensureVisible(input);
+    await tester.enterText(input, '12');
+    await tester.pump();
+
+    final submit = find.byKey(const ValueKey('page-update-submit'));
+    await tester.ensureVisible(submit);
+    await tester.pumpAndSettle();
+    await tester.tap(submit);
+    await tester.pumpAndSettle();
+
+    expect(result?.page, 12);
+    expect(result?.didNotRead, isFalse);
+    expect(
+        find.byKey(const ValueKey('page-update-modal-scroll')), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Future<void> _pumpModalHarness(
+  WidgetTester tester, {
+  required Locale locale,
+  required Brightness brightness,
+  required double width,
+  required double keyboardInset,
+  ValueChanged<PageUpdateResult>? onResult,
+}) async {
+  tester.view.physicalSize = Size(width, 720);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: locale,
+      theme: ThemeData.light(),
+      darkTheme: ThemeData.dark(),
+      themeMode:
+          brightness == Brightness.dark ? ThemeMode.dark : ThemeMode.light,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(
+          textScaler: const TextScaler.linear(2),
+          viewInsets: EdgeInsets.only(bottom: keyboardInset),
+          viewPadding: const EdgeInsets.only(bottom: 34),
+        ),
+        child: child!,
+      ),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => TextButton(
+            onPressed: () async {
+              final result = await PageUpdateModal.show(
+                context: context,
+                currentPage: 0,
+                totalPages: 144,
+              );
+              onResult?.call(result);
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}

--- a/app/test/ui/core/widgets/page_update_modal_test.dart
+++ b/app/test/ui/core/widgets/page_update_modal_test.dart
@@ -71,7 +71,6 @@ void main() {
                 expect(inputNode.label, contains(inputLabel));
                 expect(inputNode.hasFlag(SemanticsFlag.isTextField), isTrue);
                 expect(inputNode.hasFlag(SemanticsFlag.isEnabled), isTrue);
-                expect(inputNode.hasFlag(SemanticsFlag.isFocusable), isTrue);
                 final inputData = inputNode.getSemanticsData();
                 expect(inputData.hasAction(SemanticsAction.tap), isTrue);
                 expect(inputData.hasAction(SemanticsAction.focus), isTrue);

--- a/app/test/ui/core/widgets/page_update_modal_test.dart
+++ b/app/test/ui/core/widgets/page_update_modal_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show SemanticsAction, Tristate;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -38,6 +40,10 @@ void main() {
                 find.byKey(const ValueKey('page-update-input')),
                 findsOneWidget,
               );
+              expect(
+                find.byKey(const ValueKey('page-update-dial')),
+                findsNothing,
+              );
 
               for (final key in const [
                 ValueKey('page-update-submit'),
@@ -53,6 +59,25 @@ void main() {
               final updateLabel =
                   locale.languageCode == 'ko' ? '업데이트' : 'Update';
               final cancelLabel = locale.languageCode == 'ko' ? '취소' : 'Cancel';
+              final inputLabel =
+                  locale.languageCode == 'ko' ? '새 페이지 번호' : 'New Page Number';
+              final inputSemantics = find.bySemanticsLabel(
+                RegExp(inputLabel),
+              );
+              final inputNode = tester.getSemantics(inputSemantics);
+              expect(inputNode.label, contains(inputLabel));
+              expect(inputNode.flagsCollection.isTextField, isTrue);
+              expect(
+                inputNode.flagsCollection.isEnabled,
+                Tristate.isTrue,
+              );
+              expect(
+                inputNode.flagsCollection.isFocused,
+                isNot(Tristate.none),
+              );
+              final inputData = inputNode.getSemanticsData();
+              expect(inputData.hasAction(SemanticsAction.tap), isTrue);
+              expect(inputData.hasAction(SemanticsAction.focus), isTrue);
               expect(
                 find.semantics.byLabel(updateLabel),
                 findsOneWidget,
@@ -69,15 +94,73 @@ void main() {
     }
   }
 
-  testWidgets('direct input submits while the keyboard inset is visible',
+  for (final width in const [320.0, 393.0]) {
+    for (final page in const [12, 108]) {
+      testWidgets(
+        'direct input submits $page at ${width}px with keyboard visible',
+        (tester) async {
+          PageUpdateResult? result;
+          final semantics = tester.ensureSemantics();
+          await _pumpModalHarness(
+            tester,
+            locale: const Locale('en'),
+            brightness: Brightness.dark,
+            width: width,
+            keyboardInset: 280,
+            onResult: (value) => result = value,
+          );
+
+          await tester.tap(find.text('open'));
+          await tester.pumpAndSettle();
+
+          final input = find.descendant(
+            of: find.byKey(const ValueKey('page-update-input')),
+            matching: find.byType(TextField),
+          );
+          await tester.ensureVisible(input);
+          await tester.enterText(input, '$page');
+          await tester.pump();
+
+          final inputNode = tester.getSemantics(
+            find.bySemanticsLabel(RegExp('New Page Number')),
+          );
+          expect(inputNode.label, contains('New Page Number'));
+          expect(inputNode.value, '$page');
+          expect(inputNode.flagsCollection.isTextField, isTrue);
+          expect(inputNode.flagsCollection.isFocused, Tristate.isTrue);
+          expect(
+            inputNode.getSemanticsData().hasAction(SemanticsAction.setText),
+            isTrue,
+          );
+
+          final submit = find.byKey(const ValueKey('page-update-submit'));
+          await tester.ensureVisible(submit);
+          await tester.pumpAndSettle();
+          await tester.tap(submit);
+          await tester.pumpAndSettle();
+
+          expect(result?.page, page);
+          expect(result?.didNotRead, isFalse);
+          expect(
+            find.byKey(const ValueKey('page-update-modal-scroll')),
+            findsNothing,
+          );
+          expect(tester.takeException(), isNull);
+          semantics.dispose();
+        },
+      );
+    }
+  }
+
+  testWidgets('default next page submits without wheel interaction',
       (tester) async {
     PageUpdateResult? result;
     await _pumpModalHarness(
       tester,
-      locale: const Locale('en'),
+      locale: const Locale('ko'),
       brightness: Brightness.dark,
       width: 320,
-      keyboardInset: 280,
+      keyboardInset: 0,
       onResult: (value) => result = value,
     );
 
@@ -88,20 +171,15 @@ void main() {
       of: find.byKey(const ValueKey('page-update-input')),
       matching: find.byType(TextField),
     );
-    await tester.ensureVisible(input);
-    await tester.enterText(input, '12');
-    await tester.pump();
+    expect(tester.widget<TextField>(input).controller?.text, '1');
 
-    final submit = find.byKey(const ValueKey('page-update-submit'));
-    await tester.ensureVisible(submit);
-    await tester.pumpAndSettle();
-    await tester.tap(submit);
+    await tester
+        .ensureVisible(find.byKey(const ValueKey('page-update-submit')));
+    await tester.tap(find.byKey(const ValueKey('page-update-submit')));
     await tester.pumpAndSettle();
 
-    expect(result?.page, 12);
+    expect(result?.page, 1);
     expect(result?.didNotRead, isFalse);
-    expect(
-        find.byKey(const ValueKey('page-update-modal-scroll')), findsNothing);
     expect(tester.takeException(), isNull);
   });
 }


### PR DESCRIPTION
## 목적

대형 글자와 소프트웨어 키보드가 함께 활성화된 페이지 수정 모달에서 입력과 액션이 잘리던 BOK-386을 해결합니다.

## 주요 변경

- 키보드 inset을 반영한 최대 높이와 스크롤 가능한 모달 구조 적용
- 페이지 직접 입력을 공통 BLabTextField로 통합하고 숫자 입력·검증·제출 지원
- 200% 글자 크기에서는 다자리 숫자가 잘리던 중복 휠을 숨기고 직접 입력에 집중
- 기본 다음 페이지 제출, 현지화된 페이지 단위, VoiceOver 입력 이름·역할·값·동작 보장
- Update/Cancel을 전체 너비 BLabButton으로 교체

## 배경

BOK-382 실제 iPhone 17e 접근성 대형 글자 검증에서 페이지 수정 시트가 키보드 전후로 넘쳐 Update와 Cancel에 정상 도달하기 어려웠습니다. 초기 리뷰에서 다자리 휠 잘림, 기본값 무조작 제출 실패, VoiceOver 의미 정보와 페이지 단위 현지화 누락도 발견해 함께 교정했습니다.

## 검증

- 변경 파일 flutter analyze: 통과
- 페이지 수정 모달 집중 테스트: 21/21 통과
- 전체 Flutter 테스트: 447/447 통과
- 16조합: ko/en × light/dark × 320/393px × 200% 글자 × 키보드 hidden/visible
- 직접 입력: 12/108 × 320/393px, VoiceOver text-field/focus/setText/value 검증
- iPhone 17e dev, 영어 다크, 200% 글자: 키보드 전후 Update/Cancel 도달, 기본값 13 제출, 13/108p 저장 확인
- 전체 analyzer: info 136건(기존 132건 + Flutter 3.35 호환 테스트의 deprecated API info 4건), 오류·경고 없음

## 관련 이슈

- BOK-386

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded text-field options, including keyboard behavior, validation, styling, suffix text, change/submission callbacks, and optional clear buttons.
  * Added accessible semantic labels for text fields.
  * Improved page-update modal layout with scrolling, safe-area support, keyboard-aware spacing, and design-system controls.
  * Added localized page abbreviations for English and Korean.

* **Bug Fixes**
  * Improved page-number submission, default-page handling, validation, and modal dismissal behavior across screen sizes, themes, locales, and text scales.

* **Tests**
  * Added comprehensive coverage for accessibility, scrolling, keyboard insets, localization, and modal results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
