### PR TITLE
fix(mobile): scope IPA marker scanning

### DIFF
--- a/app/tool/verify_mobile_client_config.py
+++ b/app/tool/verify_mobile_client_config.py
@@ -488,6 +488,15 @@ def require_forbidden_environment_contract(content: str, label: str) -> None:
 
 
 def run_self_test() -> None:
+    def write_deflated_ipa(ipa_path: Path, member_path: str, content: bytes) -> None:
+        with zipfile.ZipFile(
+            ipa_path, "w", compression=zipfile.ZIP_DEFLATED
+        ) as archive:
+            archive.writestr(member_path, content)
+        with zipfile.ZipFile(ipa_path) as archive:
+            if archive.getinfo(member_path).compress_type != zipfile.ZIP_DEFLATED:
+                raise BoundaryError("self-test IPA member was not deflated")
+
     require_allowed_defines("--dart-define=ENVIRONMENT=development", "allowed")
     try:
         require_allowed_defines("--dart-define=OPENAI_API_KEY=value", "blocked")
@@ -617,25 +626,26 @@ def run_self_test() -> None:
         else:
             raise BoundaryError("self-test did not scan a cross-chunk forbidden value")
         runner_ipa = artifact / "Runner.ipa"
-        with zipfile.ZipFile(runner_ipa, "w") as archive:
-            archive.writestr(
-                "Payload/Runner.app/config",
-                base64.b64encode(forbidden_value.encode("utf-8")),
-            )
+        write_deflated_ipa(
+            runner_ipa,
+            "Payload/Runner.app/config",
+            base64.b64encode(forbidden_value.encode("utf-8")),
+        )
         try:
             require_clean_artifact(runner_ipa, (forbidden_value,))
         except BoundaryError:
             pass
         else:
             raise BoundaryError("self-test did not scan compressed IPA content")
-        with zipfile.ZipFile(runner_ipa, "w") as archive:
-            archive.writestr(
-                "Payload/Runner.app/Frameworks/Flutter.framework/Flutter",
-                b"PRIVATE_KEY",
-            )
+        write_deflated_ipa(
+            runner_ipa,
+            "Payload/Runner.app/Frameworks/Flutter.framework/Flutter",
+            b"PRIVATE_KEY",
+        )
         require_clean_artifact(runner_ipa)
-        with zipfile.ZipFile(runner_ipa, "w") as archive:
-            archive.writestr("Payload/Runner.app/config", b"OPENAI_API_KEY")
+        write_deflated_ipa(
+            runner_ipa, "Payload/Runner.app/config", b"OPENAI_API_KEY"
+        )
         try:
             require_clean_artifact(runner_ipa)
         except BoundaryError as error:
@@ -646,11 +656,11 @@ def run_self_test() -> None:
                 raise BoundaryError("self-test did not provide a safe marker diagnostic")
         else:
             raise BoundaryError("self-test did not scan an app-owned server marker")
-        with zipfile.ZipFile(runner_ipa, "w") as archive:
-            archive.writestr(
-                "Payload/Runner.app/Frameworks/Flutter.framework/Flutter",
-                forbidden_value.encode("utf-8"),
-            )
+        write_deflated_ipa(
+            runner_ipa,
+            "Payload/Runner.app/Frameworks/Flutter.framework/Flutter",
+            forbidden_value.encode("utf-8"),
+        )
         try:
             require_clean_artifact(runner_ipa, (forbidden_value,))
         except BoundaryError:

--- a/app/tool/verify_mobile_client_config.py
+++ b/app/tool/verify_mobile_client_config.py
@@ -104,6 +104,15 @@ SERVER_ONLY_MARKERS = (
     "SUPABASE_ACCESS_TOKEN",
     "SUPABASE_PROJECT_REF",
 )
+ARTIFACT_SERVER_ONLY_MARKERS = tuple(
+    sorted(
+        {
+            name
+            for required_names, optional_names in FORBIDDEN_ENVIRONMENT_CONTRACTS.values()
+            for name in required_names | optional_names
+        }
+    )
+)
 DART_DEFINE_PATTERN = re.compile(
     r"--dart-define(?:=|\s+)([A-Za-z][A-Za-z0-9_]*)="
 )
@@ -213,17 +222,18 @@ def encoded_forms(value: str) -> tuple[bytes, ...]:
     )
 
 
-def scan_stream(handle: object, needles: tuple[bytes, ...]) -> bool:
+def scan_stream(handle: object, needles: tuple[bytes, ...]) -> bytes | None:
     if not needles:
-        return False
+        return None
     carry_size = max(len(needle) for needle in needles) - 1
     carry = b""
     while content := handle.read(65536):
         content = carry + content
