### PR TITLE
fix(accessibility): reflow completed book actions

### DIFF
--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -53,6 +53,7 @@ import 'package:book_golas/ui/book_detail/widgets/reading_timer_modal.dart';
 import 'package:book_golas/ui/core/widgets/floating_timer_bar.dart';
 import 'package:book_golas/data/services/book_share_service.dart';
 import 'widgets/book_share_composer.dart';
+import 'widgets/completed_book_action_card.dart';
 
 class BookDetailScreen extends StatelessWidget {
   final Book book;
@@ -458,7 +459,7 @@ class _BookDetailContentState extends State<_BookDetailContent>
                                   _buildBookReviewButton(context, book),
                                 ],
                                 const SizedBox(height: 12),
-                                _buildRestartReadingButton(context, book),
+                                _buildRestartReadingButton(context),
                               ],
                               const SizedBox(height: 20),
                             ],
@@ -1515,151 +1516,28 @@ class _BookDetailContentState extends State<_BookDetailContent>
   }
 
   Widget _buildBookReviewButton(BuildContext context, Book book) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final hasReview = book.longReview != null && book.longReview!.isNotEmpty;
 
-    return GestureDetector(
+    return CompletedBookActionCard(
+      cardKey: const ValueKey('completed-book-review-action'),
+      title: hasReview
+          ? AppLocalizations.of(context).bookDetailEditReview
+          : AppLocalizations.of(context).bookDetailWriteReview,
+      description: hasReview
+          ? AppLocalizations.of(context).bookDetailReviewYourWritten
+          : AppLocalizations.of(context).bookDetailRecordThoughts,
+      icon: CupertinoIcons.pencil_outline,
       onTap: () => _navigateToBookReview(context, book),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-        decoration: BoxDecoration(
-          color: isDark ? BLabColors.surfaceDark : Colors.white,
-          borderRadius: BorderRadius.circular(12),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: isDark ? 0.2 : 0.04),
-              blurRadius: 8,
-              offset: const Offset(0, 2),
-            ),
-          ],
-        ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Row(
-              children: [
-                Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    color: BLabColors.primary.withValues(alpha: 0.1),
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  child: const Icon(
-                    CupertinoIcons.pencil_outline,
-                    color: BLabColors.primary,
-                    size: 22,
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      hasReview
-                          ? AppLocalizations.of(context).bookDetailEditReview
-                          : AppLocalizations.of(context).bookDetailWriteReview,
-                      style: TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w600,
-                        color: isDark ? Colors.white : Colors.black,
-                      ),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      hasReview
-                          ? AppLocalizations.of(context)
-                              .bookDetailReviewYourWritten
-                          : AppLocalizations.of(context)
-                              .bookDetailRecordThoughts,
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: isDark ? Colors.grey[400] : Colors.grey[600],
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-            Icon(
-              CupertinoIcons.chevron_right,
-              color: isDark ? Colors.grey[400] : Colors.grey[500],
-              size: 20,
-            ),
-          ],
-        ),
-      ),
     );
   }
 
-  Widget _buildRestartReadingButton(BuildContext context, Book book) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-
-    return GestureDetector(
+  Widget _buildRestartReadingButton(BuildContext context) {
+    return CompletedBookActionCard(
+      cardKey: const ValueKey('completed-book-restart-action'),
+      title: AppLocalizations.of(context).bookDetailContinueReading,
+      description: AppLocalizations.of(context).bookDetailAchieveGoal,
+      icon: Icons.refresh_rounded,
       onTap: () => _navigateToReadingStart(context),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-        decoration: BoxDecoration(
-          color: isDark ? BLabColors.surfaceDark : Colors.white,
-          borderRadius: BorderRadius.circular(12),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: isDark ? 0.2 : 0.04),
-              blurRadius: 8,
-              offset: const Offset(0, 2),
-            ),
-          ],
-        ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Row(
-              children: [
-                Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    color: BLabColors.primary.withValues(alpha: 0.1),
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  child: const Icon(
-                    Icons.refresh_rounded,
-                    color: BLabColors.primary,
-                    size: 22,
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      AppLocalizations.of(context).bookDetailContinueReading,
-                      style: TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w600,
-                        color: isDark ? Colors.white : Colors.black,
-                      ),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      AppLocalizations.of(context).bookDetailAchieveGoal,
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: isDark ? Colors.grey[400] : Colors.grey[600],
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-            Icon(
-              CupertinoIcons.chevron_right,
-              color: isDark ? Colors.grey[400] : Colors.grey[500],
-              size: 20,
-            ),
-          ],
-        ),
-      ),
     );
   }
 

