### PR TITLE
chore(governance): open web 1.0.1 release line

### DIFF
--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -58,7 +58,7 @@
       "profile": "web-release-train",
       "mode": "version-line",
       "active_versions": [
-        "1.0.0"
+        "1.0.1"
       ],
       "target_version_source": ".byungskerlab/release-lines.json",
       "production_branch": "main",

--- a/.byungskerlab/release-lines.json
+++ b/.byungskerlab/release-lines.json
@@ -27,7 +27,7 @@
     },
     "web": {
       "active_versions": [
-        "1.0.0"
+        "1.0.1"
       ],
       "evidence_refs": [
         "docs/product-roadmap.md"


### PR DESCRIPTION
Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local

BOK-401의 웹 release line 거버넌스 불일치를 해소합니다.

## 📋 Changes

- web active version을 branch policy와 release registry에서 1.0.0 → 1.0.1로 함께 변경
- 기존 비정합 `version/web/1.0.0`을 force-push 없이 보존하고 새 line 생성 준비

## 🧠 Context & Background

기존 web version line은 release registry에만 1.0.0이 남고 branch policy에는 active version이 없어 fail-closed preflight가 실패합니다. BOK-394 공개 정책 변경 전에 새 web 1.0.1 line을 정확한 `dev` 기준으로 열기 위한 governance 변경입니다.

## ✅ How to Test

- `jq empty` on both governance JSON files
- governance 1.0.0 target-delivery preflight
- prospective web 1.0.1 target-delivery preflight
- `git diff --check`

- [x] 타깃 버전 원본, branch, base, PR metadata가 모두 일치한다.

## 🧾 Screenshots or Videos

렌더링 변화가 없는 거버넌스 변경이므로 생략합니다.

## 🔗 Related Issues

- BOK-401
- BOK-394

## 🙌 Additional Notes

이 PR은 version branch 생성, 배포 또는 공개 정책 변경을 수행하지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the active web delivery version from 1.0.0 to 1.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->