### PR TITLE
ci(mobile): sync safe deploy triggers to dev

### DIFF
--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - main
-    # web 전용 / 문서 전용 변경 시 iOS 빌드 트리거 안 함
-    paths-ignore:
-      - 'web/**'
-      - 'docs/**'
-      - '**/*.md'
-      - '.gitignore'
-      - '.editorconfig'
+    paths:
+      - 'app/**'
+      - 'supabase/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - dev
-    # web 전용 / 문서 전용 변경 시 iOS 빌드 트리거 안 함
-    paths-ignore:
-      - 'web/**'
-      - 'docs/**'
-      - '**/*.md'
-      - '.gitignore'
-      - '.editorconfig'
+    paths:
+      - 'app/**'
+      - 'supabase/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 목적

사고가 발생한 `dev` 브랜치에서 거버넌스·문서 전용 push가 Dev Supabase 변경과 TestFlight 배포를 다시 촉발하지 않도록 모바일 1.0.2의 안전한 trigger 계약만 제한적으로 동기화합니다.

## 주요 변경

- `ios-testflight.yml`의 dev push를 `app/**`, `supabase/**` positive allowlist로 제한
- `ios-production.yml`도 같은 production push 계약으로 정렬
- version line의 다른 미승격 workflow 변경은 포함하지 않음

## 검증

- 변경 파일 2개와 trigger block만 확인
- 거버넌스·워크플로·문서 fixture skip 확인
- 앱·Supabase fixture deploy 확인
- YAML parse, `git diff --check`, target-delivery preflight 통과

## 롤백

예전 `paths-ignore`로 되돌리지 않습니다. 문제가 있으면 현재 positive allowlist를 더 좁히거나 push trigger를 제거하고 `workflow_dispatch`만 유지하는 forward recovery를 적용합니다. 현재 allowlist가 workflow 파일 자체를 제외하므로 이 복구 변경은 자동 모바일 배포를 촉발하지 않습니다.

## 관련 이슈

- BOK-402
- BOK-401

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store

## Merge authority

Merge-Authority-ID: BOK-402-PR327-MERGE-20260804-01
Merge-Authority-Owner: byungsker
Merge-Authority-Source: Codex task approval on 2026-08-04 KST
Merge-Authority-Head-SHA: 6e95c9a08a42392a0ca80688ebffd33b5b214ae3
Merge-Authority-Base-SHA: 7f312c77ac042e556dbb2acfb50bb97842e76f55
Merge-Authority-Consumed: d4f45c00cf51069d4f92515ff25f6f6e63b4cf12 at 2026-08-04 01:17 KST