--- a/app/lib/ui/book_detail/widgets/completed_book_action_card.dart
+++ b/app/lib/ui/book_detail/widgets/completed_book_action_card.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'package:book_golas/ui/core/theme/design_system.dart';
+
+class CompletedBookActionCard extends StatelessWidget {
+  const CompletedBookActionCard({
+    super.key,
+    required this.cardKey,
+    required this.title,
+    required this.description,
+    required this.icon,
+    required this.onTap,
+  });
+
+  final Key cardKey;
+  final String title;
+  final String description;
+  final IconData icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final textScale = MediaQuery.textScalerOf(context).scale(15);
+
+    return Semantics(
+      button: true,
+      excludeSemantics: true,
+      label: '$title. $description',
+      onTap: onTap,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: 48),
+        child: Material(
+          color: isDark ? BLabColors.surfaceDark : Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          child: InkWell(
+            key: cardKey,
+            borderRadius: BorderRadius.circular(12),
+            onTap: onTap,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: isDark ? 0.2 : 0.04),
+                    blurRadius: 8,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final shouldStack =
+                      textScale >= 1.3 || constraints.maxWidth < 300;
+                  return shouldStack
+                      ? _StackedCardContent(
+                          icon: icon,
+                          title: title,
+                          description: description,
+                          isDark: isDark,
+                        )
+                      : _InlineCardContent(
+                          icon: icon,
+                          title: title,
+                          description: description,
+                          isDark: isDark,
+                        );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _InlineCardContent extends StatelessWidget {
+  const _InlineCardContent({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.isDark,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        _ActionIcon(icon: icon),
+        const SizedBox(width: 12),
+        Expanded(
+          child: _ActionText(
+            title: title,
+            description: description,
+            isDark: isDark,
+          ),
+        ),
+        const SizedBox(width: 8),
+        _Chevron(isDark: isDark),
+      ],
+    );
+  }
+}
+
+class _StackedCardContent extends StatelessWidget {
+  const _StackedCardContent({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.isDark,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _ActionIcon(icon: icon),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                title,
+                key: const ValueKey('completed-book-action-title-stacked'),
+                style: _titleStyle(isDark),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        Padding(
+          padding: const EdgeInsets.only(left: 52),
+          child: Text(
+            description,
+            key: const ValueKey('completed-book-action-description-stacked'),
+            style: _descriptionStyle(isDark),
+          ),
+        ),
+        const SizedBox(height: 6),
+        Align(
+          alignment: Alignment.centerRight,
+          child: _Chevron(isDark: isDark),
+        ),
+      ],
+    );
+  }
+}
+
+class _ActionIcon extends StatelessWidget {
+  const _ActionIcon({required this.icon});
+
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        color: BLabColors.primary.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Icon(icon, color: BLabColors.primary, size: 22),
+    );
+  }
+}
+
+class _ActionText extends StatelessWidget {
+  const _ActionText({
+    required this.title,
+    required this.description,
+    required this.isDark,
+  });
+
+  final String title;
+  final String description;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: _titleStyle(isDark)),
+        const SizedBox(height: 2),
+        Text(description, style: _descriptionStyle(isDark)),
+      ],
+    );
+  }
+}
+
+class _Chevron extends StatelessWidget {
+  const _Chevron({required this.isDark});
+
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Icon(
+      CupertinoIcons.chevron_right,
+      color: isDark ? Colors.grey[400] : Colors.grey[500],
+      size: 20,
+    );
+  }
+}
+
+TextStyle _titleStyle(bool isDark) {
+  return TextStyle(
+    fontSize: 15,
+    fontWeight: FontWeight.w600,
+    color: isDark ? Colors.white : Colors.black,
+  );
+}
+
+TextStyle _descriptionStyle(bool isDark) {
+  return TextStyle(
+    fontSize: 12,
+    color: isDark ? Colors.grey[400] : Colors.grey[600],
+  );
+}

