### PR TITLE
fix(accessibility): preserve book detail action labels

### DIFF
--- a/app/lib/ui/book_detail/widgets/floating_action_bar.dart
+++ b/app/lib/ui/book_detail/widgets/floating_action_bar.dart
@@ -267,38 +267,48 @@ class _ReadingModeBarState extends State<_ReadingModeBar> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final shouldStackActions = MediaQuery.textScalerOf(context).scale(1) >= 1.4;
+
+    final recordAction = _GlassPillButton(
+      key: _recordKey,
+      isDark: widget.isDark,
+      icon: CupertinoIcons.pencil,
+      label: l10n.bottomBarRecord,
+      onTap: () => _onRecordTap(context),
+      onLongPressStart: (details) => _onRecordLongPressStart(context, details),
+      onLongPressMoveUpdate: _onLongPressMoveUpdate,
+      onLongPressEnd: _onLongPressEnd,
+    );
+    final startReadingAction = _GlassPillButton(
+      key: _startReadingKey,
+      isDark: widget.isDark,
+      icon: CupertinoIcons.book_fill,
+      label: l10n.bottomBarStartReading,
+      onTap: () => _onStartReadingTap(context),
+      onLongPressStart: (details) =>
+          _onStartReadingLongPressStart(context, details),
+      onLongPressMoveUpdate: _onLongPressMoveUpdate,
+      onLongPressEnd: _onLongPressEnd,
+    );
+
+    if (shouldStackActions) {
+      return Column(
+        key: const ValueKey('reading-action-bar-stacked'),
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(width: double.infinity, child: recordAction),
+          const SizedBox(height: 8),
+          SizedBox(width: double.infinity, child: startReadingAction),
+        ],
+      );
+    }
 
     return Row(
+      key: const ValueKey('reading-action-bar-inline'),
       children: [
-        Expanded(
-          flex: 3,
-          child: _GlassPillButton(
-            key: _recordKey,
-            isDark: widget.isDark,
-            icon: CupertinoIcons.pencil,
-            label: l10n.bottomBarRecord,
-            onTap: () => _onRecordTap(context),
-            onLongPressStart: (details) =>
-                _onRecordLongPressStart(context, details),
-            onLongPressMoveUpdate: _onLongPressMoveUpdate,
-            onLongPressEnd: _onLongPressEnd,
-          ),
-        ),
+        Expanded(flex: 4, child: recordAction),
         const SizedBox(width: 12),
-        Expanded(
-          flex: 7,
-          child: _GlassPillButton(
-            key: _startReadingKey,
-            isDark: widget.isDark,
-            icon: CupertinoIcons.book_fill,
-            label: l10n.bottomBarStartReading,
-            onTap: () => _onStartReadingTap(context),
-            onLongPressStart: (details) =>
-                _onStartReadingLongPressStart(context, details),
-            onLongPressMoveUpdate: _onLongPressMoveUpdate,
-            onLongPressEnd: _onLongPressEnd,
-          ),
-        ),
+        Expanded(flex: 6, child: startReadingAction),
       ],
     );
   }
