### PR TITLE
fix(mobile): prevent completed card overflow at large text

### DIFF
--- a/app/lib/ui/book_list/widgets/completed_book_card.dart
+++ b/app/lib/ui/book_list/widgets/completed_book_card.dart
@@ -96,6 +96,12 @@ class _CompletedBookCardState extends State<CompletedBookCard> {
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final l10n = AppLocalizations.of(context);
+    final isLargeText = MediaQuery.textScalerOf(context).scale(1) >= 1.5;
+    final completionBackgroundColor = isDark
+        ? BLabColors.success.withValues(alpha: 0.18)
+        : BLabColors.successBg;
+    final completionForegroundColor =
+        isDark ? BLabColors.success : BLabColors.textPrimaryLight;
 
     final completedDate = widget.book.updatedAt ?? DateTime.now();
     final daysToComplete =
@@ -118,6 +124,9 @@ class _CompletedBookCardState extends State<CompletedBookCard> {
           ],
         ),
         child: Row(
+          crossAxisAlignment: isLargeText
+              ? CrossAxisAlignment.start
+              : CrossAxisAlignment.center,
           children: [
             Container(
               width: 60,
@@ -158,127 +167,197 @@ class _CompletedBookCardState extends State<CompletedBookCard> {
                     runSpacing: 6,
                     children: [
                       Container(
+                        key: const Key('completedBookCompletionBadge'),
+                        width: isLargeText ? double.infinity : null,
                         padding: const EdgeInsets.symmetric(
                             horizontal: 10, vertical: 6),
                         decoration: BoxDecoration(
-                          color: BLabColors.success.withValues(alpha: 0.1),
+                          color: completionBackgroundColor,
                           borderRadius: BorderRadius.circular(8),
                         ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            const Icon(
-                              CupertinoIcons.checkmark_seal_fill,
-                              size: 14,
-                              color: BLabColors.success,
-                            ),
-                            const SizedBox(width: 6),
-                            Text(
-                              daysToComplete > 0
-                                  ? l10n.bookListCompletedIn(daysToComplete)
-                                  : l10n.bookListCompletedSameDay,
-                              style: const TextStyle(
-                                fontSize: 12,
-                                fontWeight: FontWeight.w600,
-                                color: BLabColors.success,
-                              ),
-                            ),
-                          ],
+                        child: _buildBadgeContent(
+                          icon: CupertinoIcons.checkmark_seal_fill,
+                          label: daysToComplete > 0
+                              ? l10n.bookListCompletedIn(daysToComplete)
+                              : l10n.bookListCompletedSameDay,
+                          color: completionForegroundColor,
+                          isLargeText: isLargeText,
+                          iconSize: 14,
+                          fontSize: 12,
+                          spacing: 6,
                         ),
                       ),
                       if (_achievementRate != null)
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 10, vertical: 6),
-                          decoration: BoxDecoration(
-                            color: _achievementRate! >= 80
-                                ? BLabColors.successBg
-                                : _achievementRate! >= 50
-                                    ? BLabColors.amber
-                                    : BLabColors.errorBg,
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Icon(
-                                _achievementRate! >= 80
-                                    ? CupertinoIcons.star_fill
-                                    : _achievementRate! >= 50
-                                        ? CupertinoIcons.hand_thumbsup_fill
-                                        : CupertinoIcons.flame_fill,
-                                size: 12,
-                                color: _achievementRate! >= 80
-                                    ? BLabColors.success
-                                    : _achievementRate! >= 50
-                                        ? BLabColors.dangerAlt
-                                        : BLabColors.danger,
-                              ),
-                              const SizedBox(width: 4),
-                              Text(
-                                l10n.bookListAchievementRate(_achievementRate!),
-                                style: TextStyle(
-                                  fontSize: 11,
-                                  fontWeight: FontWeight.w600,
-                                  color: _achievementRate! >= 80
-                                      ? BLabColors.success
-                                      : _achievementRate! >= 50
-                                          ? BLabColors.dangerAlt
-                                          : BLabColors.danger,
-                                ),
-                              ),
-                            ],
-                          ),
+                        CompletedBookAchievementBadge(
+                          rate: _achievementRate!,
                         ),
                     ],
                   ),
                   const SizedBox(height: 6),
-                  Row(
-                    children: [
-                      Icon(
-                        CupertinoIcons.book_fill,
-                        size: 12,
-                        color: isDark ? Colors.grey[500] : Colors.grey[400],
-                      ),
-                      const SizedBox(width: 4),
-                      Text(
-                        '${widget.book.totalPages} ${l10n.unitPages}',
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: isDark ? Colors.grey[400] : Colors.grey[600],
+                  if (isLargeText)
+                    Column(
+                      children: [
+                        _buildMetadataItem(
+                          icon: CupertinoIcons.book_fill,
+                          label: '${widget.book.totalPages} ${l10n.unitPages}',
+                          isDark: isDark,
+                          isExpanded: true,
                         ),
-                      ),
-                      const SizedBox(width: 12),
-                      Icon(
-                        CupertinoIcons.checkmark_circle_fill,
-                        size: 12,
-                        color: isDark ? Colors.grey[500] : Colors.grey[400],
-                      ),
-                      const SizedBox(width: 4),
-                      Flexible(
-                        child: Text(
-                          l10n.bookListCompletedDate(
+                        const SizedBox(height: 6),
+                        _buildMetadataItem(
+                          icon: CupertinoIcons.checkmark_circle_fill,
+                          label: l10n.bookListCompletedDate(
                               '${completedDate.year}.${completedDate.month.toString().padLeft(2, '0')}.${completedDate.day.toString().padLeft(2, '0')}'),
-                          style: TextStyle(
-                            fontSize: 12,
-                            color: isDark ? Colors.grey[400] : Colors.grey[600],
-                          ),
-                          overflow: TextOverflow.ellipsis,
+                          isDark: isDark,
+                          isExpanded: true,
                         ),
-                      ),
-                    ],
-                  ),
+                      ],
+                    )
+                  else
+                    Row(
+                      children: [
+                        _buildMetadataItem(
+                          icon: CupertinoIcons.book_fill,
+                          label: '${widget.book.totalPages} ${l10n.unitPages}',
+                          isDark: isDark,
+                        ),
+                        const SizedBox(width: 12),
+                        Flexible(
+                          child: _buildMetadataItem(
+                            icon: CupertinoIcons.checkmark_circle_fill,
+                            label: l10n.bookListCompletedDate(
+                                '${completedDate.year}.${completedDate.month.toString().padLeft(2, '0')}.${completedDate.day.toString().padLeft(2, '0')}'),
+                            isDark: isDark,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ),
                 ],
               ),
             ),
-            Icon(
-              CupertinoIcons.chevron_right,
-              color: isDark ? Colors.grey[600] : Colors.grey[400],
-              size: 18,
+            Padding(
+              padding: EdgeInsets.only(top: isLargeText ? 4 : 0),
+              child: Icon(
+                CupertinoIcons.chevron_right,
+                color: isDark ? Colors.grey[600] : Colors.grey[400],
+                size: 18,
+              ),
             ),
           ],
         ),
       ),
     );
   }
