### PR TITLE
fix(accessibility): reflow completed book actions

### DIFF
--- a/app/integration_test/bok389_completed_book_route_test.dart
+++ b/app/integration_test/bok389_completed_book_route_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:provider/provider.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:book_golas/data/services/subscription_service.dart';
+import 'package:book_golas/data/services/book_service.dart';
+import 'package:book_golas/domain/models/book.dart';
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_detail/book_detail_screen.dart';
+import 'package:book_golas/ui/book_detail/view_model/reading_timer_view_model.dart';
+import 'package:book_golas/ui/book_detail/widgets/compact_book_header.dart';
+import 'package:book_golas/ui/core/theme/design_system.dart';
+import 'package:book_golas/ui/core/view_model/ad_view_model.dart';
+import 'package:book_golas/ui/reading_start/widgets/reading_start_screen.dart';
+
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  const captureLocale = String.fromEnvironment('BOK389_CAPTURE_LOCALE');
+  const captureBrightness = String.fromEnvironment('BOK389_CAPTURE_THEME');
+  const evidenceHoldMilliseconds = int.fromEnvironment(
+    'BOK389_EVIDENCE_HOLD_MILLISECONDS',
+  );
+
+  setUpAll(() async {
+    await Supabase.initialize(
+      url: 'http://127.0.0.1:65535',
+      anonKey: 'test-anon-key',
+    );
+  });
+
+  for (final locale in const [Locale('ko'), Locale('en')]) {
+    for (final brightness in Brightness.values) {
+      if (captureLocale.isNotEmpty && captureLocale != locale.languageCode) {
+        continue;
+      }
+      if (captureBrightness.isNotEmpty &&
+          captureBrightness != brightness.name) {
+        continue;
+      }
+      testWidgets(
+        'BOK-389 completed detail route preserves CTA copy, safe area, and restart flow at 393px and 200 percent in ${locale.languageCode} ${brightness.name}',
+        (tester) async {
+          await binding.setSurfaceSize(const Size(393, 852));
+          addTearDown(() => binding.setSurfaceSize(null));
+
+          await tester.pumpWidget(
+            _CompletedBookRouteFixture(
+              locale: locale,
+              brightness: brightness,
+            ),
+          );
+          await tester.pump(const Duration(milliseconds: 300));
+
+          expect(find.byType(BookDetailScreen), findsOneWidget);
+          expect(find.byType(CompactBookHeader), findsOneWidget);
+
+          final l10n = AppLocalizations.of(
+            tester.element(find.byType(BookDetailScreen)),
+          );
+          final reviewCard = find.byKey(
+            const ValueKey('completed-book-review-action'),
+          );
+          final restartCard = find.byKey(
+            const ValueKey('completed-book-restart-action'),
+          );
+
+          await tester.scrollUntilVisible(
+            reviewCard,
+            240,
+            scrollable: find.byType(Scrollable).first,
+          );
+          await tester.scrollUntilVisible(
+            restartCard,
+            240,
+            scrollable: find.byType(Scrollable).first,
+          );
+          await tester.pump();
+
+          for (final text in [
+            l10n.bookDetailWriteReview,
+            l10n.bookDetailRecordThoughts,
+            l10n.bookDetailContinueReading,
+            l10n.bookDetailAchieveGoal,
+          ]) {
+            expect(find.text(text), findsOneWidget);
+          }
+          for (final card in [reviewCard, restartCard]) {
+            expect(tester.getSize(card).shortestSide, greaterThanOrEqualTo(48));
+            expect(tester.getRect(card).bottom, lessThanOrEqualTo(818));
+          }
+          expect(
+            find.semantics.byLabel(
+              '${l10n.bookDetailContinueReading}. ${l10n.bookDetailAchieveGoal}',
+            ),
+            findsOneWidget,
+          );
+          expect(tester.takeException(), isNull);
+
+          await binding.takeScreenshot(
+            'BOK-389-${locale.languageCode}-${brightness.name}-393-200',
+          );
+          await tester.tap(restartCard);
+          await tester.pump(const Duration(milliseconds: 250));
+          expect(find.byType(ReadingStartScreen), findsOneWidget);
+          expect(tester.takeException(), isNull);
+
+          if (evidenceHoldMilliseconds > 0) {
+            await tester.pump(
+              const Duration(milliseconds: evidenceHoldMilliseconds),
+            );
+          }
+        },
+      );
+    }
+  }
+}
+
+class _CompletedBookRouteFixture extends StatelessWidget {
+  const _CompletedBookRouteFixture({
+    required this.locale,
+    required this.brightness,
+  });
+
+  final Locale locale;
+  final Brightness brightness;
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        Provider<BookService>(create: (_) => BookService()),
+        ChangeNotifierProvider(create: (_) => ReadingTimerViewModel()),
+        ChangeNotifierProvider(
+          create: (_) => AdViewModel(SubscriptionService()),
+        ),
+      ],
+      child: MaterialApp(
+        locale: locale,
+        theme: BLabTheme.light,
+        darkTheme: BLabTheme.dark,
+        themeMode:
+            brightness == Brightness.dark ? ThemeMode.dark : ThemeMode.light,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        builder: (context, child) => MediaQuery(
+          data: MediaQuery.of(context).copyWith(
+            textScaler: const TextScaler.linear(2),
+            viewPadding: const EdgeInsets.only(top: 59, bottom: 34),
+          ),
+          child: child!,
+        ),
+        home: BookDetailScreen(
+          loadRemoteData: false,
+          book: Book(
+              id: 'bok-389-completed-route-fixture',
+              title: 'A completed-book route fixture with a long title',
+              author: 'Bookgolas QA',
+              startDate: DateTime(2026, 8, 1),
+              targetDate: DateTime(2026, 8, 2),
+              currentPage: 320,
+              totalPages: 320,
+              status: BookStatus.completed.value),
+        ),
+      ),
+    );
+  }
+}

--- a/app/integration_test/bok389_completed_book_route_test.dart
+++ b/app/integration_test/bok389_completed_book_route_test.dart
@@ -118,15 +118,45 @@ void main() {
             card: restartCard,
             overlayFreeViewportBottom: overlayFreeViewportBottom,
           );