-        if any(needle in content for needle in needles):
-            return True
+        for needle in needles:
+            if needle in content:
+                return needle
         carry = content[-carry_size:] if carry_size else b""
-    return False
+    return None
 
 
 def artifact_files(artifact: Path) -> tuple[Path, ...]:
@@ -234,32 +244,54 @@ def artifact_files(artifact: Path) -> tuple[Path, ...]:
     )
 
 
-def file_contains_forbidden_material(file_path: Path, needles: tuple[bytes, ...]) -> bool:
-    if zipfile.is_zipfile(file_path):
-        with zipfile.ZipFile(file_path) as archive:
+def artifact_forbidden_material(
+    artifact: Path, artifact_file: Path, needles: tuple[bytes, ...]
+) -> tuple[str, bytes] | None:
+    relative_file = (
+        artifact_file.relative_to(artifact) if artifact.is_dir() else artifact_file.name
+    )
+    if zipfile.is_zipfile(artifact_file):
+        with zipfile.ZipFile(artifact_file) as archive:
             for member in archive.infolist():
                 if member.is_dir():
                     continue
                 with archive.open(member) as handle:
-                    if scan_stream(handle, needles):
-                        return True
-        return False
-    with file_path.open("rb") as handle:
-        return scan_stream(handle, needles)
+                    if matched_needle := scan_stream(handle, needles):
+                        return (f"{relative_file}/{member.filename}", matched_needle)
+        return None
+    with artifact_file.open("rb") as handle:
+        if matched_needle := scan_stream(handle, needles):
+            return (str(relative_file), matched_needle)
+    return None
 
 
 def require_clean_artifact(artifact: Path, forbidden_values: tuple[str, ...] = ()) -> None:
     if not artifact.exists():
         raise BoundaryError(f"artifact path does not exist: {artifact}")
-    marker_needles = tuple(marker.encode("utf-8") for marker in SERVER_ONLY_MARKERS)
+    marker_needles = tuple(
+        marker.encode("utf-8") for marker in ARTIFACT_SERVER_ONLY_MARKERS
+    )
     value_needles = tuple(
         form for value in forbidden_values if value for form in encoded_forms(value)
     )
     for artifact_file in artifact_files(artifact):
