### PR TITLE
fix(mobile): allow optional Google client ID

### DIFF
--- a/app/tool/verify_mobile_client_config.py
+++ b/app/tool/verify_mobile_client_config.py
@@ -28,6 +28,16 @@ ALLOWED_DART_DEFINES = frozenset(
         "SUPABASE_URL",
     }
 )
+REQUIRED_CLIENT_ENVIRONMENT = (
+    "ENVIRONMENT",
+    "PAID_SUBSCRIPTIONS_ENABLED",
+    "REVENUECAT_PUBLIC_KEY",
+    "SUPABASE_ANON_KEY",
+    "SUPABASE_URL",
+)
+OPTIONAL_CLIENT_ENVIRONMENT = (
+    "GOOGLE_SERVER_CLIENT_ID",
+)
 SERVER_ONLY_MARKERS = (
     "ALADIN_TTB_KEY",
     "APP_STORE_CONNECT_API_KEY",
@@ -103,15 +113,11 @@ def require_allowed_source_defines(source_root: Path) -> None:
 
 
 def require_client_environment(environment: dict[str, str]) -> None:
-    required = (
-        "ENVIRONMENT",
-        "GOOGLE_SERVER_CLIENT_ID",
-        "PAID_SUBSCRIPTIONS_ENABLED",
-        "REVENUECAT_PUBLIC_KEY",
-        "SUPABASE_ANON_KEY",
-        "SUPABASE_URL",
+    missing = sorted(
+        name
+        for name in REQUIRED_CLIENT_ENVIRONMENT
+        if not environment.get(name, "").strip()
     )
-    missing = sorted(name for name in required if not environment.get(name, "").strip())
     if missing:
         raise BoundaryError(
             "required client configuration is missing: " + ", ".join(missing)
@@ -125,7 +131,10 @@ def require_client_environment(environment: dict[str, str]) -> None:
     ):
         raise BoundaryError("SUPABASE_URL must be a public Supabase HTTPS URL")
     for marker in SERVER_ONLY_MARKERS:
-        if any(marker in environment[name] for name in required):
+        if any(
+            marker in environment.get(name, "")
+            for name in REQUIRED_CLIENT_ENVIRONMENT + OPTIONAL_CLIENT_ENVIRONMENT
+        ):
             raise BoundaryError("client configuration contains a server-only marker")
     parts = environment["SUPABASE_ANON_KEY"].split(".")
     if len(parts) == 3:
@@ -247,13 +256,27 @@ def run_self_test() -> None:
     require_client_environment(
         {
             "ENVIRONMENT": "development",
-            "GOOGLE_SERVER_CLIENT_ID": "public-test-client-id",
+            "GOOGLE_SERVER_CLIENT_ID": "",
             "PAID_SUBSCRIPTIONS_ENABLED": "false",
             "REVENUECAT_PUBLIC_KEY": "public-test-key",
             "SUPABASE_ANON_KEY": "public-test-key",
             "SUPABASE_URL": "https://example.supabase.co",
         }
     )
+    try:
+        require_client_environment(
+            {
+                "ENVIRONMENT": "development",
+                "PAID_SUBSCRIPTIONS_ENABLED": "false",
+                "REVENUECAT_PUBLIC_KEY": "public-test-key",
+                "SUPABASE_ANON_KEY": "public-test-key",
+                "SUPABASE_URL": "",
+            }
+        )
+    except BoundaryError:
+        pass
+    else:
+        raise BoundaryError("self-test did not block an empty required client value")
     try:
         require_client_environment(
             {

--- a/docs/guides/mobile-client-configuration.md
+++ b/docs/guides/mobile-client-configuration.md
@@ -19,6 +19,12 @@ provider access tokens, local environment files, or local operational overrides.
 The public keys above still require their provider-side restrictions. They are
 not a substitute for a server-side secret or a quota boundary.
 
+`GOOGLE_SERVER_CLIENT_ID` is allowlisted but optional: an unset or empty value
+is compiled as an empty Dart define and the app maps it to no server client ID.
+The build boundary still requires `ENVIRONMENT`, `PAID_SUBSCRIPTIONS_ENABLED`,
+`REVENUECAT_PUBLIC_KEY`, `SUPABASE_ANON_KEY`, and `SUPABASE_URL`; no server-only
+value is permitted in either required or optional client input.
+
 ## Local verification
 
 Run this before a local iOS build:


### PR DESCRIPTION
## 목적

BOK-391 TestFlight 배포 실패를 교정합니다. 선택 입력인 Google 서버 클라이언트 ID가 비어 있을 때에도, 앱의 기존 null 처리 경로를 사용합니다.

## 주요 변경

- `GOOGLE_SERVER_CLIENT_ID`를 allowlisted-but-optional 입력으로 구분합니다.
- 필수 클라이언트 입력의 빈 값은 계속 실패하고, 선택 입력도 서버 전용 marker 검사를 계속 받습니다.
- 모바일 구성 경계 문서에 required/optional 계약을 기록합니다.

## 실패 근거

[Workflow run 30755224472](https://github.com/byungsker/book-golas/actions/runs/30755224472)는 `8d3ae3921b8403c7c1791c72b522d7bdb343f984`에서 빈 `GOOGLE_SERVER_CLIENT_ID`를 required로 오분류해 build 전에 실패했습니다.

## 검증

- `python3 app/tool/verify_mobile_client_config.py --self-test --source-root app --workflow .github/workflows/ios-testflight.yml --workflow .github/workflows/ios-production.yml`
- 빈 Google ID 허용 및 빈 필수 Supabase URL 실패-폐쇄 CLI 회귀
- `ruby -c app/ios/fastlane/Fastfile` 및 두 iOS workflow YAML parse
- `flutter test test/config/feature_flags_test.dart`
- `flutter analyze --no-fatal-infos`

## 관련 이슈

- BOK-391

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store

## Merge authority packet

- Merge-Authority-ID: review-gated-auto-bookgolas-mobile-1.0.2-pr313-f98e8c7-20260803
- Owner-Authorization-Source: byungsker standing authority decision path (`review-gated-auto`)
- Repository: byungsker/book-golas
- Pull-Request: #313
- Authorized-Head-SHA: f98e8c77e60f9f0f0e1a0e8770606dfb2c0fc445
- Authorized-Base-Branch: version/mobile/1.0.2
- Authorized-Base-SHA: 8d3ae3921b8403c7c1791c72b522d7bdb343f984
- Authorized-Scope: mobile 1.0.2
- Work-Branch: codex/fix/mobile/1.0.2/BOK-391-optional-google-client-id
- Merge-Action: merge-commit into version/mobile/1.0.2
- Quality-Decision: APPROVE_NEXT
- Final-Decision: APPROVE_NEXT
- Required-Checks: passing
- Trusted-Base: version/mobile/1.0.2@8d3ae3921b8403c7c1791c72b522d7bdb343f984
- Merge-Authority-Consumed: a69f7fe8257475c3d95046256d4fd93f99880aa3
- Rollback-SHA: a69f7fe8257475c3d95046256d4fd93f99880aa3