-          _expectActionAboveFloatingBar(
+          _expectCompletedActionsAboveFloatingBar(
             tester,
-            card: restartCard,
-            texts: [
-              l10n.bookDetailContinueReading,
-              l10n.bookDetailAchieveGoal,
+            cards: [
+              _CompletedActionExpectation(
+                card: reviewCard,
+                texts: [
+                  l10n.bookDetailWriteReview,
+                  l10n.bookDetailRecordThoughts,
+                ],
+              ),
+              _CompletedActionExpectation(
+                card: restartCard,
+                texts: [
+                  l10n.bookDetailContinueReading,
+                  l10n.bookDetailAchieveGoal,
+                ],
+              ),
             ],
-            overlayFreeViewportTop: overlayFreeViewportTop,
-            overlayFreeViewportBottom: overlayFreeViewportBottom,
+          );
+          await tester.pump(const Duration(milliseconds: 100));
+          await tester.pump();
+          _expectCompletedActionsAboveFloatingBar(
+            tester,
+            cards: [
+              _CompletedActionExpectation(
+                card: reviewCard,
+                texts: [
+                  l10n.bookDetailWriteReview,
+                  l10n.bookDetailRecordThoughts,
+                ],
+              ),
+              _CompletedActionExpectation(
+                card: restartCard,
+                texts: [
+                  l10n.bookDetailContinueReading,
+                  l10n.bookDetailAchieveGoal,
+                ],
+              ),
+            ],
           );
           expect(
             find.semantics.byLabel(
@@ -161,6 +191,39 @@ void main() {
         },
       );
     }
+  }
+}
+
+class _CompletedActionExpectation {
+  const _CompletedActionExpectation({
+    required this.card,
+    required this.texts,
+  });
+
+  final Finder card;
+  final List<String> texts;
+}
+
+void _expectCompletedActionsAboveFloatingBar(
+  WidgetTester tester, {
+  required List<_CompletedActionExpectation> cards,
+}) {
+  final floatingActionBar = find.byKey(FloatingActionBar.actionBarKey);
+  expect(floatingActionBar, findsOneWidget);
+  final actionBarRect = tester.getRect(floatingActionBar);
+  final overlayFreeViewportBottom =
+      actionBarRect.top - FloatingActionBar.contentSeparation;
+  final overlayFreeViewportTop =
+      tester.getRect(find.byType(AppBar)).bottom + 12;
+
+  for (final action in cards) {
+    _expectActionAboveFloatingBar(
+      tester,
+      card: action.card,
+      texts: action.texts,
+      overlayFreeViewportTop: overlayFreeViewportTop,
+      overlayFreeViewportBottom: overlayFreeViewportBottom,
+    );
   }
 }
 