+
+  Widget _buildMetadataItem({
+    required IconData icon,
+    required String label,
+    required bool isDark,
+    bool isExpanded = false,
+    TextOverflow? overflow,
+  }) {
+    final text = Text(
+      label,
+      style: TextStyle(
+        fontSize: 12,
+        color: isDark ? Colors.grey[400] : Colors.grey[600],
+      ),
+      overflow: overflow,
+    );
+
+    return Row(
+      mainAxisSize: isExpanded ? MainAxisSize.max : MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 2),
+          child: Icon(
+            icon,
+            size: 12,
+            color: isDark ? Colors.grey[500] : Colors.grey[400],
+          ),
+        ),
+        const SizedBox(width: 4),
+        if (isExpanded)
+          Expanded(child: text)
+        else if (overflow != null)
+          Flexible(child: text)
+        else
+          text,
+      ],
+    );
+  }
+}
+
+class CompletedBookAchievementBadge extends StatelessWidget {
+  final int rate;
+
+  const CompletedBookAchievementBadge({
+    super.key,
+    required this.rate,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final isLargeText = MediaQuery.textScalerOf(context).scale(1) >= 1.5;
+    final backgroundColor = rate >= 80
+        ? BLabColors.successBg
+        : rate >= 50
+            ? BLabColors.amber
+            : BLabColors.errorBg;
+    final icon = rate >= 80
+        ? CupertinoIcons.star_fill
+        : rate >= 50
+            ? CupertinoIcons.hand_thumbsup_fill
+            : CupertinoIcons.flame_fill;
+
+    return Container(
+      key: const Key('completedBookAchievementBadge'),
+      width: isLargeText ? double.infinity : null,
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: _buildBadgeContent(
+        icon: icon,
+        label: l10n.bookListAchievementRate(rate),
+        color: BLabColors.textPrimaryLight,
+        isLargeText: isLargeText,
+        iconSize: 12,
+        fontSize: 11,
+        spacing: 4,
+      ),
+    );
+  }
+}
+
+Widget _buildBadgeContent({
+  required IconData icon,
+  required String label,
+  required Color color,
+  required bool isLargeText,
+  required double iconSize,
+  required double fontSize,
+  required double spacing,
+}) {
+  final text = Text(
+    label,
+    style: TextStyle(
+      fontSize: fontSize,
+      fontWeight: FontWeight.w600,
+      color: color,
+    ),
+  );
+
+  return Row(
+    mainAxisSize: isLargeText ? MainAxisSize.max : MainAxisSize.min,
+    children: [
+      Icon(icon, size: iconSize, color: color),
+      SizedBox(width: spacing),
+      if (isLargeText) Expanded(child: text) else Flexible(child: text),
+    ],
+  );
 }

--- a/app/test/ui/book_list/widgets/completed_book_card_test.dart
+++ b/app/test/ui/book_list/widgets/completed_book_card_test.dart
@@ -1,0 +1,265 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_list/widgets/completed_book_card.dart';
+import 'package:book_golas/ui/core/theme/design_system.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  for (final locale in const [Locale('ko'), Locale('en')]) {
+    for (final brightness in Brightness.values) {
+      for (final width in const [320.0, 393.0]) {
+        testWidgets(
+          'completed metadata remains reachable at 200 percent in '
+          '${locale.languageCode} ${brightness.name} ${width}px',
+          (tester) async {
+            await _pumpCard(
+              tester,
+              locale: locale,
+              brightness: brightness,
+              width: width,
+            );
+
+            final completedLabel = locale.languageCode == 'ko'
+                ? '32일만에 완독'
+                : 'Completed in 32 days';
+            final pagesLabel =
+                locale.languageCode == 'ko' ? '108 페이지' : '108 pages';
+            final dateLabel = locale.languageCode == 'ko'
+                ? '완독: 2026.08.02'
+                : 'Completed: 2026.08.02';
+
+            expect(tester.takeException(), isNull);
+            expect(find.text(_bookTitle), findsOneWidget);
+            expect(find.text(completedLabel), findsOneWidget);
+            expect(find.text(pagesLabel), findsOneWidget);
+            expect(find.text(dateLabel), findsOneWidget);
+
+            final completionBadge = tester.widget<Container>(
+              find.byKey(const Key('completedBookCompletionBadge')),
+            );
+            final completionText =
+                tester.widget<Text>(find.text(completedLabel));
+            final completionBackground =
+                (completionBadge.decoration! as BoxDecoration).color!;
+            final renderedCompletionBackground = Color.alphaBlend(
+              completionBackground,
+              brightness == Brightness.dark
+                  ? BLabColors.surfaceDark
+                  : BLabColors.surfaceLight,
+            );
+            expect(
+              _contrastRatio(
+                completionText.style!.color!,
+                renderedCompletionBackground,
+              ),
+              greaterThanOrEqualTo(3),
+            );
+
+            final cardRect = tester.getRect(find.byType(CompletedBookCard));
+            for (final label in [completedLabel, pagesLabel, dateLabel]) {
+              final labelRect = tester.getRect(find.text(label));
+              expect(labelRect.left, greaterThanOrEqualTo(cardRect.left));
+              expect(labelRect.right, lessThanOrEqualTo(cardRect.right));
+            }
+          },
+        );
+      }
+    }
+  }
+
+  for (final locale in const [Locale('ko'), Locale('en')]) {
+    for (final brightness in Brightness.values) {
+      for (final width in const [320.0, 393.0]) {
+        testWidgets(
+          'completed metadata remains available at default scale in '
+          '${locale.languageCode} ${brightness.name} ${width}px',
+          (tester) async {
+            await _pumpCard(
+              tester,
+              locale: locale,
+              brightness: brightness,
+              width: width,
+              textScale: 1,
+            );
+
+            final completedLabel = locale.languageCode == 'ko'
+                ? '32일만에 완독'
+                : 'Completed in 32 days';
+            final pagesLabel =
+                locale.languageCode == 'ko' ? '108 페이지' : '108 pages';
+            final dateLabel = locale.languageCode == 'ko'
+                ? '완독: 2026.08.02'
+                : 'Completed: 2026.08.02';
+
+            expect(tester.takeException(), isNull);
+            expect(find.text(_bookTitle), findsOneWidget);
+            expect(find.text(completedLabel), findsOneWidget);
+            expect(find.text(pagesLabel), findsOneWidget);
+            expect(find.text(dateLabel), findsOneWidget);
+          },
+        );
+      }
+    }
+  }
+
+  testWidgets('completed card remains tappable at 200 percent', (tester) async {
+    var tapCount = 0;
+    await _pumpCard(
+      tester,
+      locale: const Locale('en'),
+      brightness: Brightness.dark,
+      width: 320,
+      onTap: () => tapCount++,
+    );
+
+    await tester.tap(find.byType(CompletedBookCard));
+    await tester.pump();
+
+    expect(tapCount, 1);
+    expect(tester.takeException(), isNull);
+  });
+
+  for (final locale in const [Locale('ko'), Locale('en')]) {
+    for (final brightness in Brightness.values) {
+      for (final width in const [160.0, 233.0]) {
+        testWidgets(
+          'achievement badge remains reachable at 200 percent in '
+          '${locale.languageCode} ${brightness.name} ${width}px',
+          (tester) async {
+            await _pumpAchievementBadge(
+              tester,
+              locale: locale,
+              brightness: brightness,
+              width: width,
+            );
+
+            final label = locale.languageCode == 'ko'
+                ? '달성률 100%'
+                : 'Achievement rate 100%';
+            final badgeRect = tester.getRect(
+              find.byKey(const Key('completedBookAchievementBadge')),
+            );
+            final labelRect = tester.getRect(find.text(label));
+            final text = tester.widget<Text>(find.text(label));
+            final badge = tester.widget<Container>(
+              find.byKey(const Key('completedBookAchievementBadge')),
+            );
+            final background = (badge.decoration! as BoxDecoration).color!;
+
+            expect(tester.takeException(), isNull);
+            expect(labelRect.left, greaterThanOrEqualTo(badgeRect.left));
+            expect(labelRect.right, lessThanOrEqualTo(badgeRect.right));
+            expect(
+              _contrastRatio(text.style!.color!, background),
+              greaterThanOrEqualTo(3),
+            );
+          },
+        );
+      }
+    }
+  }
+}
+
+const _bookTitle = 'The Little Prince: An Illustrated Anniversary Edition';
+
+Future<void> _pumpCard(
+  WidgetTester tester, {
+  required Locale locale,
+  required Brightness brightness,
+  required double width,
+  double textScale = 2,
+  VoidCallback? onTap,
+}) async {
+  tester.view.physicalSize = Size(width, 720);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final book = Book(
+    title: _bookTitle,
+    startDate: DateTime(2026, 7, 1),
+    targetDate: DateTime(2026, 8, 15),
+    updatedAt: DateTime(2026, 8, 2),
+    currentPage: 108,
+    totalPages: 108,
+    status: 'completed',
+  );
+
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: locale,
+      theme: BLabTheme.light,
+      darkTheme: BLabTheme.dark,
+      themeMode:
+          brightness == Brightness.dark ? ThemeMode.dark : ThemeMode.light,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(
+          textScaler: TextScaler.linear(textScale),
+        ),
+        child: child!,
+      ),
+      home: Scaffold(
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: CompletedBookCard(
+            book: book,
+            onTap: onTap ?? () {},
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+Future<void> _pumpAchievementBadge(
+  WidgetTester tester, {
+  required Locale locale,
+  required Brightness brightness,
+  required double width,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: locale,
+      theme: BLabTheme.light,
+      darkTheme: BLabTheme.dark,
+      themeMode:
+          brightness == Brightness.dark ? ThemeMode.dark : ThemeMode.light,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(
+          textScaler: const TextScaler.linear(2),
+        ),
+        child: child!,
+      ),
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: width,
+            child: const CompletedBookAchievementBadge(rate: 100),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+double _contrastRatio(Color foreground, Color background) {
+  final foregroundLuminance = foreground.computeLuminance();
+  final backgroundLuminance = background.computeLuminance();
+  final lighter = foregroundLuminance > backgroundLuminance
+      ? foregroundLuminance
+      : backgroundLuminance;
+  final darker = foregroundLuminance > backgroundLuminance
+      ? backgroundLuminance
+      : foregroundLuminance;
+  return (lighter + 0.05) / (darker + 0.05);
+}


### PR DESCRIPTION
## 목적

대형 글자와 좁은 화면에서 완독 도서 카드의 상태와 메타데이터가 잘리는 문제를 수정합니다.

## 주요 변경

- 150% 이상 글자 배율에서 완독 상태와 성취율 배지를 가로 전체로 배치하고 문구를 줄바꿈합니다.
- 페이지 수와 완독일을 세로 메타데이터로 전환해 200%에서도 전체 정보가 보이도록 합니다.
- 기본 글자 배율의 좁은 화면에서도 긴 완독 문구와 완료일이 가용 폭 안에서 배치되도록 교정합니다.
- 라이트 모드 완독·성취율 배지의 텍스트 대비를 3:1 이상으로 보강합니다.
- 한국어·영어, 라이트·다크, 320px·393px, 기본·200% 글자 배율과 카드 탭 동작을 회귀 테스트합니다.

## 배경

BOK-382 실제 iPhone 17e 접근성 검증에서 완독 상태 행이 카드 오른쪽으로 넘쳐 정보가 잘렸습니다. 보완 리뷰 과정에서 기본 글자 배율의 좁은 화면에서도 같은 계열의 넘침을 재현해 함께 교정했습니다.

## 검증

- `flutter test test/ui/book_list/widgets/completed_book_card_test.dart` — 25/25 통과
- `flutter test` — 482/482 통과
- 변경 파일 focused `flutter analyze` — 이슈 없음
- 전체 `flutter analyze` — 기존 info 136건, 새 error/warning 없음
- 대비 회귀 — ko/en × light/dark 완독·성취율 배지 3:1 이상
- iPhone 17e accessibility-large — 완독 정보 전체 표시 및 카드 상세 진입 확인
- iOS simulator build — 성공
- `git diff --check` — 통과

## 관련 이슈

- BOK-388

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store
