### PR TITLE
fix(mobile): make completion prompt accessible

### DIFF
--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -36,6 +36,7 @@ import 'widgets/sheets/daily_target_confirm_sheet.dart';
 import 'widgets/sheets/delete_confirmation_sheet.dart';
 import 'widgets/sheets/image_source_sheet.dart';
 import 'widgets/sheets/book_info_sheet.dart';
+import 'widgets/sheets/book_review_prompt_sheet.dart';
 // import 'widgets/sheets/full_title_sheet.dart';
 import 'widgets/sheets/pause_reading_confirmation_sheet.dart';
 import 'widgets/dialogs/edit_planned_book_dialog.dart';
@@ -747,127 +748,16 @@ class _BookDetailContentState extends State<_BookDetailContent>
   }
 
   /// 독후감 작성 유도 바텀시트
-  void _showBookReviewPromptSheet(BookDetailViewModel bookVm) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
+  Future<void> _showBookReviewPromptSheet(BookDetailViewModel bookVm) async {
     final book = bookVm.currentBook;
-
-    showModalBottomSheet(
+    final shouldWriteReview = await showBookReviewPromptSheet(
       context: context,
-      backgroundColor: Colors.transparent,
-      isDismissible: true,
-      builder: (bottomSheetContext) => Container(
-        padding: const EdgeInsets.all(24),
-        decoration: BoxDecoration(
-          color: isDark ? BLabColors.surfaceDark : Colors.white,
-          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Container(
-              width: 40,
-              height: 4,
-              margin: const EdgeInsets.only(bottom: 20),
-              decoration: BoxDecoration(
-                color: Colors.grey[400],
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-            const Text(
-              '🎉',
-              style: TextStyle(fontSize: 48),
-            ),
-            const SizedBox(height: 12),
-            Text(
-              'Congratulations!',
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 22,
-                color: isDark ? Colors.white : Colors.black,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              book.title,
-              style: TextStyle(
-                fontSize: 15,
-                color: isDark ? Colors.grey[400] : Colors.grey[600],
-              ),
-              textAlign: TextAlign.center,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-            ),
-            const SizedBox(height: 20),
-            Text(
-              'Would you like to write a review?',
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                fontSize: 15,
-                color: isDark ? Colors.grey[300] : Colors.grey[700],
-                height: 1.5,
-              ),
-            ),
-            const SizedBox(height: 24),
-            Row(
-              children: [
-                Expanded(
-                  child: GestureDetector(
-                    onTap: () => Navigator.pop(bottomSheetContext),
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(vertical: 14),
-                      decoration: BoxDecoration(
-                        color: isDark ? Colors.grey[800] : Colors.grey[200],
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: Center(
-                        child: Text(
-                          AppLocalizations.of(context).bookDetailLater,
-                          style: TextStyle(
-                            fontSize: 15,
-                            fontWeight: FontWeight.w600,
-                            color: isDark ? Colors.grey[300] : Colors.grey[700],
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  flex: 2,
-                  child: GestureDetector(
-                    onTap: () {
-                      Navigator.pop(bottomSheetContext);
-                      _navigateToBookReview(context, book);
-                    },
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(vertical: 14),
-                      decoration: BoxDecoration(
-                        color: BLabColors.primary,
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: Center(
-                        child: Text(
-                          AppLocalizations.of(context).bookDetailTabReview,
-                          style: const TextStyle(
-                            fontSize: 15,
-                            fontWeight: FontWeight.w600,
-                            color: Colors.white,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            SizedBox(
-              height: MediaQuery.of(bottomSheetContext).padding.bottom + 8,
-            ),
-          ],
-        ),
-      ),
+      bookTitle: book.title,
     );
+
+    if (shouldWriteReview && mounted) {
+      await _navigateToBookReview(context, book);
+    }
   }
 
   void _showDailyTargetChangeDialog(BookDetailViewModel bookVm) async {

--- a/app/lib/ui/book_detail/widgets/sheets/book_review_prompt_sheet.dart
+++ b/app/lib/ui/book_detail/widgets/sheets/book_review_prompt_sheet.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/core/theme/design_system.dart';
+import 'package:book_golas/ui/core/widgets/liquid_glass_button.dart';
+
+Future<bool> showBookReviewPromptSheet({
+  required BuildContext context,
+  required String bookTitle,
+}) async {
+  final result = await showModalBottomSheet<bool>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    isDismissible: true,
+    enableDrag: true,
+    builder: (sheetContext) {
+      final mediaQuery = MediaQuery.of(sheetContext);
+      final keyboardInset = mediaQuery.viewInsets.bottom;
+      final maxHeight =
+          (mediaQuery.size.height - keyboardInset - mediaQuery.padding.top)
+              .clamp(0.0, mediaQuery.size.height)
+              .toDouble();
+
+      return AnimatedPadding(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOutCubic,
+        padding: EdgeInsets.only(bottom: keyboardInset),
+        child: Container(
+          constraints: BoxConstraints(maxHeight: maxHeight),
+          decoration: BoxDecoration(
+            color: BLabColors.surface(sheetContext),
+            borderRadius: const BorderRadius.vertical(
+              top: Radius.circular(24),
+            ),
+          ),
+          child: SafeArea(
+            top: false,
+            child: _BookReviewPromptContent(bookTitle: bookTitle),
+          ),
+        ),
+      );
+    },
+  );
+
+  return result ?? false;
+}
+
+class _BookReviewPromptContent extends StatelessWidget {
+  final String bookTitle;
+
+  const _BookReviewPromptContent({required this.bookTitle});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final textTheme = Theme.of(context).textTheme;
+    final isLargeText = MediaQuery.textScalerOf(context).scale(1) >= 1.5;
+
+    return SingleChildScrollView(
+      key: const ValueKey('book-review-prompt-scroll'),
+      padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ExcludeSemantics(
+            child: Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: BLabColors.grey(400, context),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          const ExcludeSemantics(
+            child: Text('🎉', style: TextStyle(fontSize: 48)),
+          ),
+          const SizedBox(height: 12),
+          Semantics(
+            header: true,
+            child: Text(
+              l10n.bookDetailCompletionCongrats,
+              textAlign: TextAlign.center,
+              style: textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: BLabColors.textPrimary(context),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            bookTitle,
+            textAlign: TextAlign.center,
+            style: textTheme.titleMedium?.copyWith(
+              color: BLabColors.textSecondary(context),
+            ),
+          ),
+          const SizedBox(height: 20),
+          Text(
+            l10n.bookDetailCompletionPrompt,
+            textAlign: TextAlign.center,
+            style: textTheme.bodyLarge?.copyWith(
+              color: BLabColors.textSecondary(context),
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 24),
+          if (isLargeText)
+            Column(
+              children: [
+                BLabButton(
+                  key: const ValueKey('book-review-prompt-write'),
+                  text: l10n.bookDetailWriteReview,
+                  onPressed: () => Navigator.pop(context, true),
+                  isFullWidth: true,
+                ),
+                const SizedBox(height: 8),
+                BLabButton(
+                  key: const ValueKey('book-review-prompt-later'),
+                  text: l10n.bookDetailLater,
+                  onPressed: () => Navigator.pop(context, false),
+                  variant: BLabButtonVariant.secondary,
+                  isFullWidth: true,
+                ),
+              ],
+            )
+          else
+            Row(
+              children: [
+                Expanded(
+                  child: BLabButton(
+                    key: const ValueKey('book-review-prompt-later'),
+                    text: l10n.bookDetailLater,
+                    onPressed: () => Navigator.pop(context, false),
+                    variant: BLabButtonVariant.secondary,
+                    isFullWidth: true,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  flex: 2,
+                  child: BLabButton(
+                    key: const ValueKey('book-review-prompt-write'),
+                    text: l10n.bookDetailWriteReview,
+                    onPressed: () => Navigator.pop(context, true),
+                    isFullWidth: true,
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/test/ui/book_detail/widgets/book_review_prompt_sheet_test.dart
+++ b/app/test/ui/book_detail/widgets/book_review_prompt_sheet_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_detail/widgets/sheets/book_review_prompt_sheet.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  for (final locale in const [Locale('ko'), Locale('en')]) {
+    for (final brightness in Brightness.values) {
+      for (final width in const [320.0, 393.0]) {
+        testWidgets(
+          'completion prompt remains reachable at 200 percent in '
+          '${locale.languageCode} ${brightness.name} ${width}px',
+          (tester) async {
+            await _pumpSheetHarness(
+              tester,
+              locale: locale,
+              brightness: brightness,
+              width: width,
+            );
+
+            await tester.tap(find.text('open'));
+            await tester.pumpAndSettle();
+
+            final expectedTitle = locale.languageCode == 'ko'
+                ? '완독을 축하합니다!'
+                : 'Congratulations on finishing!';
+            final expectedPrompt = locale.languageCode == 'ko'
+                ? '독서의 여운이 남아있을 때\n독후감을 작성해보시겠어요?'
+                : 'While the afterglow of reading is still fresh,\n'
+                    'would you like to write a review?';
+            final laterLabel = locale.languageCode == 'ko' ? '나중에' : 'Later';
+            final reviewLabel =
+                locale.languageCode == 'ko' ? '독후감 쓰러가기' : 'Write Review';
+
+            expect(tester.takeException(), isNull);
+            expect(
+              find.byKey(const ValueKey('book-review-prompt-scroll')),
+              findsOneWidget,
+            );
+            expect(find.text(expectedTitle), findsOneWidget);
+            expect(find.text(expectedPrompt), findsOneWidget);
+            expect(find.text(_bookTitle), findsOneWidget);
+
+            for (final key in const [
+              ValueKey('book-review-prompt-write'),
+              ValueKey('book-review-prompt-later'),
+            ]) {
+              final action = find.byKey(key);
+              await tester.ensureVisible(action);
+              await tester.pumpAndSettle();
+              expect(action.hitTestable(), findsOneWidget);
+              expect(tester.takeException(), isNull);
+            }
+
+            expect(find.semantics.byLabel(reviewLabel), findsOneWidget);
+            expect(find.semantics.byLabel(laterLabel), findsOneWidget);
+          },
+        );
+      }
+    }
+  }
+
+  testWidgets('later closes the prompt without opening a review',
+      (tester) async {
+    bool? shouldWriteReview;
+    await _pumpSheetHarness(
+      tester,
+      locale: const Locale('ko'),
+      brightness: Brightness.light,
+      width: 320,
+      onResult: (value) => shouldWriteReview = value,
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('book-review-prompt-later')),
+    );
+    await tester.tap(find.byKey(const ValueKey('book-review-prompt-later')));
+    await tester.pumpAndSettle();
+
+    expect(shouldWriteReview, isFalse);
+    expect(
+      find.byKey(const ValueKey('book-review-prompt-scroll')),
+      findsNothing,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('write review closes the prompt with a positive result',
+      (tester) async {
+    bool? shouldWriteReview;
+    await _pumpSheetHarness(
+      tester,
+      locale: const Locale('en'),
+      brightness: Brightness.dark,
+      width: 393,
+      onResult: (value) => shouldWriteReview = value,
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('book-review-prompt-write')),
+    );
+    await tester.tap(find.byKey(const ValueKey('book-review-prompt-write')));
+    await tester.pumpAndSettle();
+
+    expect(shouldWriteReview, isTrue);
+    expect(
+      find.byKey(const ValueKey('book-review-prompt-scroll')),
+      findsNothing,
+    );
+    expect(tester.takeException(), isNull);
+  });
+}
+
+const _bookTitle =
+    'A Very Long Book Title That Must Remain Available Without Truncation';
+
+Future<void> _pumpSheetHarness(
+  WidgetTester tester, {
+  required Locale locale,
+  required Brightness brightness,
+  required double width,
+  ValueChanged<bool>? onResult,
+}) async {
+  tester.view.physicalSize = Size(width, 720);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: locale,
+      theme: ThemeData.light(),
+      darkTheme: ThemeData.dark(),
+      themeMode:
+          brightness == Brightness.dark ? ThemeMode.dark : ThemeMode.light,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(
+          textScaler: const TextScaler.linear(2),
+          viewPadding: const EdgeInsets.only(bottom: 34),
+        ),
+        child: child!,
+      ),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => TextButton(
+            onPressed: () async {
+              final result = await showBookReviewPromptSheet(
+                context: context,
+                bookTitle: _bookTitle,
+              );
+              onResult?.call(result);
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}


### PR DESCRIPTION
## 목적

대형 글자에서 완독 축하·독후감 유도 시트가 화면 아래로 넘쳐 다음 행동을 선택할 수 없는 BOK-387을 수정합니다.

## 주요 변경

- 완독 안내를 화면 높이와 키보드 inset을 고려하는 스크롤 가능한 전용 시트로 분리
- 150% 이상 글자 배율에서 독후감 쓰기·나중에 액션을 세로 배치
- 기존 한국어·영어 현지화 문구와 BLab 버튼·의미 기반 제목을 적용
- 시트 결과를 명시적으로 반환해 독후감 화면 이동과 닫기 동작을 분리
- ko/en × light/dark × 320/393px × 200% 및 두 액션 회귀 테스트 추가

## 배경

실제 iPhone 17e accessibility-large 완독 흐름에서 기존 고정 높이 Column이 158px 오버플로되어 제목과 선택 버튼이 잘렸습니다.

## 검증

- 전체 Flutter 테스트: 457/457 통과
- 집중 완독 시트 테스트: 10/10 통과
- 실제 iPhone 17e dev, accessibility-large: RenderFlex overflow 없이 전체 문구·버튼 표시
- 실제 독후감 쓰기 → Book Review 이동, 나중에 → 모달 닫기 후 완독 상세 유지
- git diff --check 통과
- repository-wide analyze: 신규 error/warning 없음, 기존 info 136건

## 관련 이슈

- BOK-387

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store