--- a/app/integration_test/bok389_completed_book_route_test.dart
+++ b/app/integration_test/bok389_completed_book_route_test.dart
@@ -42,6 +42,13 @@ void main() {
       testWidgets(
         'BOK-389 completed detail route preserves CTA copy, safe area, and restart flow at 393px and 200 percent in ${locale.languageCode} ${brightness.name}',
         (tester) async {
+          final originalHitTestWarningShouldBeFatal =
+              WidgetController.hitTestWarningShouldBeFatal;
+          WidgetController.hitTestWarningShouldBeFatal = true;
+          addTearDown(() {
+            WidgetController.hitTestWarningShouldBeFatal =
+                originalHitTestWarningShouldBeFatal;
+          });
           await binding.setSurfaceSize(const Size(393, 852));
           addTearDown(() => binding.setSurfaceSize(null));
 
@@ -66,30 +73,52 @@ void main() {
             const ValueKey('completed-book-restart-action'),
           );
 
-          await tester.scrollUntilVisible(
-            reviewCard,
-            240,
-            scrollable: find.byType(Scrollable).first,
+          final overlayFreeViewportBottom =
+              tester.view.physicalSize.height / tester.view.devicePixelRatio -
+                  62 -
+                  22;
+          final overlayFreeViewportTop =
+              tester.getRect(find.byType(AppBar)).bottom + 12;
+          await _positionActionAboveFloatingBar(
+            tester,
+            card: reviewCard,
+            overlayFreeViewportBottom: overlayFreeViewportBottom,
           );
-          await tester.scrollUntilVisible(
-            restartCard,
-            240,
-            scrollable: find.byType(Scrollable).first,
+          _expectActionAboveFloatingBar(
+            tester,
+            card: reviewCard,
+            texts: [
+              l10n.bookDetailWriteReview,
+              l10n.bookDetailRecordThoughts,
+            ],
+            overlayFreeViewportTop: overlayFreeViewportTop,
+            overlayFreeViewportBottom: overlayFreeViewportBottom,
           );
-          await tester.pump();
-
-          for (final text in [
-            l10n.bookDetailWriteReview,
-            l10n.bookDetailRecordThoughts,
-            l10n.bookDetailContinueReading,
-            l10n.bookDetailAchieveGoal,
-          ]) {
-            expect(find.text(text), findsOneWidget);
-          }
-          for (final card in [reviewCard, restartCard]) {
-            expect(tester.getSize(card).shortestSide, greaterThanOrEqualTo(48));
-            expect(tester.getRect(card).bottom, lessThanOrEqualTo(818));
-          }
+          await _positionActionAboveFloatingBar(
+            tester,
+            card: restartCard,
+            overlayFreeViewportBottom: overlayFreeViewportBottom,
+          );
+          _expectActionAboveFloatingBar(
+            tester,
+            card: restartCard,
+            texts: [
+              l10n.bookDetailContinueReading,
+              l10n.bookDetailAchieveGoal,
+            ],
+            overlayFreeViewportTop: overlayFreeViewportTop,
+            overlayFreeViewportBottom: overlayFreeViewportBottom,
+          );
+          _expectActionAboveFloatingBar(
+            tester,
+            card: reviewCard,
+            texts: [
+              l10n.bookDetailWriteReview,
+              l10n.bookDetailRecordThoughts,
+            ],
+            overlayFreeViewportTop: overlayFreeViewportTop,
+            overlayFreeViewportBottom: overlayFreeViewportBottom,
+          );
           expect(
             find.semantics.byLabel(
               '${l10n.bookDetailContinueReading}. ${l10n.bookDetailAchieveGoal}',
@@ -97,23 +126,64 @@ void main() {
             findsOneWidget,
           );
           expect(tester.takeException(), isNull);
-
           await binding.takeScreenshot(
-            'BOK-389-${locale.languageCode}-${brightness.name}-393-200',
+            'BOK-389-${locale.languageCode}-${brightness.name}-393-200-both-ctas',
           );
-          await tester.tap(restartCard);
-          await tester.pump(const Duration(milliseconds: 250));
-          expect(find.byType(ReadingStartScreen), findsOneWidget);
-          expect(tester.takeException(), isNull);
 
           if (evidenceHoldMilliseconds > 0) {
             await tester.pump(
               const Duration(milliseconds: evidenceHoldMilliseconds),
             );
           }
+
+          await tester.tap(restartCard);
+          await tester.pump(const Duration(milliseconds: 250));
+          await tester.pump();
+          expect(find.byType(ReadingStartScreen), findsOneWidget);
+          expect(tester.takeException(), isNull);
         },
       );
     }
+  }
+}
+
+Future<void> _positionActionAboveFloatingBar(
+  WidgetTester tester, {
+  required Finder card,
+  required double overlayFreeViewportBottom,
+}) async {
+  await tester.pump();
+  final position = Scrollable.maybeOf(tester.element(card))!.position;
+  final cardRect = tester.getRect(card);
+  final targetOffset = (position.pixels +
+          cardRect.bottom -
+          (overlayFreeViewportBottom - 12))
+      .clamp(
+    position.minScrollExtent,
+    position.maxScrollExtent,
+  ).toDouble();
+  position.jumpTo(targetOffset);
+  await tester.pump();
+}
+
+void _expectActionAboveFloatingBar(
+  WidgetTester tester, {
+  required Finder card,
+  required List<String> texts,
+  required double overlayFreeViewportTop,
+  required double overlayFreeViewportBottom,
+}) {
+  final cardRect = tester.getRect(card);
+  expect(tester.getSize(card).shortestSide, greaterThanOrEqualTo(48));
+  expect(cardRect.top, greaterThanOrEqualTo(overlayFreeViewportTop));
+  expect(cardRect.bottom, lessThanOrEqualTo(overlayFreeViewportBottom));
+
+  for (final text in texts) {
+    final textFinder = find.text(text);
+    expect(textFinder, findsOneWidget);
+    final textRect = tester.getRect(textFinder);
+    expect(textRect.top, greaterThanOrEqualTo(overlayFreeViewportTop));
+    expect(textRect.bottom, lessThanOrEqualTo(overlayFreeViewportBottom));
   }
 }
 

--- a/app/integration_test/bok389_completed_book_route_test.dart
+++ b/app/integration_test/bok389_completed_book_route_test.dart
@@ -11,6 +11,7 @@ import 'package:book_golas/l10n/app_localizations.dart';
 import 'package:book_golas/ui/book_detail/book_detail_screen.dart';
 import 'package:book_golas/ui/book_detail/view_model/reading_timer_view_model.dart';
 import 'package:book_golas/ui/book_detail/widgets/compact_book_header.dart';
+import 'package:book_golas/ui/book_detail/widgets/floating_action_bar.dart';
 import 'package:book_golas/ui/core/theme/design_system.dart';
 import 'package:book_golas/ui/core/view_model/ad_view_model.dart';
 import 'package:book_golas/ui/reading_start/widgets/reading_start_screen.dart';
@@ -52,6 +53,14 @@ void main() {
           await binding.setSurfaceSize(const Size(393, 852));
           addTearDown(() => binding.setSurfaceSize(null));
 
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          expect(find.byType(ReadingStartScreen), findsNothing);
+          expect(
+            find.byKey(FloatingActionBar.actionBarKey),
+            findsNothing,
+          );
+
           await tester.pumpWidget(
             _CompletedBookRouteFixture(
               locale: locale,
@@ -73,12 +82,22 @@ void main() {
             const ValueKey('completed-book-restart-action'),
           );
 
+          final floatingActionBar = find.byKey(FloatingActionBar.actionBarKey);
+          expect(floatingActionBar, findsOneWidget);
+          final actionBarRect = tester.getRect(floatingActionBar);
           final overlayFreeViewportBottom =
-              tester.view.physicalSize.height / tester.view.devicePixelRatio -
-                  62 -
-                  22;
+              actionBarRect.top - FloatingActionBar.contentSeparation;
           final overlayFreeViewportTop =
               tester.getRect(find.byType(AppBar)).bottom + 12;
+          final viewportBottom = tester.getRect(find.byType(Scaffold)).bottom;
+          expect(
+            actionBarRect.bottom,
+            lessThanOrEqualTo(
+              viewportBottom -
+                  FloatingActionBar.bottomOffset -
+                  _CompletedBookRouteFixture.bottomSafeArea,
+            ),
+          );
           await _positionActionAboveFloatingBar(
             tester,
             card: reviewCard,
@@ -109,16 +128,6 @@ void main() {
             overlayFreeViewportTop: overlayFreeViewportTop,
             overlayFreeViewportBottom: overlayFreeViewportBottom,
           );
-          _expectActionAboveFloatingBar(
-            tester,
-            card: reviewCard,
-            texts: [
-              l10n.bookDetailWriteReview,
-              l10n.bookDetailRecordThoughts,
-            ],
-            overlayFreeViewportTop: overlayFreeViewportTop,
-            overlayFreeViewportBottom: overlayFreeViewportBottom,
-          );
           expect(
             find.semantics.byLabel(
               '${l10n.bookDetailContinueReading}. ${l10n.bookDetailAchieveGoal}',
@@ -141,6 +150,14 @@ void main() {
           await tester.pump();
           expect(find.byType(ReadingStartScreen), findsOneWidget);
           expect(tester.takeException(), isNull);
+
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          expect(find.byType(ReadingStartScreen), findsNothing);
+          expect(
+            find.byKey(FloatingActionBar.actionBarKey),
+            findsNothing,
+          );
         },
       );
     }
@@ -155,13 +172,13 @@ Future<void> _positionActionAboveFloatingBar(
   await tester.pump();
   final position = Scrollable.maybeOf(tester.element(card))!.position;
   final cardRect = tester.getRect(card);
-  final targetOffset = (position.pixels +
-          cardRect.bottom -
-          (overlayFreeViewportBottom - 12))
-      .clamp(
-    position.minScrollExtent,
-    position.maxScrollExtent,
-  ).toDouble();
+  final targetOffset =
+      (position.pixels + cardRect.bottom - (overlayFreeViewportBottom - 12))
+          .clamp(
+            position.minScrollExtent,
+            position.maxScrollExtent,
+          )
+          .toDouble();
   position.jumpTo(targetOffset);
   await tester.pump();
 }
@@ -188,6 +205,8 @@ void _expectActionAboveFloatingBar(
 }
 
 class _CompletedBookRouteFixture extends StatelessWidget {
+  static const bottomSafeArea = 34.0;
+
   const _CompletedBookRouteFixture({
     required this.locale,
     required this.brightness,
@@ -207,6 +226,9 @@ class _CompletedBookRouteFixture extends StatelessWidget {
         ),
       ],
       child: MaterialApp(
+        key: ValueKey(
+          'bok389-material-app-${locale.languageCode}-${brightness.name}',
+        ),
         locale: locale,
         theme: BLabTheme.light,
         darkTheme: BLabTheme.dark,
@@ -217,11 +239,14 @@ class _CompletedBookRouteFixture extends StatelessWidget {
         builder: (context, child) => MediaQuery(
           data: MediaQuery.of(context).copyWith(
             textScaler: const TextScaler.linear(2),
-            viewPadding: const EdgeInsets.only(top: 59, bottom: 34),
+            viewPadding: const EdgeInsets.only(top: 59, bottom: bottomSafeArea),
           ),
           child: child!,
         ),
         home: BookDetailScreen(
+          key: ValueKey(
+            'bok389-book-detail-${locale.languageCode}-${brightness.name}',
+          ),
           loadRemoteData: false,
           book: Book(
               id: 'bok-389-completed-route-fixture',

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -139,6 +139,7 @@ class _BookDetailContentState extends State<_BookDetailContent>
   late AnimationController _progressAnimController;
   late Animation<double> _progressAnimation;
   double _animatedProgress = 0.0;
+  double? _floatingActionBarHeight;
   final ScrollController _scrollController = ScrollController();
 
   // Confetti 컨트롤러
@@ -154,6 +155,19 @@ class _BookDetailContentState extends State<_BookDetailContent>
 
   void _onTabChanged() {
     if (mounted) setState(() {});
+  }
+
+  void _updateFloatingActionBarHeight(double height) {
+    if (!mounted ||
+        (_floatingActionBarHeight != null &&
+            (_floatingActionBarHeight! - height).abs() < 0.5)) {
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        setState(() => _floatingActionBarHeight = height);
+      }
+    });
   }
 
   void _updateTabControllerIfNeeded(Book book) {
@@ -470,10 +484,10 @@ class _BookDetailContentState extends State<_BookDetailContent>
                                 _buildRestartReadingButton(context),
                               ],
                               SizedBox(
-                                height: !_isBookPlanned(book) &&
-                                        !widget.isEmbedded
-                                    ? 104
-                                    : 20,
+                                height: _completedActionBottomClearance(
+                                  context,
+                                  book,
+                                ),
                               ),
                             ],
                           ),
@@ -595,6 +609,7 @@ class _BookDetailContentState extends State<_BookDetailContent>
                           : null,
                       isReadingMode: _isBookReading(bookVm.currentBook),
                       isTimerRunning: timerVm.isRunning,
+                      onHeightChanged: _updateFloatingActionBarHeight,
                     );
                   },
                 ),
@@ -1551,6 +1566,20 @@ class _BookDetailContentState extends State<_BookDetailContent>
       description: AppLocalizations.of(context).bookDetailAchieveGoal,
       icon: Icons.refresh_rounded,
       onTap: () => _navigateToReadingStart(context),
+    );
+  }
+
+  double _completedActionBottomClearance(BuildContext context, Book book) {
+    if (widget.isEmbedded || _isBookPlanned(book) || !_isBookCompleted(book)) {
+      return 20;
+    }
+    return FloatingActionBar.contentBottomClearance(
+      actionBarHeight: _floatingActionBarHeight ??
+          FloatingActionBar.minimumHeightFor(
+            context,
+            isReadingMode: false,
+          ),
+      bottomSafeArea: MediaQuery.viewPaddingOf(context).bottom,
     );
   }
 

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -469,7 +469,12 @@ class _BookDetailContentState extends State<_BookDetailContent>
                                 const SizedBox(height: 12),
                                 _buildRestartReadingButton(context),
                               ],
-                              const SizedBox(height: 20),
+                              SizedBox(
+                                height: !_isBookPlanned(book) &&
+                                        !widget.isEmbedded
+                                    ? 104
+                                    : 20,
+                              ),
                             ],
                           ),
                         ),