-        if file_contains_forbidden_material(artifact_file, marker_needles):
-            raise BoundaryError("server-only configuration marker found in mobile artifact")
-        if value_needles and file_contains_forbidden_material(artifact_file, value_needles):
-            raise BoundaryError("forbidden value-derived material found in mobile artifact")
+        if marker_match := artifact_forbidden_material(
+            artifact, artifact_file, marker_needles
+        ):
+            relative_path, marker = marker_match
+            raise BoundaryError(
+                "server-only configuration marker "
+                f"{marker.decode('ascii')} found in mobile artifact at {relative_path}"
+            )
+        if value_needles and (
+            value_match := artifact_forbidden_material(
+                artifact, artifact_file, value_needles
+            )
+        ):
+            relative_path, _ = value_match
+            raise BoundaryError(
+                f"forbidden value-derived material found in mobile artifact at {relative_path}"
+            )
 
 
 def require_required_forbidden_environment_values(
@@ -584,15 +616,47 @@ def run_self_test() -> None:
             pass
         else:
             raise BoundaryError("self-test did not scan a cross-chunk forbidden value")
-        (artifact / "binary").write_bytes(b"safe")
-        with zipfile.ZipFile(artifact / "Runner.ipa", "w") as archive:
-            archive.writestr("Payload/Runner.app/config", base64.b64encode(forbidden_value.encode("utf-8")))
+        runner_ipa = artifact / "Runner.ipa"
+        with zipfile.ZipFile(runner_ipa, "w") as archive:
+            archive.writestr(
+                "Payload/Runner.app/config",
+                base64.b64encode(forbidden_value.encode("utf-8")),
+            )
         try:
-            require_clean_artifact(artifact / "Runner.ipa", (forbidden_value,))
+            require_clean_artifact(runner_ipa, (forbidden_value,))
         except BoundaryError:
             pass
         else:
             raise BoundaryError("self-test did not scan compressed IPA content")
+        with zipfile.ZipFile(runner_ipa, "w") as archive:
+            archive.writestr(
+                "Payload/Runner.app/Frameworks/Flutter.framework/Flutter",
+                b"PRIVATE_KEY",
+            )
+        require_clean_artifact(runner_ipa)
+        with zipfile.ZipFile(runner_ipa, "w") as archive:
+            archive.writestr("Payload/Runner.app/config", b"OPENAI_API_KEY")
+        try:
+            require_clean_artifact(runner_ipa)
+        except BoundaryError as error:
+            if (
+                "OPENAI_API_KEY" not in str(error)
+                or "Payload/Runner.app/config" not in str(error)
+            ):
+                raise BoundaryError("self-test did not provide a safe marker diagnostic")
+        else:
+            raise BoundaryError("self-test did not scan an app-owned server marker")
+        with zipfile.ZipFile(runner_ipa, "w") as archive:
+            archive.writestr(
+                "Payload/Runner.app/Frameworks/Flutter.framework/Flutter",
+                forbidden_value.encode("utf-8"),
+            )
+        try:
+            require_clean_artifact(runner_ipa, (forbidden_value,))
+        except BoundaryError:
+            pass
+        else:
+            raise BoundaryError("self-test did not scan a vendor forbidden value")
         (artifact / "binary").write_bytes(optional_value.encode("utf-8"))
         try:
             require_clean_artifact(


### PR DESCRIPTION
## 목적

BOK-391 signed IPA 경계가 일반 Flutter engine 문자열에 의해 false positive로 실패한 것을 교정합니다.

## 실패 근거

[Workflow run 30758340195](https://github.com/byungsker/book-golas/actions/runs/30758340195)는 signed TestFlight IPA boundary에서 upload 전에 안전하게 중단되었습니다. 진단용 로컬 Release-prod Runner.app 재현에서는 `Frameworks/Flutter.framework/Flutter`의 일반 `PRIVATE_KEY` 문자열만 검출됐고, 앱 소유 파일의 서버 비밀 식별자나 값은 검출되지 않았습니다.

## 주요 변경

- artifact marker 검사를 현재 mobile workflow에서 실제로 금지하는 정확한 서버 환경 식별자로 제한합니다.
- marker failure에는 식별자 이름과 artifact 상대 경로만 기록하며 값은 기록하지 않습니다.
- forbidden value-derived scan은 IPA의 모든 파일과 모든 zip member에서 그대로 수행합니다.

## 위협 모델

일반적인 third-party binary 문자열은 비밀 유출 증거가 아니므로 generic marker만으로 release를 막지 않습니다. 반면 실제 server environment identifier는 모든 artifact 경로에서 계속 차단하고, 설정된 forbidden value의 raw·encoded·compressed 형태는 vendor framework를 포함한 전체 IPA에서 계속 차단합니다. vendor directory 제외 규칙은 추가하지 않습니다.

## 검증

- `python3 app/tool/verify_mobile_client_config.py --self-test --source-root app --workflow .github/workflows/ios-testflight.yml --workflow .github/workflows/ios-production.yml`
- synthetic IPA: Flutter.framework `PRIVATE_KEY` 허용, app-owned exact server marker 실패, vendor forbidden value 실패
- existing local Release-prod Runner.app marker scan 통과
- `python3 -m py_compile app/tool/verify_mobile_client_config.py`
- Fastlane syntax 및 workflow YAML parse
- `flutter test --no-pub test/config/feature_flags_test.dart`
- `flutter analyze --no-fatal-infos`

## 관련 이슈

- BOK-391

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile client configuration verification to detect server-only markers more accurately.
  * Enhanced diagnostics to identify the matched content and its location within files and archives.
  * Added coverage for IPA archives and clearer handling of vendor-provided versus app-owned markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Merge authority packet

- Merge-Authority-ID: review-gated-auto-bookgolas-mobile-1.0.2-pr320-e1fe8d7-20260803
- Owner-Authorization-Source: byungsker standing authority decision path (`review-gated-auto-bookgolas-mobile-1.0.2-20260802`)
- Repository: byungsker/book-golas
- Pull-Request: #320
- Authorized-Head-SHA: e1fe8d7e331c0b8e8d1c37a908270df51e6bf933
- Authorized-Base-Branch: version/mobile/1.0.2
- Authorized-Base-SHA: 4e5d30c255f4d20a7f67ca0e6ee7c2f3ebbf98b5
- Authorized-Scope: mobile 1.0.2
- Work-Branch: codex/fix/mobile/1.0.2/BOK-391-artifact-marker-path
- Merge-Action: merge-commit into version/mobile/1.0.2
- Quality-Decision: APPROVE_NEXT
- Final-Decision: APPROVE_NEXT
- Required-Checks: passing
- Trusted-Base: version/mobile/1.0.2@4e5d30c255f4d20a7f67ca0e6ee7c2f3ebbf98b5
- Merge-Authority-Consumed: 9e7336aa08998abd99cbbe59a3964c7ee97973be
- Rollback-SHA: 9e7336aa08998abd99cbbe59a3964c7ee97973be