--- a/app/test/ui/book_detail/widgets/completed_book_action_card_test.dart
+++ b/app/test/ui/book_detail/widgets/completed_book_action_card_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_detail/widgets/completed_book_action_card.dart';
+import 'package:book_golas/ui/core/theme/design_system.dart';
+
+void main() {
+  final testCases = <({Locale locale, ThemeMode themeMode, double width})>[
+    for (final locale in const [Locale('ko'), Locale('en')])
+      for (final themeMode in const [ThemeMode.light, ThemeMode.dark])
+        for (final width in const [320.0, 393.0])
+          (locale: locale, themeMode: themeMode, width: width),
+  ];
+
+  for (final testCase in testCases) {
+    final label =
+        '${testCase.locale.languageCode} ${testCase.themeMode.name} ${testCase.width.toInt()}px';
+
+    testWidgets(
+        'completed actions reflow without truncation at 200 percent in $label',
+        (
+      tester,
+    ) async {
+      final actions = _ActionCounts();
+      final semantics = tester.ensureSemantics();
+
+      await _pumpCompletedActions(
+        tester,
+        testCase: testCase,
+        actions: actions,
+        textScale: 2,
+      );
+
+      final isKorean = testCase.locale.languageCode == 'ko';
+      final reviewTitle = isKorean ? '독후감 쓰러가기' : 'Write Review';
+      final reviewDescription =
+          isKorean ? '생각을 기록해보세요' : 'Record your thoughts';
+      final restartTitle = isKorean ? '새로운 독서 시작하기' : 'Continue Reading';
+      final restartDescription =
+          isKorean ? '독서 목표를 달성해보세요!' : 'Achieve your reading goal!';
+
+      expect(tester.takeException(), isNull);
+      expect(find.byKey(const ValueKey('completed-book-action-title-stacked')),
+          findsNWidgets(2));
+      expect(
+          find.byKey(
+              const ValueKey('completed-book-action-description-stacked')),
+          findsNWidgets(2));
+      _expectFitsInsideCard(
+          tester, 'completed-book-review-action', reviewTitle);
+      _expectFitsInsideCard(
+          tester, 'completed-book-review-action', reviewDescription);
+      _expectFitsInsideCard(
+          tester, 'completed-book-restart-action', restartTitle);
+      _expectFitsInsideCard(
+          tester, 'completed-book-restart-action', restartDescription);
+
+      final reviewCard =
+          find.byKey(const ValueKey('completed-book-review-action'));
+      final restartCard =
+          find.byKey(const ValueKey('completed-book-restart-action'));
+      expect(tester.getSize(reviewCard).shortestSide, greaterThanOrEqualTo(48));
+      expect(
+          tester.getSize(restartCard).shortestSide, greaterThanOrEqualTo(48));
+      expect(find.semantics.byLabel('$reviewTitle. $reviewDescription'),
+          findsOneWidget);
+      final restartSemantics =
+          find.semantics.byLabel('$restartTitle. $restartDescription');
+      expect(restartSemantics, findsOneWidget);
+
+      await tester.tap(reviewCard);
+      await tester.pump();
+      tester.semantics.tap(restartSemantics);
+      await tester.pump();
+      expect(actions.review, 1);
+      expect(actions.restart, 1);
+      semantics.dispose();
+    });
+  }
+}
+
+void _expectFitsInsideCard(WidgetTester tester, String cardKey, String text) {
+  final cardRect = tester.getRect(find.byKey(ValueKey(cardKey)));
+  final textRect = tester.getRect(find.text(text));
+  expect(textRect.left, greaterThanOrEqualTo(cardRect.left));
+  expect(textRect.right, lessThanOrEqualTo(cardRect.right));
+  expect(textRect.top, greaterThanOrEqualTo(cardRect.top));
+  expect(textRect.bottom, lessThanOrEqualTo(cardRect.bottom));
+}
+
+Future<void> _pumpCompletedActions(
+  WidgetTester tester, {
+  required ({Locale locale, ThemeMode themeMode, double width}) testCase,
+  required _ActionCounts actions,
+  required double textScale,
+}) async {
+  tester.view.physicalSize = Size(testCase.width, 852);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: testCase.locale,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      theme: BLabTheme.light,
+      darkTheme: BLabTheme.dark,
+      themeMode: testCase.themeMode,
+      builder: (context, appChild) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(
+          textScaler: TextScaler.linear(textScale),
+        ),
+        child: appChild!,
+      ),
+      home: Scaffold(
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(20),
+          child: Builder(
+            builder: (context) {
+              final l10n = AppLocalizations.of(context);
+              return Column(
+                children: [
+                  CompletedBookActionCard(
+                    cardKey: const ValueKey('completed-book-review-action'),
+                    title: l10n.bookDetailWriteReview,
+                    description: l10n.bookDetailRecordThoughts,
+                    icon: CupertinoIcons.pencil_outline,
+                    onTap: () => actions.review += 1,
+                  ),
+                  const SizedBox(height: 12),
+                  CompletedBookActionCard(
+                    cardKey: const ValueKey('completed-book-restart-action'),
+                    title: l10n.bookDetailContinueReading,
+                    description: l10n.bookDetailAchieveGoal,
+                    icon: Icons.refresh_rounded,
+                    onTap: () => actions.restart += 1,
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+class _ActionCounts {
+  int review = 0;
+  int restart = 0;
+}


### PR DESCRIPTION
## 목적

BOK-389 완독 상세의 독후감·재독 CTA가 대형 글자에서 넘치거나 문구가 잘리지 않도록 교정합니다.

## 주요 변경

- CTA를 재사용 가능한 접근성 카드로 분리했습니다.
- 좁은 폭 또는 큰 글자 배율에서 세로 레이아웃으로 재배치합니다.
- 한국어·영어, light·dark, 320px·393px, 200% 글자 배율을 검증하는 위젯 테스트를 추가했습니다.

## 배경

기존 PR #311은 오래된 version line base를 사용해 교체합니다. 이 PR은 `a69f7fe8257475c3d95046256d4fd93f99880aa3`에서 동일한 BOK-389 전용 변경을 재구성했습니다.

## 검증

- `flutter test --no-pub test/ui/book_detail/widgets/completed_book_action_card_test.dart` 재실행을 시작했으나 로컬 실행 시간 제한 전에 컴파일 단계가 종료되어, 최종 판정은 PR CI로 확인합니다.
- `git diff --check a69f7fe8257475c3d95046256d4fd93f99880aa3..HEAD`
- 기존 exact-head iPhone Air iOS 26.5 한국어 dark 200% component-host 증거를 보존했습니다. signed-in 실제 재독 동작은 dev 설정 제약으로 QA에 남습니다.

## 관련 이슈

- BOK-389
- Supersedes #311

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store