--- a/app/lib/ui/book_detail/book_detail_screen.dart
+++ b/app/lib/ui/book_detail/book_detail_screen.dart
@@ -53,6 +53,7 @@ import 'package:book_golas/ui/book_detail/widgets/reading_timer_modal.dart';
 import 'package:book_golas/ui/core/widgets/floating_timer_bar.dart';
 import 'package:book_golas/data/services/book_share_service.dart';
 import 'widgets/book_share_composer.dart';
+import 'widgets/completed_book_action_card.dart';
 
 class BookDetailScreen extends StatelessWidget {
   final Book book;
@@ -466,7 +467,7 @@ class _BookDetailContentState extends State<_BookDetailContent>
                                   _buildBookReviewButton(context, book),
                                 ],
                                 const SizedBox(height: 12),
-                                _buildRestartReadingButton(context, book),
+                                _buildRestartReadingButton(context),
                               ],
                               const SizedBox(height: 20),
                             ],
@@ -1523,151 +1524,28 @@ class _BookDetailContentState extends State<_BookDetailContent>
   }
 
   Widget _buildBookReviewButton(BuildContext context, Book book) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
     final hasReview = book.longReview != null && book.longReview!.isNotEmpty;
 
-    return GestureDetector(
+    return CompletedBookActionCard(
+      cardKey: const ValueKey('completed-book-review-action'),
+      title: hasReview
+          ? AppLocalizations.of(context).bookDetailEditReview
+          : AppLocalizations.of(context).bookDetailWriteReview,
+      description: hasReview
+          ? AppLocalizations.of(context).bookDetailReviewYourWritten
+          : AppLocalizations.of(context).bookDetailRecordThoughts,
+      icon: CupertinoIcons.pencil_outline,
       onTap: () => _navigateToBookReview(context, book),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-        decoration: BoxDecoration(
-          color: isDark ? BLabColors.surfaceDark : Colors.white,
-          borderRadius: BorderRadius.circular(12),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: isDark ? 0.2 : 0.04),
-              blurRadius: 8,
-              offset: const Offset(0, 2),
-            ),
-          ],
-        ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Row(
-              children: [
-                Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    color: BLabColors.primary.withValues(alpha: 0.1),
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  child: const Icon(
-                    CupertinoIcons.pencil_outline,
-                    color: BLabColors.primary,
-                    size: 22,
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      hasReview
-                          ? AppLocalizations.of(context).bookDetailEditReview
-                          : AppLocalizations.of(context).bookDetailWriteReview,
-                      style: TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w600,
-                        color: isDark ? Colors.white : Colors.black,
-                      ),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      hasReview
-                          ? AppLocalizations.of(context)
-                              .bookDetailReviewYourWritten
-                          : AppLocalizations.of(context)
-                              .bookDetailRecordThoughts,
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: isDark ? Colors.grey[400] : Colors.grey[600],
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-            Icon(
-              CupertinoIcons.chevron_right,
-              color: isDark ? Colors.grey[400] : Colors.grey[500],
-              size: 20,
-            ),
-          ],
-        ),
-      ),
     );
   }
 
