### PR TITLE
fix(mobile): reflow compact book header

### DIFF
--- a/app/integration_test/bok392_book_detail_route_test.dart
+++ b/app/integration_test/bok392_book_detail_route_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:provider/provider.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:book_golas/data/services/subscription_service.dart';
+import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_detail/book_detail_screen.dart';
+import 'package:book_golas/ui/book_detail/widgets/compact_book_header.dart';
+import 'package:book_golas/ui/book_detail/view_model/reading_timer_view_model.dart';
+import 'package:book_golas/ui/core/theme/design_system.dart';
+import 'package:book_golas/ui/core/view_model/ad_view_model.dart';
+
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  const captureLocale = String.fromEnvironment('BOK392_CAPTURE_LOCALE');
+  const captureBrightness = String.fromEnvironment('BOK392_CAPTURE_THEME');
+  const evidenceHoldMilliseconds = int.fromEnvironment(
+    'BOK392_EVIDENCE_HOLD_MILLISECONDS',
+  );
+
+  setUpAll(() async {
+    await Supabase.initialize(
+      url: 'http://127.0.0.1:65535',
+      anonKey: 'test-anon-key',
+    );
+  });
+
+  for (final locale in const [Locale('ko'), Locale('en')]) {
+    for (final brightness in Brightness.values) {
+      if (captureLocale.isNotEmpty && captureLocale != locale.languageCode) {
+        continue;
+      }
+      if (captureBrightness.isNotEmpty &&
+          captureBrightness != brightness.name) {
+        continue;
+      }
+      testWidgets(
+        'BOK-392 detail route is readable at 393px and 200 percent in '
+        '${locale.languageCode} ${brightness.name}',
+        (tester) async {
+          await binding.setSurfaceSize(const Size(393, 852));
+          addTearDown(() => binding.setSurfaceSize(null));
+
+          await tester.pumpWidget(
+            _BookDetailRouteFixture(
+              locale: locale,
+              brightness: brightness,
+            ),
+          );
+          await tester.pump(const Duration(milliseconds: 300));
+
+          expect(find.byType(BookDetailScreen), findsOneWidget);
+          expect(find.byType(CompactBookHeader), findsOneWidget);
+          expect(find.text(_title), findsOneWidget);
+          expect(find.text(_author), findsOneWidget);
+          expect(
+            find.text(locale.languageCode == 'ko' ? '독서 중' : 'Reading'),
+            findsOneWidget,
+          );
+          expect(tester.takeException(), isNull);
+
+          await binding.takeScreenshot(
+            'BOK-392-${locale.languageCode}-${brightness.name}-393-200',
+          );
+          if (evidenceHoldMilliseconds > 0) {
+            await tester.pump(
+              const Duration(milliseconds: evidenceHoldMilliseconds),
+            );
+          }
+        },
+      );
+    }
+  }
+}
+
+const _title =
+    'The Little Prince: An Illustrated Anniversary Edition with a Long Subtitle';
+const _author =
+    'Antoine de Saint-Exupéry and the International Translation Team';
+
+class _BookDetailRouteFixture extends StatelessWidget {
+  const _BookDetailRouteFixture({
+    required this.locale,
+    required this.brightness,
+  });
+
+  final Locale locale;
+  final Brightness brightness;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      locale: locale,
+      theme: BLabTheme.light,
+      darkTheme: BLabTheme.dark,
+      themeMode:
+          brightness == Brightness.dark ? ThemeMode.dark : ThemeMode.light,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(
+          textScaler: const TextScaler.linear(2),
+          viewPadding: const EdgeInsets.only(bottom: 34),
+        ),
+        child: child!,
+      ),
+      home: MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => ReadingTimerViewModel()),
+          ChangeNotifierProvider(
+            create: (_) => AdViewModel(SubscriptionService()),
+          ),
+        ],
+        child: BookDetailScreen(
+          isEmbedded: true,
+          book: Book(
+            id: 'bok-392-safe-fixture',
+            title: _title,
+            author: _author,
+            startDate: DateTime(2026, 8, 1),
+            targetDate: DateTime(2026, 8, 31),
+            currentPage: 42,
+            totalPages: 320,
+            status: BookStatus.reading.value,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ui/book_detail/widgets/compact_book_header.dart
+++ b/app/lib/ui/book_detail/widgets/compact_book_header.dart
@@ -67,26 +67,31 @@ class CompactBookHeader extends StatelessWidget {
                 _buildAuthorAndStatus(context, isDark),
                 if (onBookInfoTap != null) ...[
                   const SizedBox(height: 8),
-                  GestureDetector(
-                    onTap: onBookInfoTap,
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        const Icon(
-                          CupertinoIcons.info_circle,
-                          size: 14,
-                          color: BLabColors.primary,
-                        ),
-                        const SizedBox(width: 4),
-                        Text(
-                          AppLocalizations.of(context).bookInfoViewButton,
-                          style: const TextStyle(
-                            fontSize: 12,
+                  Semantics(
+                    button: true,
+                    label: AppLocalizations.of(context).bookInfoViewButton,
+                    child: GestureDetector(
+                      onTap: onBookInfoTap,
+                      child: Wrap(
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        spacing: 4,
+                        runSpacing: 2,
+                        children: [
+                          const Icon(
+                            CupertinoIcons.info_circle,
+                            size: 14,
                             color: BLabColors.primary,
-                            fontWeight: FontWeight.w500,
                           ),
-                        ),
-                      ],
+                          Text(
+                            AppLocalizations.of(context).bookInfoViewButton,
+                            style: const TextStyle(
+                              fontSize: 12,
+                              color: BLabColors.primary,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ],
@@ -135,48 +140,50 @@ class CompactBookHeader extends StatelessWidget {
   }
 
   Widget _buildTitle(bool isDark) {
-    return GestureDetector(
-      onTap: onTitleTap,
-      child: Text(
-        title,
-        style: TextStyle(
-          fontSize: 16,
-          fontWeight: FontWeight.w700,
-          height: 1.3,
-          color: isDark ? Colors.white : Colors.black,
+    return Semantics(
+      button: onTitleTap != null,
+      label: title,
+      child: GestureDetector(
+        onTap: onTitleTap,
+        child: ExcludeSemantics(
+          child: Text(
+            title,
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              height: 1.3,
+              color: isDark ? Colors.white : Colors.black,
+            ),
+          ),
         ),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
       ),
     );
   }
 
   Widget _buildAuthorAndStatus(BuildContext context, bool isDark) {
-    return Row(
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
       children: [
-        if (author != null) ...[
-          Flexible(
+        if (author != null && author!.isNotEmpty) ...[
+          Semantics(
+            button: onBookInfoTap != null,
+            label: author!,
             child: GestureDetector(
               onTap: onBookInfoTap,
-              child: Text(
-                author!,
-                style: TextStyle(
-                  fontSize: 13,
-                  color: isDark ? Colors.grey[400] : Colors.grey[600],
-                  fontWeight: FontWeight.w500,
+              child: ExcludeSemantics(
+                child: Text(
+                  author!,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: isDark ? Colors.grey[400] : Colors.grey[600],
+                    fontWeight: FontWeight.w500,
+                  ),
                 ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
               ),
             ),
           ),
-          Text(
-            ' · ',
-            style: TextStyle(
-              fontSize: 13,
-              color: isDark ? Colors.grey[500] : Colors.grey[400],
-            ),
-          ),
+          const SizedBox(height: 4),
         ],
         _buildStatusBadge(context),
       ],
@@ -186,33 +193,40 @@ class CompactBookHeader extends StatelessWidget {
   Widget _buildStatusBadge(BuildContext context) {
     final statusInfo = _getStatusInfo(context);
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-      decoration: BoxDecoration(
-        color: statusInfo.color.withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            width: 6,
-            height: 6,
-            decoration: BoxDecoration(
-              color: statusInfo.color,
-              shape: BoxShape.circle,
-            ),
+    return Semantics(
+      key: const ValueKey('compact-book-header-status'),
+      label: statusInfo.label,
+      child: ExcludeSemantics(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+          decoration: BoxDecoration(
+            color: statusInfo.color.withValues(alpha: 0.12),
+            borderRadius: BorderRadius.circular(6),
           ),
-          const SizedBox(width: 5),
-          Text(
-            statusInfo.label,
-            style: TextStyle(
-              color: statusInfo.color,
-              fontWeight: FontWeight.w600,
-              fontSize: 11,
-            ),
+          child: Wrap(
+            crossAxisAlignment: WrapCrossAlignment.center,
+            spacing: 5,
+            runSpacing: 2,
+            children: [
+              Container(
+                width: 6,
+                height: 6,
+                decoration: BoxDecoration(
+                  color: statusInfo.color,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              Text(
+                statusInfo.label,
+                style: TextStyle(
+                  color: statusInfo.color,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 11,
+                ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -382,6 +382,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -469,6 +474,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.6.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   functions_client:
     dependency: transitive
     description:
@@ -677,6 +687,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -981,6 +996,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.0"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   provider:
     dependency: "direct main"
     description:
@@ -1250,6 +1273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.12.0"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   synchronized:
     dependency: transitive
     description:
@@ -1442,6 +1473,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   webview_flutter:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -61,6 +61,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
   flutter_lints: ^4.0.0
   flutter_launcher_icons: ^0.13.1

--- a/app/test/ui/book_detail/widgets/compact_book_header_accessibility_test.dart
+++ b/app/test/ui/book_detail/widgets/compact_book_header_accessibility_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:book_golas/data/services/subscription_service.dart';
+import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_detail/book_detail_screen.dart';
+import 'package:book_golas/ui/book_detail/view_model/reading_timer_view_model.dart';
+import 'package:book_golas/ui/book_detail/widgets/compact_book_header.dart';
+import 'package:book_golas/ui/core/theme/design_system.dart';
+import 'package:book_golas/ui/core/view_model/ad_view_model.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    await Supabase.initialize(
+      url: 'http://localhost:54321',
+      anonKey: 'test-anon-key',
+    );
+  });
+
+  for (final locale in const [Locale('ko'), Locale('en')]) {
+    for (final brightness in Brightness.values) {
+      for (final width in const [320.0, 393.0]) {
+        testWidgets(
+          'detail header reflows without overflow at 200 percent in '
+          '${locale.languageCode} ${brightness.name} ${width.toInt()}px',
+          (tester) async {
+            final semantics = tester.ensureSemantics();
+            try {
+              await _pumpDetailScreen(
+                tester,
+                locale: locale,
+                brightness: brightness,
+                width: width,
+              );
+
+              final headerFinder = find.byType(CompactBookHeader);
+              expect(headerFinder, findsOneWidget);
+              expect(tester.takeException(), isNull);
+
+              final titleFinder = find.text(_title);
+              final authorFinder = find.text(_author);
+              final statusFinder = find.text(
+                locale.languageCode == 'ko' ? '독서 중' : 'Reading',
+              );
+              expect(titleFinder, findsOneWidget);
+              expect(authorFinder, findsOneWidget);
+              expect(statusFinder, findsOneWidget);
+
+              final headerRect = tester.getRect(headerFinder);
+              for (final finder in [titleFinder, authorFinder, statusFinder]) {
+                final rect = tester.getRect(finder);
+                expect(rect.left, greaterThanOrEqualTo(headerRect.left));
+                expect(rect.right, lessThanOrEqualTo(headerRect.right));
+                expect(rect.top, greaterThanOrEqualTo(headerRect.top));
+                expect(rect.bottom, lessThanOrEqualTo(headerRect.bottom));
+              }
+
+              final titleNode = tester.getSemantics(
+                find.bySemanticsLabel(_title),
+              );
+              final authorNode = tester.getSemantics(
+                find.bySemanticsLabel(_author),
+              );
+              expect(
+                titleNode.getSemanticsData().flagsCollection.isButton,
+                isTrue,
+              );
+              expect(
+                authorNode.getSemanticsData().flagsCollection.isButton,
+                isTrue,
+              );
+              final statusNode = tester.getSemantics(
+                find.byKey(const ValueKey('compact-book-header-status')),
+              );
+              expect(
+                statusNode.label,
+                locale.languageCode == 'ko' ? '독서 중' : 'Reading',
+              );
+            } finally {
+              semantics.dispose();
+            }
+          },
+        );
+      }
+    }
+  }
+}
+
+const _title =
+    'The Little Prince: An Illustrated Anniversary Edition with a Long Subtitle';
+const _author =
+    'Antoine de Saint-Exupéry and the International Translation Team';
+
+Future<void> _pumpDetailScreen(
+  WidgetTester tester, {
+  required Locale locale,
+  required Brightness brightness,
+  required double width,
+}) async {
+  tester.view.physicalSize = Size(width, 852);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: locale,
+      theme: BLabTheme.light,
+      darkTheme: BLabTheme.dark,
+      themeMode:
+          brightness == Brightness.dark ? ThemeMode.dark : ThemeMode.light,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(
+          textScaler: const TextScaler.linear(2),
+          viewPadding: const EdgeInsets.only(bottom: 34),
+        ),
+        child: child!,
+      ),
+      home: MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => ReadingTimerViewModel()),
+          ChangeNotifierProvider(
+            create: (_) => AdViewModel(SubscriptionService()),
+          ),
+        ],
+        child: BookDetailScreen(
+          isEmbedded: true,
+          book: Book(
+            id: 'compact-header-test-book',
+            title: _title,
+            author: _author,
+            startDate: DateTime(2026, 8, 1),
+            targetDate: DateTime(2026, 8, 31),
+            currentPage: 42,
+            totalPages: 320,
+            status: BookStatus.reading.value,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump(const Duration(milliseconds: 300));
+}

--- a/app/test_driver/bok392_integration_test.dart
+++ b/app/test_driver/bok392_integration_test.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();


### PR DESCRIPTION
## 목적

BOK-392: 큰 글자에서 도서 상세 CompactBookHeader가 가로로 넘치고 제목·저자·상태가 잘리는 문제를 수정합니다.

## 주요 변경

- 제목과 저자·상태를 세로 흐름으로 재배치하고 상태 배지를 줄바꿈 가능하게 변경
- 제목·저자·상태·도서 정보 동작의 접근성 의미를 명시
- 실제 `BookDetailScreen` 경로용 iOS 고정 fixture와 integration driver를 추가
- `integration_test` SDK 의존성은 반복 가능한 네이티브 화면 증거 수집에만 사용

## 검증

- `flutter test test/ui/book_detail/widgets/compact_book_header_accessibility_test.dart` (8/8 pass)
- `flutter analyze lib/ui/book_detail/widgets/compact_book_header.dart test/ui/book_detail/widgets/compact_book_header_accessibility_test.dart` (pass)
- `flutter analyze integration_test/bok392_book_detail_route_test.dart test_driver/bok392_integration_test.dart` (pass)
- `git diff --check` (pass)
- iPhone Air iOS simulator, actual `BookDetailScreen`, 393pt × 852pt, 200% text, fixed safe book data, no login/remote data: Korean/light `/tmp/bok392-evidence/BOK-392-ko-light-393-200.png` SHA-256 `4e150ec481bf46491c45d2748283d939c5a5d50bf0262c796ae5e311ea37bb0c`; English/dark `/tmp/bok392-evidence/BOK-392-en-dark-393-200.png` SHA-256 `67e33669242c12156688603aba58d52b2caaf32d3c7fefb748f96a56d808c063`

관련 이슈: BOK-392

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store