### PR TITLE
ci(mobile): isolate automatic store deployment triggers

### DIFF
--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - main
-    # web 전용 / 문서 전용 변경 시 iOS 빌드 트리거 안 함
-    paths-ignore:
-      - 'web/**'
-      - 'docs/**'
-      - '**/*.md'
-      - '.gitignore'
-      - '.editorconfig'
+    paths:
+      - 'app/**'
+      - 'supabase/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -14,13 +14,9 @@ on:
       - dev
       - 'version/mobile/**'
       - 'release/mobile/**'
-    # web 전용 / 문서 전용 변경 시 iOS 빌드 트리거 안 함
-    paths-ignore:
-      - 'web/**'
-      - 'docs/**'
-      - '**/*.md'
-      - '.gitignore'
-      - '.editorconfig'
+    paths:
+      - 'app/**'
+      - 'supabase/**'
   workflow_dispatch:
     inputs:
       operation:
@@ -97,6 +93,75 @@ jobs:
 
       - name: Verify mobile client configuration boundary
         run: python3 app/tool/verify_mobile_client_config.py --self-test --source-root app --workflow .github/workflows/ios-testflight.yml --workflow .github/workflows/ios-production.yml
+
+  workflow-trigger-contract:
+    name: Mobile Store Workflow Trigger Contract
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Verify automatic deployment paths
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          expected = ("app/**", "supabase/**")
+
+          def push_paths(path: str) -> tuple[str, ...]:
+              lines = Path(path).read_text("utf-8").splitlines()
+              push = lines.index("  push:")
+              end = next(
+                  (
+                      index
+                      for index in range(push + 1, len(lines))
+                      if lines[index].strip()
+                      and len(lines[index]) - len(lines[index].lstrip()) <= 2
+                  ),
+                  len(lines),
+              )
+              block = lines[push + 1 : end]
+              if "    paths-ignore:" in block:
+                  raise SystemExit(f"{path}: push.paths-ignore is not permitted")
+              paths = block.index("    paths:")
+              values = []
+              for line in block[paths + 1 :]:
+                  if line.strip() and len(line) - len(line.lstrip()) <= 4:
+                      break
+                  if line.strip():
+                      values.append(line.split("-", 1)[1].strip(" '\""))
+              return tuple(values)
+
+          for workflow in (
+              ".github/workflows/ios-testflight.yml",
+              ".github/workflows/ios-production.yml",
+          ):
+              actual = push_paths(workflow)
+              if actual != expected:
+                  raise SystemExit(f"{workflow}: expected {expected}, found {actual}")
+
+          prefixes = tuple(pattern.removesuffix("**") for pattern in expected)
+          fixtures = {
+              ".byungskerlab/branch-policy.json": False,
+              ".byungskerlab/release-lines.json": False,
+              ".github/workflows/ios-testflight.yml": False,
+              "docs/product-roadmap.md": False,
+              "app/lib/main.dart": True,
+              "supabase/functions/delete-user/index.ts": True,
+          }
+          for changed_path, should_deploy in fixtures.items():
+              does_deploy = changed_path.startswith(prefixes)
+              if does_deploy != should_deploy:
+                  raise SystemExit(
+                      f"{changed_path}: expected deploy={should_deploy}, found {does_deploy}"
+                  )
+          PY
 
   migrate-database:
     name: Apply Database Migrations (Dev)


### PR DESCRIPTION
## 목적

거버넌스·문서 전용 push가 Dev Supabase 변경과 TestFlight/App Store 배포를 자동 촉발하지 않도록 Store 워크플로의 자동 실행 경로를 제한합니다.

## 주요 변경

- TestFlight와 Production push 트리거를 `app/**`, `supabase/**` positive allowlist로 변경
- PR 전용 `Mobile Store Workflow Trigger Contract` 검증 추가
- 거버넌스·워크플로·문서 fixture는 skip, 앱·Supabase fixture는 deploy로 검증

## 배경

PR #325의 거버넌스 전용 병합이 `iOS TestFlight Deploy` run 30821039942를 촉발해 Dev Edge Function 일부를 변경했습니다. 해당 함수는 검증된 모바일 1.0.2 SHA로 복구했으며, 이 PR은 재발 경로를 차단합니다.

## 검증

- 모바일 client configuration boundary self-test 통과
- inline trigger contract fixture 통과
- YAML parse 및 `git diff --check` 통과
- target-delivery preflight 통과
- 독립 Engineering Quality Reviewer: APPROVE_NEXT

## 관련 이슈

- BOK-402
- BOK-401

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store

## Merge authority

Merge-Authority-ID: BOK-402-PR326-MERGE-20260803-01
Merge-Authority-Owner: byungsker
Merge-Authority-Source: Codex task approval on 2026-08-04 KST
Merge-Authority-Head-SHA: 97b27b0bae597c3ab61dea80ddb722d67e35cb70
Merge-Authority-Base-SHA: 4997d4d027f9da28f61186c863e04e934d6ebdf9
Merge-Authority-Consumed: ea087382941c2e678b9dce1c74f6615d1d9ad43e at 2026-08-04 01:06 KST