-  Widget _buildRestartReadingButton(BuildContext context, Book book) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-
-    return GestureDetector(
+  Widget _buildRestartReadingButton(BuildContext context) {
+    return CompletedBookActionCard(
+      cardKey: const ValueKey('completed-book-restart-action'),
+      title: AppLocalizations.of(context).bookDetailContinueReading,
+      description: AppLocalizations.of(context).bookDetailAchieveGoal,
+      icon: Icons.refresh_rounded,
       onTap: () => _navigateToReadingStart(context),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-        decoration: BoxDecoration(
-          color: isDark ? BLabColors.surfaceDark : Colors.white,
-          borderRadius: BorderRadius.circular(12),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: isDark ? 0.2 : 0.04),
-              blurRadius: 8,
-              offset: const Offset(0, 2),
-            ),
-          ],
-        ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Row(
-              children: [
-                Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    color: BLabColors.primary.withValues(alpha: 0.1),
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  child: const Icon(
-                    Icons.refresh_rounded,
-                    color: BLabColors.primary,
-                    size: 22,
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      AppLocalizations.of(context).bookDetailContinueReading,
-                      style: TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w600,
-                        color: isDark ? Colors.white : Colors.black,
-                      ),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      AppLocalizations.of(context).bookDetailAchieveGoal,
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: isDark ? Colors.grey[400] : Colors.grey[600],
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-            Icon(
-              CupertinoIcons.chevron_right,
-              color: isDark ? Colors.grey[400] : Colors.grey[500],
-              size: 20,
-            ),
-          ],
-        ),
-      ),
     );
   }
 

--- a/app/lib/ui/book_detail/widgets/completed_book_action_card.dart
+++ b/app/lib/ui/book_detail/widgets/completed_book_action_card.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'package:book_golas/ui/core/theme/design_system.dart';
+
+class CompletedBookActionCard extends StatelessWidget {
+  const CompletedBookActionCard({
+    super.key,
+    required this.cardKey,
+    required this.title,
+    required this.description,
+    required this.icon,
+    required this.onTap,
+  });
+
+  final Key cardKey;
+  final String title;
+  final String description;
+  final IconData icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final textScale = MediaQuery.textScalerOf(context).scale(15);
+
+    return Semantics(
+      button: true,
+      excludeSemantics: true,
+      label: '$title. $description',
+      onTap: onTap,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: 48),
+        child: Material(
+          color: isDark ? BLabColors.surfaceDark : Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          child: InkWell(
+            key: cardKey,
+            borderRadius: BorderRadius.circular(12),
+            onTap: onTap,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: isDark ? 0.2 : 0.04),
+                    blurRadius: 8,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final shouldStack =
+                      textScale >= 1.3 || constraints.maxWidth < 300;
+                  return shouldStack
+                      ? _StackedCardContent(
+                          icon: icon,
+                          title: title,
+                          description: description,
+                          isDark: isDark,
+                        )
+                      : _InlineCardContent(
+                          icon: icon,
+                          title: title,
+                          description: description,
+                          isDark: isDark,
+                        );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _InlineCardContent extends StatelessWidget {
+  const _InlineCardContent({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.isDark,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        _ActionIcon(icon: icon),
+        const SizedBox(width: 12),
+        Expanded(
+          child: _ActionText(
+            title: title,
+            description: description,
+            isDark: isDark,
+          ),
+        ),
+        const SizedBox(width: 8),
+        _Chevron(isDark: isDark),
+      ],
+    );
+  }
+}
+
+class _StackedCardContent extends StatelessWidget {
+  const _StackedCardContent({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.isDark,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _ActionIcon(icon: icon),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                title,
+                key: const ValueKey('completed-book-action-title-stacked'),
+                style: _titleStyle(isDark),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        Padding(
+          padding: const EdgeInsets.only(left: 52),
+          child: Text(
+            description,
+            key: const ValueKey('completed-book-action-description-stacked'),
+            style: _descriptionStyle(isDark),
+          ),
+        ),
+        const SizedBox(height: 6),
+        Align(
+          alignment: Alignment.centerRight,
+          child: _Chevron(isDark: isDark),
+        ),
+      ],
+    );
+  }
+}
+
+class _ActionIcon extends StatelessWidget {
+  const _ActionIcon({required this.icon});
+
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        color: BLabColors.primary.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Icon(icon, color: BLabColors.primary, size: 22),
+    );
+  }
+}
+
+class _ActionText extends StatelessWidget {
+  const _ActionText({
+    required this.title,
+    required this.description,
+    required this.isDark,
+  });
+
+  final String title;
+  final String description;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: _titleStyle(isDark)),
+        const SizedBox(height: 2),
+        Text(description, style: _descriptionStyle(isDark)),
+      ],
+    );
+  }
+}
+
+class _Chevron extends StatelessWidget {
+  const _Chevron({required this.isDark});
+
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Icon(
+      CupertinoIcons.chevron_right,
+      color: isDark ? Colors.grey[400] : Colors.grey[500],
+      size: 20,
+    );
+  }
+}
+
+TextStyle _titleStyle(bool isDark) {
+  return TextStyle(
+    fontSize: 15,
+    fontWeight: FontWeight.w600,
+    color: isDark ? Colors.white : Colors.black,
+  );
+}
+
+TextStyle _descriptionStyle(bool isDark) {
+  return TextStyle(
+    fontSize: 12,
+    color: isDark ? Colors.grey[400] : Colors.grey[600],
+  );
+}

