### PR TITLE
fix(mobile): repair compact book header accessibility

### DIFF
--- a/app/integration_test/bok392_book_detail_route_test.dart
+++ b/app/integration_test/bok392_book_detail_route_test.dart
@@ -116,6 +116,7 @@ class _BookDetailRouteFixture extends StatelessWidget {
         ],
         child: BookDetailScreen(
           isEmbedded: true,
+          loadRemoteData: false,
           book: Book(
             id: 'bok-392-safe-fixture',
             title: _title,

--- a/app/integration_test/bok392_book_detail_route_test.dart
+++ b/app/integration_test/bok392_book_detail_route_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:provider/provider.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:book_golas/data/services/subscription_service.dart';
+import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_detail/book_detail_screen.dart';
+import 'package:book_golas/ui/book_detail/widgets/compact_book_header.dart';
+import 'package:book_golas/ui/book_detail/view_model/reading_timer_view_model.dart';
+import 'package:book_golas/ui/core/theme/design_system.dart';
+import 'package:book_golas/ui/core/view_model/ad_view_model.dart';
+
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  const captureLocale = String.fromEnvironment('BOK392_CAPTURE_LOCALE');
+  const captureBrightness = String.fromEnvironment('BOK392_CAPTURE_THEME');
+  const evidenceHoldMilliseconds = int.fromEnvironment(
+    'BOK392_EVIDENCE_HOLD_MILLISECONDS',
+  );
+
+  setUpAll(() async {
+    await Supabase.initialize(
+      url: 'http://127.0.0.1:65535',
+      anonKey: 'test-anon-key',
+    );
+  });
+
+  for (final locale in const [Locale('ko'), Locale('en')]) {
+    for (final brightness in Brightness.values) {
+      if (captureLocale.isNotEmpty && captureLocale != locale.languageCode) {
+        continue;
+      }
+      if (captureBrightness.isNotEmpty &&
+          captureBrightness != brightness.name) {
+        continue;
+      }
+      testWidgets(
+        'BOK-392 detail route is readable at 393px and 200 percent in '
+        '${locale.languageCode} ${brightness.name}',
+        (tester) async {
+          await binding.setSurfaceSize(const Size(393, 852));
+          addTearDown(() => binding.setSurfaceSize(null));
+
+          await tester.pumpWidget(
+            _BookDetailRouteFixture(
+              locale: locale,
+              brightness: brightness,
+            ),
+          );
+          await tester.pump(const Duration(milliseconds: 300));
+
+          expect(find.byType(BookDetailScreen), findsOneWidget);
+          expect(find.byType(CompactBookHeader), findsOneWidget);
+          expect(find.text(_title), findsOneWidget);
+          expect(find.text(_author), findsOneWidget);
+          expect(
+            find.text(locale.languageCode == 'ko' ? '독서 중' : 'Reading'),
+            findsOneWidget,
+          );
+          expect(tester.takeException(), isNull);
+
+          await binding.takeScreenshot(
+            'BOK-392-${locale.languageCode}-${brightness.name}-393-200',
+          );
+          if (evidenceHoldMilliseconds > 0) {
+            await tester.pump(
+              const Duration(milliseconds: evidenceHoldMilliseconds),
+            );
+          }
+        },
+      );
+    }
+  }
+}
+
+const _title =
+    'The Little Prince: An Illustrated Anniversary Edition with a Long Subtitle';
+const _author =
+    'Antoine de Saint-Exupéry and the International Translation Team';
+
+class _BookDetailRouteFixture extends StatelessWidget {
+  const _BookDetailRouteFixture({
+    required this.locale,
+    required this.brightness,
+  });
+
+  final Locale locale;
+  final Brightness brightness;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      locale: locale,
+      theme: BLabTheme.light,
+      darkTheme: BLabTheme.dark,
+      themeMode:
+          brightness == Brightness.dark ? ThemeMode.dark : ThemeMode.light,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(
+          textScaler: const TextScaler.linear(2),
+          viewPadding: const EdgeInsets.only(bottom: 34),
+        ),
+        child: child!,
+      ),
+      home: MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => ReadingTimerViewModel()),
+          ChangeNotifierProvider(
+            create: (_) => AdViewModel(SubscriptionService()),
+          ),
+        ],
+        child: BookDetailScreen(
+          isEmbedded: true,
+          book: Book(
+            id: 'bok-392-safe-fixture',
+            title: _title,
+            author: _author,
+            startDate: DateTime(2026, 8, 1),
+            targetDate: DateTime(2026, 8, 31),
+            currentPage: 42,
+            totalPages: 320,
+            status: BookStatus.reading.value,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/integration_test/bok392_book_detail_route_test.dart
+++ b/app/integration_test/bok392_book_detail_route_test.dart
@@ -56,10 +56,10 @@ void main() {
           expect(find.byType(CompactBookHeader), findsOneWidget);
           expect(find.text(_title), findsOneWidget);
           expect(find.text(_author), findsOneWidget);
-          expect(
-            find.text(locale.languageCode == 'ko' ? '독서 중' : 'Reading'),
-            findsOneWidget,
+          final l10n = AppLocalizations.of(
+            tester.element(find.byType(BookDetailScreen)),
           );
+          expect(find.text(l10n.statusReading), findsOneWidget);
           expect(tester.takeException(), isNull);
 
           await binding.takeScreenshot(

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -58,6 +58,7 @@ class BookDetailScreen extends StatelessWidget {
   final Book book;
   final bool showCelebration;
   final bool isEmbedded;
+  final bool loadRemoteData;
   final int? initialTabIndex;
   final bool autoOpenScan;
   final void Function(VoidCallback updatePage, VoidCallback addMemorable)?
@@ -68,6 +69,7 @@ class BookDetailScreen extends StatelessWidget {
     required this.book,
     this.showCelebration = false,
     this.isEmbedded = false,
+    this.loadRemoteData = true,
     this.initialTabIndex,
     this.autoOpenScan = false,
     this.onCallbacksReady,
@@ -90,12 +92,15 @@ class BookDetailScreen extends StatelessWidget {
           create: (_) => ReadingProgressViewModel(bookId: book.id!),
         ),
         ChangeNotifierProvider(
-          create: (_) => RecallViewModel()..loadRecentSearches(book.id!),
+          create: (_) => loadRemoteData
+              ? (RecallViewModel()..loadRecentSearches(book.id!))
+              : RecallViewModel(),
         ),
       ],
       child: _BookDetailContent(
         showCelebration: showCelebration,
         isEmbedded: isEmbedded,
+        loadRemoteData: loadRemoteData,
         initialTabIndex: initialTabIndex,
         autoOpenScan: autoOpenScan,
         onCallbacksReady: onCallbacksReady,
@@ -107,6 +112,7 @@ class BookDetailScreen extends StatelessWidget {
 class _BookDetailContent extends StatefulWidget {
   final bool showCelebration;
   final bool isEmbedded;
+  final bool loadRemoteData;
   final int? initialTabIndex;
   final bool autoOpenScan;
   final void Function(VoidCallback updatePage, VoidCallback addMemorable)?
@@ -115,6 +121,7 @@ class _BookDetailContent extends StatefulWidget {
   const _BookDetailContent({
     this.showCelebration = false,
     this.isEmbedded = false,
+    this.loadRemoteData = true,
     this.initialTabIndex,
     this.autoOpenScan = false,
     this.onCallbacksReady,
@@ -179,20 +186,21 @@ class _BookDetailContentState extends State<_BookDetailContent>
       final memorableVm = context.read<MemorablePageViewModel>();
       final progressVm = context.read<ReadingProgressViewModel>();
 
-      // 최신 책 데이터 가져오기 (DB에서 fresh data)
-      await bookVm.refreshBook();
-
-      // DB eventual consistency를 위한 딜레이 후 achievements 로드
-      await Future.delayed(const Duration(milliseconds: 300));
-      await bookVm.loadDailyAchievements();
+      if (widget.loadRemoteData) {
+        await bookVm.refreshBook();
+        await Future.delayed(const Duration(milliseconds: 300));
+        await bookVm.loadDailyAchievements();
+      }
 
       if (mounted) {
         _animatedProgress =
             bookVm.currentBook.currentPage / bookVm.currentBook.totalPages;
       }
 
-      memorableVm.fetchBookImages();
-      progressVm.fetchProgressHistory();
+      if (widget.loadRemoteData) {
+        memorableVm.fetchBookImages();
+        progressVm.fetchProgressHistory();
+      }
 
       // 탭 컨트롤러 업데이트 (완독 상태면 4탭)
       _updateTabControllerIfNeeded(bookVm.currentBook);

--- a/app/lib/ui/book_detail/widgets/compact_book_header.dart
+++ b/app/lib/ui/book_detail/widgets/compact_book_header.dart
@@ -68,29 +68,41 @@ class CompactBookHeader extends StatelessWidget {
                 if (onBookInfoTap != null) ...[
                   const SizedBox(height: 8),
                   Semantics(
+                    key: const ValueKey('compact-book-header-book-info'),
                     button: true,
                     label: AppLocalizations.of(context).bookInfoViewButton,
                     child: GestureDetector(
                       onTap: onBookInfoTap,
-                      child: Wrap(
-                        crossAxisAlignment: WrapCrossAlignment.center,
-                        spacing: 4,
-                        runSpacing: 2,
-                        children: [
-                          const Icon(
-                            CupertinoIcons.info_circle,
-                            size: 14,
-                            color: BLabColors.primary,
-                          ),
-                          Text(
-                            AppLocalizations.of(context).bookInfoViewButton,
-                            style: const TextStyle(
-                              fontSize: 12,
-                              color: BLabColors.primary,
-                              fontWeight: FontWeight.w500,
+                      behavior: HitTestBehavior.opaque,
+                      child: ExcludeSemantics(
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(minHeight: 48),
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: Wrap(
+                              crossAxisAlignment: WrapCrossAlignment.center,
+                              spacing: 4,
+                              runSpacing: 2,
+                              children: [
+                                const Icon(
+                                  CupertinoIcons.info_circle,
+                                  size: 14,
+                                  color: BLabColors.primary,
+                                ),
+                                Text(
+                                  AppLocalizations.of(
+                                    context,
+                                  ).bookInfoViewButton,
+                                  style: const TextStyle(
+                                    fontSize: 12,
+                                    color: BLabColors.primary,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                              ],
                             ),
                           ),
-                        ],
+                        ),
                       ),
                     ),
                   ),

--- a/app/lib/ui/book_detail/widgets/compact_book_header.dart
+++ b/app/lib/ui/book_detail/widgets/compact_book_header.dart
@@ -67,26 +67,31 @@ class CompactBookHeader extends StatelessWidget {
                 _buildAuthorAndStatus(context, isDark),
                 if (onBookInfoTap != null) ...[
                   const SizedBox(height: 8),
-                  GestureDetector(
-                    onTap: onBookInfoTap,
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        const Icon(
-                          CupertinoIcons.info_circle,
-                          size: 14,
-                          color: BLabColors.primary,
-                        ),
-                        const SizedBox(width: 4),
-                        Text(
-                          AppLocalizations.of(context).bookInfoViewButton,
-                          style: const TextStyle(
-                            fontSize: 12,
+                  Semantics(
+                    button: true,
+                    label: AppLocalizations.of(context).bookInfoViewButton,
+                    child: GestureDetector(
+                      onTap: onBookInfoTap,
+                      child: Wrap(
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        spacing: 4,
+                        runSpacing: 2,
+                        children: [
+                          const Icon(
+                            CupertinoIcons.info_circle,
+                            size: 14,
                             color: BLabColors.primary,
-                            fontWeight: FontWeight.w500,
                           ),
-                        ),
-                      ],
+                          Text(
+                            AppLocalizations.of(context).bookInfoViewButton,
+                            style: const TextStyle(
+                              fontSize: 12,
+                              color: BLabColors.primary,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ],
@@ -135,48 +140,50 @@ class CompactBookHeader extends StatelessWidget {
   }
 
   Widget _buildTitle(bool isDark) {
-    return GestureDetector(
-      onTap: onTitleTap,
-      child: Text(
-        title,
-        style: TextStyle(
-          fontSize: 16,
-          fontWeight: FontWeight.w700,
-          height: 1.3,
-          color: isDark ? Colors.white : Colors.black,
+    return Semantics(
+      button: onTitleTap != null,
+      label: title,
+      child: GestureDetector(
+        onTap: onTitleTap,
+        child: ExcludeSemantics(
+          child: Text(
+            title,
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              height: 1.3,
+              color: isDark ? Colors.white : Colors.black,
+            ),
+          ),
         ),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
       ),
     );
   }
 
   Widget _buildAuthorAndStatus(BuildContext context, bool isDark) {
-    return Row(
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
       children: [
-        if (author != null) ...[
-          Flexible(
+        if (author != null && author!.isNotEmpty) ...[
+          Semantics(
+            button: onBookInfoTap != null,
+            label: author!,
             child: GestureDetector(
               onTap: onBookInfoTap,
-              child: Text(
-                author!,
-                style: TextStyle(
-                  fontSize: 13,
-                  color: isDark ? Colors.grey[400] : Colors.grey[600],
-                  fontWeight: FontWeight.w500,
+              child: ExcludeSemantics(
+                child: Text(
+                  author!,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: isDark ? Colors.grey[400] : Colors.grey[600],
+                    fontWeight: FontWeight.w500,
+                  ),
                 ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
               ),
             ),
           ),
-          Text(
-            ' · ',
-            style: TextStyle(
-              fontSize: 13,
-              color: isDark ? Colors.grey[500] : Colors.grey[400],
-            ),
-          ),
+          const SizedBox(height: 4),
         ],
         _buildStatusBadge(context),
       ],
@@ -186,33 +193,40 @@ class CompactBookHeader extends StatelessWidget {
   Widget _buildStatusBadge(BuildContext context) {
     final statusInfo = _getStatusInfo(context);
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-      decoration: BoxDecoration(
-        color: statusInfo.color.withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            width: 6,
-            height: 6,
-            decoration: BoxDecoration(
-              color: statusInfo.color,
-              shape: BoxShape.circle,
-            ),
+    return Semantics(
+      key: const ValueKey('compact-book-header-status'),
+      label: statusInfo.label,
+      child: ExcludeSemantics(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+          decoration: BoxDecoration(
+            color: statusInfo.color.withValues(alpha: 0.12),
+            borderRadius: BorderRadius.circular(6),
           ),
-          const SizedBox(width: 5),
-          Text(
-            statusInfo.label,
-            style: TextStyle(
-              color: statusInfo.color,
-              fontWeight: FontWeight.w600,
-              fontSize: 11,
-            ),
+          child: Wrap(
+            crossAxisAlignment: WrapCrossAlignment.center,
+            spacing: 5,
+            runSpacing: 2,
+            children: [
+              Container(
+                width: 6,
+                height: 6,
+                decoration: BoxDecoration(
+                  color: statusInfo.color,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              Text(
+                statusInfo.label,
+                style: TextStyle(
+                  color: statusInfo.color,
+                  fontWeight: FontWeight.w600,
+                  fontSize: 11,
+                ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -382,6 +382,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -469,6 +474,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.6.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   functions_client:
     dependency: transitive
     description:
@@ -677,6 +687,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -981,6 +996,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.0"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   provider:
     dependency: "direct main"
     description:
@@ -1250,6 +1273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.12.0"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   synchronized:
     dependency: transitive
     description:
@@ -1442,6 +1473,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   webview_flutter:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -61,6 +61,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
   flutter_lints: ^4.0.0
   flutter_launcher_icons: ^0.13.1

--- a/app/test/ui/book_detail/widgets/compact_book_header_accessibility_test.dart
+++ b/app/test/ui/book_detail/widgets/compact_book_header_accessibility_test.dart
@@ -19,7 +19,7 @@ void main() {
   setUpAll(() async {
     SharedPreferences.setMockInitialValues({});
     await Supabase.initialize(
-      url: 'http://localhost:54321',
+      url: 'http://127.0.0.1:65535',
       anonKey: 'test-anon-key',
     );
   });
@@ -46,12 +46,11 @@ void main() {
 
               final titleFinder = find.text(_title);
               final authorFinder = find.text(_author);
-              final statusFinder = find.text(
-                locale.languageCode == 'ko' ? '독서 중' : 'Reading',
-              );
-              final bookInfoLabel = AppLocalizations.of(
+              final l10n = AppLocalizations.of(
                 tester.element(find.byType(BookDetailScreen)),
-              ).bookInfoViewButton;
+              );
+              final statusFinder = find.text(l10n.statusReading);
+              final bookInfoLabel = l10n.bookInfoViewButton;
               final bookInfoFinder = find.byKey(
                 const ValueKey('compact-book-header-book-info'),
               );
@@ -88,7 +87,7 @@ void main() {
               );
               expect(
                 statusNode.label,
-                locale.languageCode == 'ko' ? '독서 중' : 'Reading',
+                l10n.statusReading,
               );
               final bookInfoNode = tester.getSemantics(bookInfoFinder);
               expect(bookInfoNode.label, bookInfoLabel);
@@ -151,6 +150,7 @@ Future<void> _pumpDetailScreen(
         ],
         child: BookDetailScreen(
           isEmbedded: true,
+          loadRemoteData: false,
           book: Book(
             id: 'compact-header-test-book',
             title: _title,

--- a/app/test/ui/book_detail/widgets/compact_book_header_accessibility_test.dart
+++ b/app/test/ui/book_detail/widgets/compact_book_header_accessibility_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:book_golas/data/services/subscription_service.dart';
+import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_detail/book_detail_screen.dart';
+import 'package:book_golas/ui/book_detail/view_model/reading_timer_view_model.dart';
+import 'package:book_golas/ui/book_detail/widgets/compact_book_header.dart';
+import 'package:book_golas/ui/core/theme/design_system.dart';
+import 'package:book_golas/ui/core/view_model/ad_view_model.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    await Supabase.initialize(
+      url: 'http://localhost:54321',
+      anonKey: 'test-anon-key',
+    );
+  });
+
+  for (final locale in const [Locale('ko'), Locale('en')]) {
+    for (final brightness in Brightness.values) {
+      for (final width in const [320.0, 393.0]) {
+        testWidgets(
+          'detail header reflows without overflow at 200 percent in '
+          '${locale.languageCode} ${brightness.name} ${width.toInt()}px',
+          (tester) async {
+            final semantics = tester.ensureSemantics();
+            try {
+              await _pumpDetailScreen(
+                tester,
+                locale: locale,
+                brightness: brightness,
+                width: width,
+              );
+
+              final headerFinder = find.byType(CompactBookHeader);
+              expect(headerFinder, findsOneWidget);
+              expect(tester.takeException(), isNull);
+
+              final titleFinder = find.text(_title);
+              final authorFinder = find.text(_author);
+              final statusFinder = find.text(
+                locale.languageCode == 'ko' ? '독서 중' : 'Reading',
+              );
+              expect(titleFinder, findsOneWidget);
+              expect(authorFinder, findsOneWidget);
+              expect(statusFinder, findsOneWidget);
+
+              final headerRect = tester.getRect(headerFinder);
+              for (final finder in [titleFinder, authorFinder, statusFinder]) {
+                final rect = tester.getRect(finder);
+                expect(rect.left, greaterThanOrEqualTo(headerRect.left));
+                expect(rect.right, lessThanOrEqualTo(headerRect.right));
+                expect(rect.top, greaterThanOrEqualTo(headerRect.top));
+                expect(rect.bottom, lessThanOrEqualTo(headerRect.bottom));
+              }
+
+              final titleNode = tester.getSemantics(
+                find.bySemanticsLabel(_title),
+              );
+              final authorNode = tester.getSemantics(
+                find.bySemanticsLabel(_author),
+              );
+              expect(
+                titleNode.getSemanticsData().flagsCollection.isButton,
+                isTrue,
+              );
+              expect(
+                authorNode.getSemanticsData().flagsCollection.isButton,
+                isTrue,
+              );
+              final statusNode = tester.getSemantics(
+                find.byKey(const ValueKey('compact-book-header-status')),
+              );
+              expect(
+                statusNode.label,
+                locale.languageCode == 'ko' ? '독서 중' : 'Reading',
+              );
+            } finally {
+              semantics.dispose();
+            }
+          },
+        );
+      }
+    }
+  }
+}
+
+const _title =
+    'The Little Prince: An Illustrated Anniversary Edition with a Long Subtitle';
+const _author =
+    'Antoine de Saint-Exupéry and the International Translation Team';
+
+Future<void> _pumpDetailScreen(
+  WidgetTester tester, {
+  required Locale locale,
+  required Brightness brightness,
+  required double width,
+}) async {
+  tester.view.physicalSize = Size(width, 852);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: locale,
+      theme: BLabTheme.light,
+      darkTheme: BLabTheme.dark,
+      themeMode:
+          brightness == Brightness.dark ? ThemeMode.dark : ThemeMode.light,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(
+          textScaler: const TextScaler.linear(2),
+          viewPadding: const EdgeInsets.only(bottom: 34),
+        ),
+        child: child!,
+      ),
+      home: MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => ReadingTimerViewModel()),
+          ChangeNotifierProvider(
+            create: (_) => AdViewModel(SubscriptionService()),
+          ),
+        ],
+        child: BookDetailScreen(
+          isEmbedded: true,
+          book: Book(
+            id: 'compact-header-test-book',
+            title: _title,
+            author: _author,
+            startDate: DateTime(2026, 8, 1),
+            targetDate: DateTime(2026, 8, 31),
+            currentPage: 42,
+            totalPages: 320,
+            status: BookStatus.reading.value,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump(const Duration(milliseconds: 300));
+}

--- a/app/test/ui/book_detail/widgets/compact_book_header_accessibility_test.dart
+++ b/app/test/ui/book_detail/widgets/compact_book_header_accessibility_test.dart
@@ -49,9 +49,16 @@ void main() {
               final statusFinder = find.text(
                 locale.languageCode == 'ko' ? '독서 중' : 'Reading',
               );
+              final bookInfoLabel = AppLocalizations.of(
+                tester.element(find.byType(BookDetailScreen)),
+              ).bookInfoViewButton;
+              final bookInfoFinder = find.byKey(
+                const ValueKey('compact-book-header-book-info'),
+              );
               expect(titleFinder, findsOneWidget);
               expect(authorFinder, findsOneWidget);
               expect(statusFinder, findsOneWidget);
+              expect(bookInfoFinder, findsOneWidget);
 
               final headerRect = tester.getRect(headerFinder);
               for (final finder in [titleFinder, authorFinder, statusFinder]) {
@@ -82,6 +89,16 @@ void main() {
               expect(
                 statusNode.label,
                 locale.languageCode == 'ko' ? '독서 중' : 'Reading',
+              );
+              final bookInfoNode = tester.getSemantics(bookInfoFinder);
+              expect(bookInfoNode.label, bookInfoLabel);
+              expect(
+                bookInfoNode.getSemanticsData().flagsCollection.isButton,
+                isTrue,
+              );
+              expect(
+                tester.getRect(bookInfoFinder).height,
+                greaterThanOrEqualTo(48),
               );
             } finally {
               semantics.dispose();

--- a/app/test_driver/bok392_integration_test.dart
+++ b/app/test_driver/bok392_integration_test.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();


### PR DESCRIPTION
## 목적

BOK-392: 200% 글자 크기에서 도서 상세 CompactBookHeader가 넘치거나 핵심 정보가 잘리는 결함을 수정합니다. 이 PR은 기존 #314를 새 version line base에서 교체합니다.

## 주요 변경

- 제목·저자·상태를 세로 흐름으로 재배치해 가로 overflow를 제거
- 제목·저자·상태·도서 정보 동작에 의미를 부여
- `도서 정보 보기`의 중복 보조기술 읽기를 제거하고 최소 48pt 터치 영역 적용
- 실제 `BookDetailScreen` 고정 fixture 및 iOS integration driver 추가
- 고정 fixture는 원격 로드를 비활성화하고 도달 불가능한 loopback endpoint만 사용
- 상태 검증 문자열은 현재 `AppLocalizations`에서 직접 도출

## 검증

- `flutter test test/ui/book_detail/widgets/compact_book_header_accessibility_test.dart` — 8/8 pass; raw output에 서비스 호출 또는 오류 없음
- `flutter analyze lib/ui/book_detail/widgets/compact_book_header.dart test/ui/book_detail/widgets/compact_book_header_accessibility_test.dart integration_test/bok392_book_detail_route_test.dart test_driver/bok392_integration_test.dart` — pass
- `git diff --check` — pass
- exact-head iPhone Air simulator, actual `BookDetailScreen`, 393pt × 852pt, 200% text, fixed safe data, no login/remote data: `/Users/byungskersmacbook/Library/Mobile Documents/iCloud~md~obsidian/Documents/byungsker-archive/project/bookgolas/evidence/BOK-392/exact-head-2ecd5c5/README.md`

관련 이슈: BOK-392
대체 PR: #314

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store