@@ -468,56 +478,71 @@ class _GlassPillButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    final supportsWrappedLabel = MediaQuery.textScalerOf(context).scale(1) >= 1.4;
+
+    return Semantics(
+      button: true,
+      label: label,
       onTap: onTap,
-      onLongPressStart: onLongPressStart,
-      onLongPressMoveUpdate: onLongPressMoveUpdate,
-      onLongPressEnd: onLongPressEnd,
-      behavior: HitTestBehavior.opaque,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(100),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
-          child: Container(
-            height: 62,
-            decoration: BoxDecoration(
-              color: isDark
-                  ? Colors.white.withValues(alpha: 0.12)
-                  : Colors.black.withValues(alpha: 0.08),
-              borderRadius: BorderRadius.circular(100),
-              border: Border.all(
-                color: isDark
-                    ? Colors.white.withValues(alpha: 0.15)
-                    : Colors.black.withValues(alpha: 0.08),
-                width: 0.5,
-              ),
-            ),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(
-                  icon,
-                  size: 17,
-                  color: isDark
-                      ? Colors.white.withValues(alpha: 0.85)
-                      : Colors.black.withValues(alpha: 0.65),
+      child: ExcludeSemantics(
+        child: GestureDetector(
+          onTap: onTap,
+          onLongPressStart: onLongPressStart,
+          onLongPressMoveUpdate: onLongPressMoveUpdate,
+          onLongPressEnd: onLongPressEnd,
+          behavior: HitTestBehavior.opaque,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(100),
+            child: BackdropFilter(
+              filter: ImageFilter.blur(sigmaX: 25, sigmaY: 25),
+              child: Container(
+                constraints: const BoxConstraints(minHeight: 62),
+                padding: EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: supportsWrappedLabel ? 8 : 0,
                 ),
-                const SizedBox(width: 8),
-                Flexible(
-                  child: Text(
-                    label,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 15,
-                      fontWeight: FontWeight.w600,
+                decoration: BoxDecoration(
+                  color: isDark
+                      ? Colors.white.withValues(alpha: 0.12)
+                      : Colors.black.withValues(alpha: 0.08),
+                  borderRadius: BorderRadius.circular(100),
+                  border: Border.all(
+                    color: isDark
+                        ? Colors.white.withValues(alpha: 0.15)
+                        : Colors.black.withValues(alpha: 0.08),
+                    width: 0.5,
+                  ),
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      icon,
+                      size: 17,
                       color: isDark
                           ? Colors.white.withValues(alpha: 0.85)
                           : Colors.black.withValues(alpha: 0.65),
                     ),
-                  ),
+                    const SizedBox(width: 8),
+                    Flexible(
+                      child: Text(
+                        label,
+                        maxLines: supportsWrappedLabel ? 2 : 1,
+                        overflow: TextOverflow.visible,
+                        softWrap: supportsWrappedLabel,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                          color: isDark
+                              ? Colors.white.withValues(alpha: 0.85)
+                              : Colors.black.withValues(alpha: 0.65),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
           ),
         ),

--- a/app/lib/ui/book_detail/widgets/floating_action_bar.dart
+++ b/app/lib/ui/book_detail/widgets/floating_action_bar.dart
@@ -28,11 +28,12 @@ class FloatingActionBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bottomSafeArea = MediaQuery.viewPaddingOf(context).bottom;
 
     return Positioned(
       left: 16,
       right: 16,
-      bottom: 22,
+      bottom: 22 + bottomSafeArea,
       child: isReadingMode
           ? _ReadingModeBar(
               isDark: isDark,

--- a/app/test/ui/book_detail/widgets/floating_action_bar_accessibility_test.dart
+++ b/app/test/ui/book_detail/widgets/floating_action_bar_accessibility_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_detail/widgets/floating_action_bar.dart';
+import 'package:book_golas/ui/core/theme/design_system.dart';
+
+void main() {
+  final testCases = <({Locale locale, ThemeMode themeMode, double width})>[
+    for (final locale in const [Locale('ko'), Locale('en')])
+      for (final themeMode in const [ThemeMode.light, ThemeMode.dark])
+        for (final width in const [320.0, 393.0])
+          (locale: locale, themeMode: themeMode, width: width),
+  ];
+
+  for (final testCase in testCases) {
+    final label =
+        '${testCase.locale.languageCode} ${testCase.themeMode.name} ${testCase.width.toInt()}px';
+
+    testWidgets(
+        'keeps fixed reading actions fully labeled and tappable at large text in $label',
+        (tester) async {
+      final semantics = tester.ensureSemantics();
+      var recordTapCount = 0;
+      var startReadingTapCount = 0;
+
+      await _pumpFloatingActionBar(
+        tester,
+        locale: testCase.locale,
+        themeMode: testCase.themeMode,
+        width: testCase.width,
+        onRecordTap: () => recordTapCount += 1,
+        onStartReadingTap: () => startReadingTapCount += 1,
+      );
+
+      final labels = testCase.locale.languageCode == 'ko'
+          ? const (record: '기록', startReading: '독서 시작')
+          : const (record: 'Record', startReading: 'Start Reading');
+      final stackedBar =
+          find.byKey(const ValueKey('reading-action-bar-stacked'));
+      expect(stackedBar, findsOneWidget);
+      expect(tester.takeException(), isNull);
+
+      for (final actionLabel in [labels.record, labels.startReading]) {
+        final textFinder = find.text(actionLabel);
+        final renderParagraph =
+            tester.renderObject<RenderParagraph>(textFinder);
+        final buttonFinder = find.ancestor(
+          of: textFinder,
+          matching: find.byType(GestureDetector),
+        );
+        final textRect = tester.getRect(textFinder);
+        final buttonRect = tester.getRect(buttonFinder);
+
+        expect(renderParagraph.didExceedMaxLines, isFalse);
+        expect(textRect.left, greaterThanOrEqualTo(buttonRect.left));
+        expect(textRect.right, lessThanOrEqualTo(buttonRect.right));
+        expect(buttonRect.height, greaterThanOrEqualTo(48));
+        expect(find.semantics.byLabel(actionLabel), findsOneWidget);
+      }
+
+      final recordButton = find.ancestor(
+        of: find.text(labels.record),
+        matching: find.byType(GestureDetector),
+      );
+      final startReadingButton = find.ancestor(
+        of: find.text(labels.startReading),
+        matching: find.byType(GestureDetector),
+      );
+      expect(
+        tester.getRect(recordButton).bottom,
+        lessThan(tester.getRect(startReadingButton).top),
+      );
+
+      tester.semantics.tap(find.semantics.byLabel(labels.record));
+      await tester.pump();
+      tester.semantics.tap(find.semantics.byLabel(labels.startReading));
+      await tester.pump();
+
+      expect(recordTapCount, 1);
+      expect(startReadingTapCount, 1);
+      semantics.dispose();
+    });
+  }
+
+  testWidgets('keeps compact inline actions at standard text scale',
+      (tester) async {
+    await _pumpFloatingActionBar(
+      tester,
+      locale: const Locale('en'),
+      themeMode: ThemeMode.light,
+      width: 393,
+      textScale: 1,
+      onRecordTap: () {},
+      onStartReadingTap: () {},
+    );
+
+    expect(find.byKey(const ValueKey('reading-action-bar-inline')),
+        findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Future<void> _pumpFloatingActionBar(
+  WidgetTester tester, {
+  required Locale locale,
+  required ThemeMode themeMode,
+  required double width,
+  required VoidCallback onRecordTap,
+  required VoidCallback onStartReadingTap,
+  double textScale = 2,
+}) async {
+  tester.view.physicalSize = Size(width, 852);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: locale,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      theme: BLabTheme.light,
+      darkTheme: BLabTheme.dark,
+      themeMode: themeMode,
+      builder: (context, appChild) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(
+          textScaler: TextScaler.linear(textScale),
+        ),
+        child: appChild!,
+      ),
+      home: Scaffold(
+        body: Stack(
+          children: [
+            FloatingActionBar(
+              onUpdatePageTap: onStartReadingTap,
+              onAddMemorablePageTap: onRecordTap,
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}

--- a/app/test/ui/book_detail/widgets/floating_action_bar_accessibility_test.dart
+++ b/app/test/ui/book_detail/widgets/floating_action_bar_accessibility_test.dart
@@ -57,6 +57,7 @@ void main() {
         expect(textRect.left, greaterThanOrEqualTo(buttonRect.left));
         expect(textRect.right, lessThanOrEqualTo(buttonRect.right));
         expect(buttonRect.height, greaterThanOrEqualTo(48));
+        expect(buttonRect.bottom, lessThanOrEqualTo(796));
         expect(find.semantics.byLabel(actionLabel), findsOneWidget);
       }
 
@@ -127,6 +128,7 @@ Future<void> _pumpFloatingActionBar(
       builder: (context, appChild) => MediaQuery(
         data: MediaQuery.of(context).copyWith(
           textScaler: TextScaler.linear(textScale),
+          viewPadding: const EdgeInsets.only(bottom: 34),
         ),
         child: appChild!,
       ),


### PR DESCRIPTION
## 목적
대형 글자에서 도서 상세 하단 Record 액션이 `Re…`로 축약되는 접근성 회귀를 고친다.

## 주요 변경
- accessibility-large에서 Record와 Start Reading을 세로 전체 너비 액션으로 전환한다.
- 두 액션의 최소 터치 영역, 전체 라벨 및 VoiceOver button semantics를 보장한다.
- 한국어·영어, light·dark, 320px·393px 대형 글자 회귀 테스트를 추가한다.

## 검증
- `flutter test test/ui/book_detail/widgets/book_detail_large_text_layout_test.dart test/ui/book_detail/widgets/floating_action_bar_accessibility_test.dart`
- `flutter analyze lib/ui/book_detail/widgets/floating_action_bar.dart test/ui/book_detail/widgets/floating_action_bar_accessibility_test.dart`
- iOS simulator exact-head component-host screenshot: `BOK-385/exact-head-f74f654/exact-head-f74f654-en-dark-component-host.png`

## 관련 이슈
- BOK-385

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store