--- a/app/lib/ui/book_detail/widgets/completed_book_action_card.dart
+++ b/app/lib/ui/book_detail/widgets/completed_book_action_card.dart
@@ -22,7 +22,8 @@ class CompletedBookActionCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    final textScale = MediaQuery.textScalerOf(context).scale(15);
+    final textScaleFactor =
+        MediaQuery.textScalerOf(context).scale(15) / 15;
 
     return Semantics(
       button: true,
@@ -53,7 +54,7 @@ class CompletedBookActionCard extends StatelessWidget {
               child: LayoutBuilder(
                 builder: (context, constraints) {
                   final shouldStack =
-                      textScale >= 1.3 || constraints.maxWidth < 300;
+                      textScaleFactor >= 1.3 || constraints.maxWidth < 300;
                   return shouldStack
                       ? _StackedCardContent(
                           icon: icon,
@@ -198,9 +199,17 @@ class _ActionText extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(title, style: _titleStyle(isDark)),
+        Text(
+          title,
+          key: const ValueKey('completed-book-action-title-inline'),
+          style: _titleStyle(isDark),
+        ),
         const SizedBox(height: 2),
-        Text(description, style: _descriptionStyle(isDark)),
+        Text(
+          description,
+          key: const ValueKey('completed-book-action-description-inline'),
+          style: _descriptionStyle(isDark),
+        ),
       ],
     );
   }

--- a/app/lib/ui/book_detail/widgets/floating_action_bar.dart
+++ b/app/lib/ui/book_detail/widgets/floating_action_bar.dart
@@ -1,17 +1,24 @@
 import 'dart:ui';
+import 'dart:math' as math;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 
 import 'package:book_golas/l10n/app_localizations.dart';
 import 'package:book_golas/ui/core/theme/design_system.dart';
 import 'package:book_golas/ui/core/widgets/floating_context_dropdown.dart';
 
 class FloatingActionBar extends StatelessWidget {
+  static const double bottomOffset = 22;
+  static const double contentSeparation = 16;
+  static const actionBarKey = ValueKey('book-detail-floating-action-bar');
+
   final VoidCallback? onUpdatePageTap;
   final VoidCallback onAddMemorablePageTap;
   final VoidCallback? onRecallSearchTap;
   final VoidCallback? onTimerTap;
+  final ValueChanged<double>? onHeightChanged;
   final bool isReadingMode;
   final bool isTimerRunning;
 
@@ -21,6 +28,7 @@ class FloatingActionBar extends StatelessWidget {
     required this.onAddMemorablePageTap,
     this.onRecallSearchTap,
     this.onTimerTap,
+    this.onHeightChanged,
     this.isReadingMode = true,
     this.isTimerRunning = false,
   });
@@ -29,24 +37,89 @@ class FloatingActionBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
+    final bottomSafeArea = MediaQuery.viewPaddingOf(context).bottom;
+
     return Positioned(
       left: 16,
       right: 16,
-      bottom: 22,
-      child: isReadingMode
-          ? _ReadingModeBar(
-              isDark: isDark,
-              onUpdatePageTap: onUpdatePageTap,
-              onAddMemorablePageTap: onAddMemorablePageTap,
-              onRecallSearchTap: onRecallSearchTap,
-              onTimerTap: onTimerTap,
-            )
-          : _CompletedModeBar(
-              isDark: isDark,
-              onAddMemorablePageTap: onAddMemorablePageTap,
-              onRecallSearchTap: onRecallSearchTap,
-            ),
+      bottom: bottomOffset + bottomSafeArea,
+      child: _MeasureSize(
+        key: actionBarKey,
+        onChange: (size) => onHeightChanged?.call(size.height),
+        child: isReadingMode
+            ? _ReadingModeBar(
+                isDark: isDark,
+                onUpdatePageTap: onUpdatePageTap,
+                onAddMemorablePageTap: onAddMemorablePageTap,
+                onRecallSearchTap: onRecallSearchTap,
+                onTimerTap: onTimerTap,
+              )
+            : _CompletedModeBar(
+                isDark: isDark,
+                onAddMemorablePageTap: onAddMemorablePageTap,
+                onRecallSearchTap: onRecallSearchTap,
+              ),
+      ),
     );
+  }
+
+  static double contentBottomClearance({
+    required double actionBarHeight,
+    required double bottomSafeArea,
+  }) {
+    return actionBarHeight + bottomOffset + bottomSafeArea + contentSeparation;
+  }
+
+  static double minimumHeightFor(
+    BuildContext context, {
+    required bool isReadingMode,
+  }) {
+    final textScale = MediaQuery.textScalerOf(context).scale(1);
+    final buttonHeight = math
+        .max(62, MediaQuery.textScalerOf(context).scale(15) * 2.4 + 16)
+        .toDouble();
+    if (isReadingMode && textScale >= 1.4) {
+      return buttonHeight * 2 + 8;
+    }
+    return buttonHeight;
+  }
+}
+
+class _MeasureSize extends SingleChildRenderObjectWidget {
+  const _MeasureSize({
+    super.key,
+    required this.onChange,
+    required super.child,
+  });
+
+  final ValueChanged<Size> onChange;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _RenderMeasureSize(onChange);
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    covariant _RenderMeasureSize renderObject,
+  ) {
+    renderObject.onChange = onChange;
+  }
+}
+
+class _RenderMeasureSize extends RenderProxyBox {
+  _RenderMeasureSize(this.onChange);
+
+  ValueChanged<Size> onChange;
+  Size? _oldSize;
+
+  @override
+  void performLayout() {
+    super.performLayout();
+    if (size == _oldSize) return;
+    _oldSize = size;
+    WidgetsBinding.instance.addPostFrameCallback((_) => onChange(size));
   }
 }
 

--- a/app/test/ui/book_detail/widgets/completed_book_action_card_test.dart
+++ b/app/test/ui/book_detail/widgets/completed_book_action_card_test.dart
@@ -7,6 +7,47 @@ import 'package:book_golas/ui/book_detail/widgets/completed_book_action_card.dar
 import 'package:book_golas/ui/core/theme/design_system.dart';
 
 void main() {
+  for (final locale in const [Locale('ko'), Locale('en')]) {
+    testWidgets(
+      'completed actions stay inline at default scale on 393px in ${locale.languageCode}',
+      (tester) async {
+        final actions = _ActionCounts();
+        await _pumpCompletedActions(
+          tester,
+          testCase: (
+            locale: locale,
+            themeMode: ThemeMode.light,
+            width: 393.0,
+          ),
+          actions: actions,
+          textScale: 1,
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(
+          find.byKey(const ValueKey('completed-book-action-title-inline')),
+          findsNWidgets(2),
+        );
+        expect(
+          find.byKey(
+            const ValueKey('completed-book-action-description-inline'),
+          ),
+          findsNWidgets(2),
+        );
+        expect(
+          find.byKey(const ValueKey('completed-book-action-title-stacked')),
+          findsNothing,
+        );
+        expect(
+          find.byKey(
+            const ValueKey('completed-book-action-description-stacked'),
+          ),
+          findsNothing,
+        );
+      },
+    );
+  }
+
   final testCases = <({Locale locale, ThemeMode themeMode, double width})>[
     for (final locale in const [Locale('ko'), Locale('en')])
       for (final themeMode in const [ThemeMode.light, ThemeMode.dark])

--- a/app/test/ui/book_detail/widgets/completed_book_action_card_test.dart
+++ b/app/test/ui/book_detail/widgets/completed_book_action_card_test.dart
@@ -66,6 +66,14 @@ void main() {
     ) async {
       final actions = _ActionCounts();
       final semantics = tester.ensureSemantics();
+      var semanticsDisposed = false;
+      void disposeSemantics() {
+        if (semanticsDisposed) return;
+        semanticsDisposed = true;
+        semantics.dispose();
+      }
+
+      addTearDown(disposeSemantics);
 
       await _pumpCompletedActions(
         tester,
@@ -117,7 +125,7 @@ void main() {
       await tester.pump();
       expect(actions.review, 1);
       expect(actions.restart, 1);
-      semantics.dispose();
+      disposeSemantics();
     });
   }
 }

--- a/app/test/ui/book_detail/widgets/completed_book_action_card_test.dart
+++ b/app/test/ui/book_detail/widgets/completed_book_action_card_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:book_golas/l10n/app_localizations.dart';
+import 'package:book_golas/ui/book_detail/widgets/completed_book_action_card.dart';
+import 'package:book_golas/ui/core/theme/design_system.dart';
+
+void main() {
+  final testCases = <({Locale locale, ThemeMode themeMode, double width})>[
+    for (final locale in const [Locale('ko'), Locale('en')])
+      for (final themeMode in const [ThemeMode.light, ThemeMode.dark])
+        for (final width in const [320.0, 393.0])
+          (locale: locale, themeMode: themeMode, width: width),
+  ];
+
+  for (final testCase in testCases) {
+    final label =
+        '${testCase.locale.languageCode} ${testCase.themeMode.name} ${testCase.width.toInt()}px';
+
+    testWidgets(
+        'completed actions reflow without truncation at 200 percent in $label',
+        (
+      tester,
+    ) async {
+      final actions = _ActionCounts();
+      final semantics = tester.ensureSemantics();
+
+      await _pumpCompletedActions(
+        tester,
+        testCase: testCase,
+        actions: actions,
+        textScale: 2,
+      );
+
+      final isKorean = testCase.locale.languageCode == 'ko';
+      final reviewTitle = isKorean ? '독후감 쓰러가기' : 'Write Review';
+      final reviewDescription =
+          isKorean ? '생각을 기록해보세요' : 'Record your thoughts';
+      final restartTitle = isKorean ? '새로운 독서 시작하기' : 'Continue Reading';
+      final restartDescription =
+          isKorean ? '독서 목표를 달성해보세요!' : 'Achieve your reading goal!';
+
+      expect(tester.takeException(), isNull);
+      expect(find.byKey(const ValueKey('completed-book-action-title-stacked')),
+          findsNWidgets(2));
+      expect(
+          find.byKey(
+              const ValueKey('completed-book-action-description-stacked')),
+          findsNWidgets(2));
+      _expectFitsInsideCard(
+          tester, 'completed-book-review-action', reviewTitle);
+      _expectFitsInsideCard(
+          tester, 'completed-book-review-action', reviewDescription);
+      _expectFitsInsideCard(
+          tester, 'completed-book-restart-action', restartTitle);
+      _expectFitsInsideCard(
+          tester, 'completed-book-restart-action', restartDescription);
+
+      final reviewCard =
+          find.byKey(const ValueKey('completed-book-review-action'));
+      final restartCard =
+          find.byKey(const ValueKey('completed-book-restart-action'));
+      expect(tester.getSize(reviewCard).shortestSide, greaterThanOrEqualTo(48));
+      expect(
+          tester.getSize(restartCard).shortestSide, greaterThanOrEqualTo(48));
+      expect(find.semantics.byLabel('$reviewTitle. $reviewDescription'),
+          findsOneWidget);
+      final restartSemantics =
+          find.semantics.byLabel('$restartTitle. $restartDescription');
+      expect(restartSemantics, findsOneWidget);
+
+      await tester.tap(reviewCard);
+      await tester.pump();
+      tester.semantics.tap(restartSemantics);
+      await tester.pump();
+      expect(actions.review, 1);
+      expect(actions.restart, 1);
+      semantics.dispose();
+    });
+  }
+}
+
+void _expectFitsInsideCard(WidgetTester tester, String cardKey, String text) {
+  final cardRect = tester.getRect(find.byKey(ValueKey(cardKey)));
+  final textRect = tester.getRect(find.text(text));
+  expect(textRect.left, greaterThanOrEqualTo(cardRect.left));
+  expect(textRect.right, lessThanOrEqualTo(cardRect.right));
+  expect(textRect.top, greaterThanOrEqualTo(cardRect.top));
+  expect(textRect.bottom, lessThanOrEqualTo(cardRect.bottom));
+}
+
+Future<void> _pumpCompletedActions(
+  WidgetTester tester, {
+  required ({Locale locale, ThemeMode themeMode, double width}) testCase,
+  required _ActionCounts actions,
+  required double textScale,
+}) async {
+  tester.view.physicalSize = Size(testCase.width, 852);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: testCase.locale,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      theme: BLabTheme.light,
+      darkTheme: BLabTheme.dark,
+      themeMode: testCase.themeMode,
+      builder: (context, appChild) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(
+          textScaler: TextScaler.linear(textScale),
+        ),
+        child: appChild!,
+      ),
+      home: Scaffold(
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(20),
+          child: Builder(
+            builder: (context) {
+              final l10n = AppLocalizations.of(context);
+              return Column(
+                children: [
+                  CompletedBookActionCard(
+                    cardKey: const ValueKey('completed-book-review-action'),
+                    title: l10n.bookDetailWriteReview,
+                    description: l10n.bookDetailRecordThoughts,
+                    icon: CupertinoIcons.pencil_outline,
+                    onTap: () => actions.review += 1,
+                  ),
+                  const SizedBox(height: 12),
+                  CompletedBookActionCard(
+                    cardKey: const ValueKey('completed-book-restart-action'),
+                    title: l10n.bookDetailContinueReading,
+                    description: l10n.bookDetailAchieveGoal,
+                    icon: Icons.refresh_rounded,
+                    onTap: () => actions.restart += 1,
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+class _ActionCounts {
+  int review = 0;
+  int restart = 0;
+}

--- a/app/test_driver/bok389_integration_test.dart
+++ b/app/test_driver/bok389_integration_test.dart
@@ -3,10 +3,8 @@ import 'dart:io';
 import 'package:integration_test/integration_test_driver_extended.dart';
 
 Future<void> main() {
-  final evidenceDirectory = Platform.environment['BOK389_EVIDENCE_DIR'];
-  if (evidenceDirectory == null || evidenceDirectory.isEmpty) {
-    throw StateError('BOK389_EVIDENCE_DIR must be set for native evidence.');
-  }
+  final evidenceDirectory =
+      Platform.environment['BOK389_EVIDENCE_DIR'] ?? 'build/bok389-evidence';
 
   return integrationDriver(
     onScreenshot: (name, bytes, [args]) async {

--- a/app/test_driver/bok389_integration_test.dart
+++ b/app/test_driver/bok389_integration_test.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+
+import 'package:integration_test/integration_test_driver_extended.dart';
+
+Future<void> main() {
+  final evidenceDirectory = Platform.environment['BOK389_EVIDENCE_DIR'];
+  if (evidenceDirectory == null || evidenceDirectory.isEmpty) {
+    throw StateError('BOK389_EVIDENCE_DIR must be set for native evidence.');
+  }
+
+  return integrationDriver(
+    onScreenshot: (name, bytes, [args]) async {
+      final file = File('$evidenceDirectory/$name.png');
+      await file.parent.create(recursive: true);
+      await file.writeAsBytes(bytes, flush: true);
+      return true;
+    },
+  );
+}


### PR DESCRIPTION
Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store

## BOK-389: 완료 도서 CTA의 대형 글자 접근성 수정

### 문제

완료 도서 상세에서 200% 글자 크기를 쓰면 재독 CTA의 제목·설명이 잘리거나, 고정된 `기록` 바와 CTA 카드가 겹칠 수 있었습니다. 기존 증거는 최종 스크롤 위치에서 두 CTA를 동시에 재확인하지 않아 화면 캡처와 기하 검증이 어긋날 여지가 있었습니다.

### 변경

- 실제 글자 배율 비율로 CTA 카드의 inline/stacked reflow를 결정했습니다.
- 완료 도서 CTA 구간에 고정 `기록` 바 높이와 간격만큼의 스크롤 여유를 부여했습니다.
- 한국어·영어, light·dark, 320px·393px, 200% 글자 배율의 위젯 회귀를 추가했습니다.
- 최종 스크롤 위치에서 실제 렌더된 `기록` 바를 다시 측정하고, 두 CTA 카드와 네 문구가 모두 그 위에 있는지 동시에 검증한 뒤 100ms와 한 프레임 후에 다시 검증하고 캡처합니다.
- 실제 iOS 완료 도서 경로에서 CTA 전체 문구·의미·최소 터치 영역·재독 후 `ReadingStartScreen` 이동을 검증했습니다.

### 검증

- `cd app && flutter test test/ui/book_detail/widgets/completed_book_action_card_test.dart` → 10 passed
- `flutter analyze` (변경 범위) → 오류·경고 없음; 기존 `use_build_context_synchronously` info 4건
- 실제 iOS `flutter drive` → `All tests passed!`
  - iPhone 17e / iOS 26.5, 393 × 852pt, 200% text
  - Korean/English × light/dark
  - 두 CTA와 전체 문구가 AppBar와 고정 `기록` 바 사이에 동시에 완전히 보이고, 재독 이동이 가능한지 확인

### Exact-head 증거

- Head: `fd3a780716f9df05730fcebe086a0c79fa18e2d2`
- Base: `539a0d4a3744d644472e129317bf926409ad7ba8`
- 네 개의 현재 헤드 캡처와 SHA-256: `project/bookgolas/evidence/BOK-389/exact-head-fd3a780/README.md`
  - `BOK-389-ko-light-393-200-both-ctas.png`
  - `BOK-389-ko-dark-393-200-both-ctas.png`
  - `BOK-389-en-light-393-200-both-ctas.png`
  - `BOK-389-en-dark-393-200-both-ctas.png`

### 관련 이슈

- BOK-389
- Supersedes: #316

Product Design 및 Quality의 exact-head 검토가 완료되기 전에는 병합하지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent completed-book action card for reviewing or restarting books.
  * Improved layouts across Korean and English, light and dark themes, narrow screens, and larger text sizes.
  * Added accessible labels, touch targets, and responsive stacking for better usability.
  * Improved floating action bar spacing to account for device safe areas and dynamic content height.

* **Bug Fixes**
  * Prevented completed-book actions from being obscured by the floating action bar.
  * Ensured restarting a completed book navigates correctly to the reading-start screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Exact-pair review packets

### Product Design — APPROVE_NEXT
- Head: `fd3a780716f9df05730fcebe086a0c79fa18e2d2`
- Base: `539a0d4a3744d644472e129317bf926409ad7ba8`
- ko/en × light/dark 캡처에서 두 CTA와 전체 문구가 실제 기록 바 위에 완전히 노출됨
- 100% inline, 200% stacked, 320/393px, 48pt 터치 영역, 의미 레이블, 재독 이동 검증
- 잔여 한계: 실제 기기 VoiceOver 순회는 별도 BOK-381 범위

### Engineering Quality — APPROVE_NEXT
- Head: `fd3a780716f9df05730fcebe086a0c79fa18e2d2`
- Base: `539a0d4a3744d644472e129317bf926409ad7ba8`
- 실제 렌더된 FloatingActionBar 실측 계약과 안전 영역·간격 적용 확인
- 두 CTA·네 문구 동시 비교 및 안정화 후 재검증, 실제 재독 이동 검증
- 독립 위젯 테스트 10/10, Target Delivery preflight, required CI 통과
- CodeRabbit 포함 미해결 리뷰 스레드 0건



## Merge authority
- Standing-Authority: `review-gated-auto-bookgolas-mobile-1.0.2-20260802`
- Owner-Authorization-Source: `byungsker-archive/company/byungskerlab/decisions/2026-07-31-issue-task-pr-review-merge-loop.md#bookgolas-102-release-scoped-amendment`
- Derived-Packet: `review-gated-auto-bookgolas-mobile-1.0.2-pr323-fd3a780-20260803`
- Packet-Head: `fd3a780716f9df05730fcebe086a0c79fa18e2d2`
- Packet-Base: `539a0d4a3744d644472e129317bf926409ad7ba8`
- Merge-Authority-Consumed: `ce050b3db0b4e3cb2f4e8eb2feaaf2e25ade06c0`


