### PR TITLE
feat(web): carry admin dashboard into Web 1.0.1

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2678,49 +2678,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
-      "integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/remapping": "^2.3.4",
-        "enhanced-resolve": "^5.18.3",
-        "jiti": "^2.6.1",
-        "lightningcss": "1.30.2",
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.1.18"
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
-      "integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.1.18",
-        "@tailwindcss/oxide-darwin-arm64": "4.1.18",
-        "@tailwindcss/oxide-darwin-x64": "4.1.18",
-        "@tailwindcss/oxide-freebsd-x64": "4.1.18",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.1.18",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
-        "@tailwindcss/oxide-linux-x64-musl": "4.1.18",
-        "@tailwindcss/oxide-wasm32-wasi": "4.1.18",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
-      "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
       "cpu": [
         "arm64"
       ],
@@ -2731,13 +2731,13 @@
         "android"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz",
-      "integrity": "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
       "cpu": [
         "arm64"
       ],
@@ -2748,13 +2748,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
-      "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
       "cpu": [
         "x64"
       ],
@@ -2765,13 +2765,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
-      "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
       "cpu": [
         "x64"
       ],
@@ -2782,13 +2782,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
-      "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
       "cpu": [
         "arm"
       ],
@@ -2799,13 +2799,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
-      "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
       "cpu": [
         "arm64"
       ],
@@ -2816,13 +2816,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
-      "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
       ],
@@ -2833,13 +2833,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
-      "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
       "cpu": [
         "x64"
       ],
@@ -2850,13 +2850,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
-      "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
       ],
@@ -2867,13 +2867,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
-      "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -2889,81 +2889,21 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.0",
-        "@tybys/wasm-util": "^0.10.1",
-        "tslib": "^2.4.0"
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.7.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
-      "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -2974,13 +2914,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
-      "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
       "cpu": [
         "x64"
       ],
@@ -2991,21 +2931,21 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.18.tgz",
-      "integrity": "sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+      "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.1.18",
-        "@tailwindcss/oxide": "4.1.18",
-        "postcss": "^8.4.41",
-        "tailwindcss": "4.1.18"
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "postcss": "^8.5.16",
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -3917,9 +3857,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4342,14 +4282,14 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.4",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-      "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -5972,9 +5912,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6119,9 +6059,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
-      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -6135,23 +6075,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.30.2",
-        "lightningcss-darwin-arm64": "1.30.2",
-        "lightningcss-darwin-x64": "1.30.2",
-        "lightningcss-freebsd-x64": "1.30.2",
-        "lightningcss-linux-arm-gnueabihf": "1.30.2",
-        "lightningcss-linux-arm64-gnu": "1.30.2",
-        "lightningcss-linux-arm64-musl": "1.30.2",
-        "lightningcss-linux-x64-gnu": "1.30.2",
-        "lightningcss-linux-x64-musl": "1.30.2",
-        "lightningcss-win32-arm64-msvc": "1.30.2",
-        "lightningcss-win32-x64-msvc": "1.30.2"
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
-      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
       ],
@@ -6170,9 +6110,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
-      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
@@ -6191,9 +6131,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
-      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
@@ -6212,9 +6152,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
-      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
@@ -6233,9 +6173,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
-      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
@@ -6254,9 +6194,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
-      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
@@ -6275,9 +6215,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
-      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
       ],
@@ -6296,9 +6236,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
-      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
       ],
@@ -6317,9 +6257,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
-      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
       ],
@@ -6338,9 +6278,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
-      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
@@ -6359,9 +6299,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
-      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
@@ -7785,16 +7725,16 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,13 +26,14 @@
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
-        "@tailwindcss/postcss": "^4",
+        "@tailwindcss/postcss": "^4.3.3",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "^16.2.12",
-        "tailwindcss": "^4",
+        "tailwindcss": "^4.3.3",
+        "tsx": "^4.23.5",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5"
       }
@@ -321,6 +322,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4472,6 +4915,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -5064,6 +5549,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -6889,9 +7389,9 @@
       "license": "MIT-0"
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7850,6 +8350,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
+      "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6479,13 +6479,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"

--- a/web/package.json
+++ b/web/package.json
@@ -39,7 +39,7 @@
     "typescript": "^5"
   },
   "overrides": {
-    "postcss": "8.5.22",
-    "minimatch": "10.2.5"
+    "minimatch": "10.2.6",
+    "postcss": "8.5.22"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "npm run test:monitoring",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test:monitoring": "node --test tests/monitoring.test.mjs"
+    "test:monitoring": "tsx --test tests/monitoring.test.mjs"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -28,18 +29,19 @@
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4",
+    "@tailwindcss/postcss": "^4.3.3",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "^16.2.12",
-    "tailwindcss": "^4",
+    "tailwindcss": "^4.3.3",
+    "tsx": "^4.23.5",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"
   },
   "overrides": {
     "minimatch": "10.2.6",
-    "postcss": "8.5.22"
+    "postcss": "8.5.25"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:monitoring": "node --test tests/monitoring.test.mjs"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/web/src/app/admin/layout.tsx
+++ b/web/src/app/admin/layout.tsx
@@ -9,7 +9,7 @@ import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 
 const navItems = [
-  { href: "/admin", label: "대시보드", icon: "📊" },
+  { href: "/admin", label: "성장·운영", icon: "📊" },
   { href: "/admin/users", label: "유저 관리", icon: "👥" },
   { href: "/admin/push-templates", label: "푸시 템플릿", icon: "📝" },
   { href: "/admin/push-logs", label: "발송 로그", icon: "📋" },

--- a/web/src/app/admin/layout.tsx
+++ b/web/src/app/admin/layout.tsx
@@ -46,48 +46,51 @@ export default function AdminLayout({
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <nav className="bg-card border-b border-border">
+    <div className="min-h-screen bg-background text-foreground">
+      <nav className="border-b border-border bg-card">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between h-16">
-            <div className="flex">
-              <Link href="/admin" className="flex-shrink-0 flex items-center gap-2">
-                <Image
-                  src="/logo-bookgolas.png"
-                  alt="북골라스"
-                  width={32}
-                  height={32}
-                  className="rounded-md"
-                />
-                <span className="text-xl font-bold text-foreground">북골라스</span>
-                <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-primary/10 text-primary">Admin</span>
-              </Link>
-              <div className="hidden sm:ml-8 sm:flex sm:space-x-4">
-                {navItems.map((item) => (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className={cn(
-                      "inline-flex items-center px-3 py-2 text-sm font-medium rounded-md transition-colors",
-                      pathname === item.href
-                        ? "bg-accent text-accent-foreground"
-                        : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
-                    )}
-                  >
-                    <span className="mr-2">{item.icon}</span>
-                    {item.label}
-                  </Link>
-                ))}
-              </div>
-            </div>
-            <div className="flex items-center gap-4">
+          <div className="flex h-16 items-center justify-between gap-4">
+            <Link href="/admin" className="flex shrink-0 items-center gap-2">
+              <Image
+                src="/logo-bookgolas.png"
+                alt="북골라스"
+                width={32}
+                height={32}
+                className="rounded-md"
+              />
+              <span className="text-xl font-bold text-foreground">북골라스</span>
+              <span className="rounded bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary">
+                Admin
+              </span>
+            </Link>
+            <div className="flex min-w-0 items-center gap-3">
               {userEmail && (
-                <span className="text-sm text-muted-foreground">{userEmail}</span>
+                <span className="hidden truncate text-sm text-muted-foreground lg:block">
+                  {userEmail}
+                </span>
               )}
               <Button variant="outline" size="sm" onClick={handleLogout}>
                 로그아웃
               </Button>
             </div>
+          </div>
+          <div className="flex gap-2 overflow-x-auto border-t border-border py-2">
+            {navItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                aria-current={pathname === item.href ? "page" : undefined}
+                className={cn(
+                  "inline-flex shrink-0 items-center whitespace-nowrap rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
+                  pathname === item.href
+                    ? "bg-accent text-accent-foreground"
+                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                )}
+              >
+                <span className="mr-2">{item.icon}</span>
+                {item.label}
+              </Link>
+            ))}
           </div>
         </div>
       </nav>

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -175,7 +175,7 @@ export function AdminDashboard({
       {error && (
         <div
           role="alert"
-          className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive"
+          className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-foreground"
         >
           {error} 아래 수치는 마지막 성공 갱신 시점의 값입니다.
         </div>

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -1,237 +1,358 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Activity,
+  BookOpen,
+  BrainCircuit,
+  Database,
+  Megaphone,
+  RefreshCw,
+  Sparkles,
+  Users,
+} from "lucide-react";
+
 import { Badge } from "@/components/ui/badge";
-import { supabase, PushLog } from "@/lib/supabase";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  formatGeneratedAt,
+  formatMetric,
+  formatPercentage,
+  getNextAction,
+  percentage,
+} from "@/lib/admin/monitoring";
+import type {
+  AdminMonitoringMetrics,
+  MetricValue,
+} from "@/types/monitoring";
 
-type DashboardStats = {
-  todaySent: number;
-  todayClicked: number;
-  ctr: number;
-  activeUsers: number;
-  fatigueUsers: number;
+type MetricCardProps = {
+  label: string;
+  value: MetricValue;
+  description: string;
+  icon: React.ReactNode;
 };
 
-type TypeStats = {
-  push_type: string;
-  sent: number;
-  clicked: number;
-  ctr: number;
-};
+function MetricCard({ label, value, description, icon }: MetricCardProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          {label}
+        </CardTitle>
+        <span className="text-primary">{icon}</span>
+      </CardHeader>
+      <CardContent>
+        <div className="text-3xl font-bold text-foreground">
+          {formatMetric(value)}
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">{description}</p>
+      </CardContent>
+    </Card>
+  );
+}
 
-export default function AdminDashboard() {
-  const [stats, setStats] = useState<DashboardStats>({
-    todaySent: 0,
-    todayClicked: 0,
-    ctr: 0,
-    activeUsers: 0,
-    fatigueUsers: 0,
-  });
-  const [typeStats, setTypeStats] = useState<TypeStats[]>([]);
-  const [recentLogs, setRecentLogs] = useState<PushLog[]>([]);
-  const [loading, setLoading] = useState(true);
+export function AdminDashboard({
+  initialMetrics = null,
+}: {
+  initialMetrics?: AdminMonitoringMetrics | null;
+}) {
+  const [metrics, setMetrics] = useState<AdminMonitoringMetrics | null>(
+    initialMetrics
+  );
+  const [loading, setLoading] = useState(initialMetrics === null);
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchDashboardData();
-  }, []);
+  const loadMetrics = useCallback(async () => {
+    setLoading(true);
+    setError(null);
 
-  async function fetchDashboardData() {
     try {
-      const today = new Date().toISOString().split("T")[0];
+      const response = await fetch("/api/admin/monitoring", {
+        cache: "no-store",
+      });
 
-      const { data: todayLogs } = await supabase
-        .from("push_logs")
-        .select("*")
-        .gte("sent_at", today);
-
-      if (todayLogs) {
-        const sent = todayLogs.length;
-        const clicked = todayLogs.filter((l) => l.is_clicked).length;
-        setStats({
-          todaySent: sent,
-          todayClicked: clicked,
-          ctr: sent > 0 ? Math.round((clicked / sent) * 100 * 10) / 10 : 0,
-          activeUsers: new Set(todayLogs.map((l) => l.user_id)).size,
-          fatigueUsers: 0,
-        });
-
-        const typeMap = new Map<string, { sent: number; clicked: number }>();
-        todayLogs.forEach((log) => {
-          const curr = typeMap.get(log.push_type) || { sent: 0, clicked: 0 };
-          curr.sent++;
-          if (log.is_clicked) curr.clicked++;
-          typeMap.set(log.push_type, curr);
-        });
-
-        setTypeStats(
-          Array.from(typeMap.entries()).map(([type, data]) => ({
-            push_type: type,
-            sent: data.sent,
-            clicked: data.clicked,
-            ctr:
-              data.sent > 0
-                ? Math.round((data.clicked / data.sent) * 100 * 10) / 10
-                : 0,
-          }))
-        );
+      if (!response.ok) {
+        throw new Error("성장 데이터를 불러오지 못했습니다.");
       }
 
-      const { data: recent } = await supabase
-        .from("push_logs")
-        .select("*")
-        .order("sent_at", { ascending: false })
-        .limit(10);
-
-      if (recent) {
-        setRecentLogs(recent);
-      }
-    } catch (error) {
-      console.error("Failed to fetch dashboard data:", error);
+      setMetrics((await response.json()) as AdminMonitoringMetrics);
+    } catch {
+      setError("데이터 연결을 확인한 뒤 다시 시도해 주세요.");
     } finally {
       setLoading(false);
     }
-  }
+  }, []);
 
-  if (loading) {
+  useEffect(() => {
+    if (initialMetrics === null) {
+      loadMetrics();
+    }
+  }, [initialMetrics, loadMetrics]);
+
+  const insight = useMemo(
+    () => (metrics ? getNextAction(metrics) : null),
+    [metrics]
+  );
+
+  if (loading && !metrics) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-muted-foreground">로딩 중...</div>
+      <div className="flex h-64 items-center justify-center text-muted-foreground">
+        성장 지표를 불러오는 중...
       </div>
     );
   }
 
+  if (!metrics) {
+    return (
+      <Card className="mx-auto max-w-xl">
+        <CardHeader>
+          <CardTitle>성장 데이터를 연결하지 못했습니다</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">{error}</p>
+          <Button onClick={loadMetrics} variant="outline">
+            <RefreshCw className="mr-2 h-4 w-4" />
+            다시 시도
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const bookActivation = percentage(
+    metrics.books.users_with_books,
+    metrics.users.total
+  );
+  const readingActivation = percentage(
+    metrics.reading.users_with_records,
+    metrics.users.total
+  );
+  const recallActivation = percentage(
+    metrics.recall.users_with_recall,
+    metrics.users.total
+  );
+  const pushCtr = percentage(
+    metrics.push.clicked_7d,
+    metrics.push.sent_7d
+  );
+  const generatedAt = formatGeneratedAt(metrics.generated_at);
+  const lowSample =
+    metrics.users.active_7d !== null && metrics.users.active_7d < 30;
+
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-bold text-foreground">Push Notification Dashboard</h1>
+      <section className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-2xl font-bold text-foreground">
+              성장·운영 대시보드
+            </h1>
+            <Badge
+              variant={
+                metrics.source_status === "connected" ? "default" : "outline"
+              }
+            >
+              {metrics.source_status === "connected"
+                ? "제품 데이터 연결됨"
+                : "일부 데이터 연결 필요"}
+            </Badge>
+          </div>
+          <p className="mt-2 text-sm text-muted-foreground">
+            최근 {metrics.period_days}일 제품 행동을 개인정보 없이 집계합니다.
+            마지막 갱신 {generatedAt}
+          </p>
+        </div>
+        <Button onClick={loadMetrics} variant="outline" disabled={loading}>
+          <RefreshCw
+            className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`}
+          />
+          새로고침
+        </Button>
+      </section>
 
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              오늘 발송
-            </CardTitle>
+      {metrics.source_status === "partial" && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-700 dark:text-amber-300">
+          고유 사용자 기반 지표는 성장 집계 RPC 배포 후 표시됩니다. 연결되지
+          않은 값은 0이 아니라 ‘연결 필요’로 표시합니다.
+        </div>
+      )}
+
+      {lowSample && (
+        <div className="rounded-lg border border-blue-500/30 bg-blue-500/10 p-4 text-sm text-blue-700 dark:text-blue-300">
+          최근 7일 활성 사용자가 30명 미만이라 비율 변화가 크게 흔들릴 수
+          있습니다. 현재 수치는 방향 탐색용으로만 사용하세요.
+        </div>
+      )}
+
+      <section>
+        <div className="mb-3 flex items-center gap-2">
+          <Activity className="h-4 w-4 text-primary" />
+          <h2 className="text-sm font-semibold">최근 7일 핵심 행동</h2>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-5">
+          <MetricCard
+            label="신규 사용자"
+            value={metrics.users.new_7d}
+            description="최근 7일 가입"
+            icon={<Users className="h-4 w-4" />}
+          />
+          <MetricCard
+            label="활성 사용자"
+            value={metrics.users.active_7d}
+            description="책·독서 기록·Recall 행동의 고유 사용자"
+            icon={<Activity className="h-4 w-4" />}
+          />
+          <MetricCard
+            label="등록한 책"
+            value={metrics.books.created_7d}
+            description="최근 7일 새 책 등록"
+            icon={<BookOpen className="h-4 w-4" />}
+          />
+          <MetricCard
+            label="독서 기록"
+            value={metrics.reading.records_7d}
+            description="최근 7일 진행 기록"
+            icon={<Sparkles className="h-4 w-4" />}
+          />
+          <MetricCard
+            label="AI Recall"
+            value={metrics.recall.created_7d}
+            description="최근 7일 Recall 검색"
+            icon={<BrainCircuit className="h-4 w-4" />}
+          />
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <Card className="xl:col-span-2">
+          <CardHeader>
+            <CardTitle className="text-base">누적 활성화 흐름</CardTitle>
           </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold text-foreground">{stats.todaySent}</div>
+          <CardContent className="space-y-5">
+            {[
+              {
+                label: "가입 → 책 등록 경험",
+                value: bookActivation,
+                detail: `${formatMetric(metrics.books.users_with_books)} / ${formatMetric(metrics.users.total)}명`,
+              },
+              {
+                label: "가입 → 독서 기록 경험",
+                value: readingActivation,
+                detail: `${formatMetric(metrics.reading.users_with_records)} / ${formatMetric(metrics.users.total)}명`,
+              },
+              {
+                label: "가입 → AI Recall 경험",
+                value: recallActivation,
+                detail: `${formatMetric(metrics.recall.users_with_recall)} / ${formatMetric(metrics.users.total)}명`,
+              },
+            ].map((item) => (
+              <div key={item.label}>
+                <div className="mb-2 flex items-center justify-between gap-4 text-sm">
+                  <span className="font-medium">{item.label}</span>
+                  <span className="text-muted-foreground">
+                    {formatPercentage(item.value)} · {item.detail}
+                  </span>
+                </div>
+                <div className="h-2 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-primary"
+                    style={{ width: `${item.value ?? 0}%` }}
+                  />
+                </div>
+              </div>
+            ))}
+            <p className="text-xs text-muted-foreground">
+              이 비율은 동일 기간 코호트가 아닌 누적 경험 비율입니다. 원인이나
+              전환 효과로 해석하지 마세요.
+            </p>
           </CardContent>
         </Card>
 
         <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              CTR
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Sparkles className="h-4 w-4 text-primary" />
+              다음 관찰 우선순위
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-3xl font-bold text-foreground">{stats.ctr}%</div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              활성 유저
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold text-foreground">{stats.activeUsers}</div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              미클릭 3+
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-3xl font-bold text-orange-400">
-              {stats.fatigueUsers}
-            </div>
+            <p className="font-semibold">{insight?.title}</p>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              {insight?.description}
+            </p>
           </CardContent>
         </Card>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <Card>
           <CardHeader>
-            <CardTitle className="text-foreground">타입별 발송 현황</CardTitle>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Megaphone className="h-4 w-4 text-primary" />
+              푸시 반응
+            </CardTitle>
           </CardHeader>
-          <CardContent>
-            {typeStats.length === 0 ? (
-              <div className="text-muted-foreground text-center py-8">
-                오늘 발송된 알림이 없습니다
-              </div>
-            ) : (
-              <div className="space-y-3">
-                {typeStats.map((stat) => (
-                  <div key={stat.push_type} className="flex items-center gap-4">
-                    <div className="w-24 font-medium text-foreground">{stat.push_type}</div>
-                    <div className="flex-1 bg-muted rounded-full h-4">
-                      <div
-                        className="bg-blue-500 rounded-full h-4"
-                        style={{
-                          width: `${Math.min((stat.sent / Math.max(...typeStats.map((s) => s.sent))) * 100, 100)}%`,
-                        }}
-                      />
-                    </div>
-                    <div className="w-32 text-sm text-muted-foreground">
-                      {stat.sent} (CTR {stat.ctr}%)
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
+          <CardContent className="grid grid-cols-3 gap-4">
+            <div>
+              <p className="text-xs text-muted-foreground">7일 발송</p>
+              <p className="mt-1 text-2xl font-bold">
+                {formatMetric(metrics.push.sent_7d)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">7일 클릭</p>
+              <p className="mt-1 text-2xl font-bold">
+                {formatMetric(metrics.push.clicked_7d)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">CTR</p>
+              <p className="mt-1 text-2xl font-bold">
+                {formatPercentage(pushCtr)}
+              </p>
+            </div>
+            <p className="col-span-3 text-xs text-muted-foreground">
+              푸시 CTR은 독서 가치나 리텐션을 직접 증명하지 않습니다. 발송
+              빈도와 메시지 품질을 점검하는 운영 지표로만 사용하세요.
+            </p>
           </CardContent>
         </Card>
 
         <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle className="text-foreground">최근 발송 로그</CardTitle>
-            <Link
-              href="/admin/push-logs"
-              className="text-sm text-blue-400 hover:underline"
-            >
-              더보기 →
-            </Link>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Database className="h-4 w-4 text-primary" />
+              데이터 상태
+            </CardTitle>
           </CardHeader>
-          <CardContent>
-            {recentLogs.length === 0 ? (
-              <div className="text-muted-foreground text-center py-8">
-                발송 로그가 없습니다
-              </div>
-            ) : (
-              <div className="space-y-2">
-                {recentLogs.slice(0, 5).map((log) => (
-                  <div
-                    key={log.id}
-                    className="flex items-center justify-between py-2 border-b border-border last:border-0"
-                  >
-                    <div className="flex items-center gap-3">
-                      <span className="text-sm text-muted-foreground">
-                        {new Date(log.sent_at).toLocaleTimeString("ko-KR", {
-                          hour: "2-digit",
-                          minute: "2-digit",
-                        })}
-                      </span>
-                      <Badge variant="outline">{log.push_type}</Badge>
-                    </div>
-                    <div>
-                      {log.is_clicked ? (
-                        <span className="text-green-400">✅ clicked</span>
-                      ) : (
-                        <span className="text-muted-foreground">⏳ pending</span>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
+          <CardContent className="space-y-3 text-sm">
+            <div className="flex items-center justify-between">
+              <span>제품 행동 · Supabase</span>
+              <Badge variant="outline">
+                {metrics.source_status === "connected" ? "연결됨" : "부분 연결"}
+              </Badge>
+            </div>
+            <div className="flex items-center justify-between">
+              <span>앱스토어 유입 · App Store Connect</span>
+              <Badge variant="secondary">외부 확인</Badge>
+            </div>
+            <div className="flex items-center justify-between">
+              <span>광고 수익 · AdMob</span>
+              <Badge variant="secondary">Company Control Plane</Badge>
+            </div>
+            <p className="pt-2 text-xs text-muted-foreground">
+              이 화면은 집계값만 반환하며 이메일, 책 제목, 독서 메모, 검색
+              내용은 조회하지 않습니다.
+            </p>
           </CardContent>
         </Card>
       </div>
     </div>
   );
+}
+
+export default function AdminDashboardPage() {
+  return <AdminDashboard />;
 }

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -172,6 +172,15 @@ export function AdminDashboard({
         </Button>
       </section>
 
+      {error && (
+        <div
+          role="alert"
+          className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive"
+        >
+          {error} 아래 수치는 마지막 성공 갱신 시점의 값입니다.
+        </div>
+      )}
+
       {metrics.source_status === "partial" && (
         <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-700 dark:text-amber-300">
           고유 사용자 기반 지표는 성장 집계 RPC 배포 후 표시됩니다. 연결되지

--- a/web/src/app/api/admin/monitoring/route.ts
+++ b/web/src/app/api/admin/monitoring/route.ts
@@ -1,0 +1,185 @@
+import { createClient } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+
+import { requireAdminUser } from "@/lib/supabase-server";
+import type { AdminMonitoringMetrics } from "@/types/monitoring";
+
+type GrowthMetricsRpc = {
+  total_users: number;
+  new_users_7d: number;
+  active_users_7d: number;
+  total_books: number;
+  books_created_7d: number;
+  users_with_books: number;
+  total_reading_records: number;
+  reading_records_7d: number;
+  users_with_reading_records: number;
+  total_ai_recalls: number;
+  ai_recalls_7d: number;
+  users_with_ai_recall: number;
+};
+
+export const dynamic = "force-dynamic";
+
+function getAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return null;
+  }
+
+  return createClient(supabaseUrl.trim(), serviceRoleKey.trim(), {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
+
+export async function GET() {
+  if (!(await requireAdminUser())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabaseAdmin = getAdminClient();
+  if (!supabaseAdmin) {
+    return NextResponse.json(
+      { error: "Server configuration error" },
+      { status: 500 }
+    );
+  }
+
+  const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [
+    rpcResult,
+    totalUsersResult,
+    newUsersResult,
+    totalBooksResult,
+    newBooksResult,
+    totalReadingResult,
+    newReadingResult,
+    totalRecallResult,
+    newRecallResult,
+    sentPushResult,
+    clickedPushResult,
+  ] = await Promise.all([
+    supabaseAdmin.rpc("get_control_plane_growth_metrics"),
+    supabaseAdmin.from("users").select("id", { count: "exact", head: true }),
+    supabaseAdmin
+      .from("users")
+      .select("id", { count: "exact", head: true })
+      .gte("created_at", cutoff),
+    supabaseAdmin.from("books").select("id", { count: "exact", head: true }),
+    supabaseAdmin
+      .from("books")
+      .select("id", { count: "exact", head: true })
+      .gte("created_at", cutoff),
+    supabaseAdmin
+      .from("reading_progress_history")
+      .select("id", { count: "exact", head: true }),
+    supabaseAdmin
+      .from("reading_progress_history")
+      .select("id", { count: "exact", head: true })
+      .gte("created_at", cutoff),
+    supabaseAdmin
+      .from("recall_search_history")
+      .select("id", { count: "exact", head: true }),
+    supabaseAdmin
+      .from("recall_search_history")
+      .select("id", { count: "exact", head: true })
+      .gte("created_at", cutoff),
+    supabaseAdmin
+      .from("push_logs")
+      .select("id", { count: "exact", head: true })
+      .gte("sent_at", cutoff),
+    supabaseAdmin
+      .from("push_logs")
+      .select("id", { count: "exact", head: true })
+      .gte("sent_at", cutoff)
+      .eq("is_clicked", true),
+  ]);
+
+  const rpcMetrics = rpcResult.error
+    ? null
+    : (rpcResult.data as GrowthMetricsRpc | null);
+  const unavailableMetrics: string[] = [];
+
+  function countOrNull(
+    result: { count: number | null; error: { message: string } | null },
+    metricName: string
+  ) {
+    if (result.error) {
+      unavailableMetrics.push(metricName);
+      return null;
+    }
+
+    return result.count ?? 0;
+  }
+
+  if (!rpcMetrics) {
+    unavailableMetrics.push(
+      "active_users_7d",
+      "users_with_books",
+      "users_with_reading_records",
+      "users_with_ai_recall"
+    );
+  }
+
+  const metrics: AdminMonitoringMetrics = {
+    generated_at: new Date().toISOString(),
+    period_days: 7,
+    source_status: "connected",
+    unavailable_metrics: unavailableMetrics,
+    users: {
+      total:
+        rpcMetrics?.total_users ??
+        countOrNull(totalUsersResult, "total_users"),
+      new_7d:
+        rpcMetrics?.new_users_7d ??
+        countOrNull(newUsersResult, "new_users_7d"),
+      active_7d: rpcMetrics?.active_users_7d ?? null,
+    },
+    books: {
+      total:
+        rpcMetrics?.total_books ??
+        countOrNull(totalBooksResult, "total_books"),
+      created_7d:
+        rpcMetrics?.books_created_7d ??
+        countOrNull(newBooksResult, "books_created_7d"),
+      users_with_books: rpcMetrics?.users_with_books ?? null,
+    },
+    reading: {
+      total_records:
+        rpcMetrics?.total_reading_records ??
+        countOrNull(totalReadingResult, "total_reading_records"),
+      records_7d:
+        rpcMetrics?.reading_records_7d ??
+        countOrNull(newReadingResult, "reading_records_7d"),
+      users_with_records: rpcMetrics?.users_with_reading_records ?? null,
+    },
+    recall: {
+      total:
+        rpcMetrics?.total_ai_recalls ??
+        countOrNull(totalRecallResult, "total_ai_recalls"),
+      created_7d:
+        rpcMetrics?.ai_recalls_7d ??
+        countOrNull(newRecallResult, "ai_recalls_7d"),
+      users_with_recall: rpcMetrics?.users_with_ai_recall ?? null,
+    },
+    push: {
+      sent_7d: countOrNull(sentPushResult, "push_sent_7d"),
+      clicked_7d: countOrNull(clickedPushResult, "push_clicked_7d"),
+    },
+  };
+
+  metrics.source_status =
+    metrics.unavailable_metrics.length > 0 ? "partial" : "connected";
+
+  return NextResponse.json(metrics, {
+    headers: {
+      "Cache-Control": "private, no-store",
+    },
+  });
+}

--- a/web/src/app/api/admin/monitoring/route.ts
+++ b/web/src/app/api/admin/monitoring/route.ts
@@ -1,22 +1,13 @@
 import { createClient } from "@supabase/supabase-js";
 import { NextResponse } from "next/server";
 
+import { normalizeGrowthMetrics } from "@/lib/admin/monitoring";
 import { requireAdminUser } from "@/lib/supabase-server";
 import type { AdminMonitoringMetrics } from "@/types/monitoring";
 
-type GrowthMetricsRpc = {
-  total_users: number;
-  new_users_7d: number;
-  active_users_7d: number;
-  total_books: number;
-  books_created_7d: number;
-  users_with_books: number;
-  total_reading_records: number;
-  reading_records_7d: number;
-  users_with_reading_records: number;
-  total_ai_recalls: number;
-  ai_recalls_7d: number;
-  users_with_ai_recall: number;
+type CountResult = {
+  count: number | null;
+  error: { message: string } | null;
 };
 
 export const dynamic = "force-dynamic";
@@ -52,44 +43,8 @@ export async function GET() {
 
   const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
 
-  const [
-    rpcResult,
-    totalUsersResult,
-    newUsersResult,
-    totalBooksResult,
-    newBooksResult,
-    totalReadingResult,
-    newReadingResult,
-    totalRecallResult,
-    newRecallResult,
-    sentPushResult,
-    clickedPushResult,
-  ] = await Promise.all([
+  const [rpcResult, sentPushResult, clickedPushResult] = await Promise.all([
     supabaseAdmin.rpc("get_control_plane_growth_metrics"),
-    supabaseAdmin.from("users").select("id", { count: "exact", head: true }),
-    supabaseAdmin
-      .from("users")
-      .select("id", { count: "exact", head: true })
-      .gte("created_at", cutoff),
-    supabaseAdmin.from("books").select("id", { count: "exact", head: true }),
-    supabaseAdmin
-      .from("books")
-      .select("id", { count: "exact", head: true })
-      .gte("created_at", cutoff),
-    supabaseAdmin
-      .from("reading_progress_history")
-      .select("id", { count: "exact", head: true }),
-    supabaseAdmin
-      .from("reading_progress_history")
-      .select("id", { count: "exact", head: true })
-      .gte("created_at", cutoff),
-    supabaseAdmin
-      .from("recall_search_history")
-      .select("id", { count: "exact", head: true }),
-    supabaseAdmin
-      .from("recall_search_history")
-      .select("id", { count: "exact", head: true })
-      .gte("created_at", cutoff),
     supabaseAdmin
       .from("push_logs")
       .select("id", { count: "exact", head: true })
@@ -101,16 +56,67 @@ export async function GET() {
       .eq("is_clicked", true),
   ]);
 
+  if (rpcResult.error) {
+    console.error(
+      "get_control_plane_growth_metrics failed:",
+      rpcResult.error.message
+    );
+  }
+
   const rpcMetrics = rpcResult.error
     ? null
-    : (rpcResult.data as GrowthMetricsRpc | null);
+    : normalizeGrowthMetrics(rpcResult.data);
+  let totalUsersResult: CountResult | null = null;
+  let newUsersResult: CountResult | null = null;
+  let totalBooksResult: CountResult | null = null;
+  let newBooksResult: CountResult | null = null;
+  let totalReadingResult: CountResult | null = null;
+  let newReadingResult: CountResult | null = null;
+  let totalRecallResult: CountResult | null = null;
+  let newRecallResult: CountResult | null = null;
+
+  if (!rpcMetrics) {
+    [
+      totalUsersResult,
+      newUsersResult,
+      totalBooksResult,
+      newBooksResult,
+      totalReadingResult,
+      newReadingResult,
+      totalRecallResult,
+      newRecallResult,
+    ] = await Promise.all([
+      supabaseAdmin.from("users").select("id", { count: "exact", head: true }),
+      supabaseAdmin
+        .from("users")
+        .select("id", { count: "exact", head: true })
+        .gte("created_at", cutoff),
+      supabaseAdmin.from("books").select("id", { count: "exact", head: true }),
+      supabaseAdmin
+        .from("books")
+        .select("id", { count: "exact", head: true })
+        .gte("created_at", cutoff),
+      supabaseAdmin
+        .from("reading_progress_history")
+        .select("id", { count: "exact", head: true }),
+      supabaseAdmin
+        .from("reading_progress_history")
+        .select("id", { count: "exact", head: true })
+        .gte("created_at", cutoff),
+      supabaseAdmin
+        .from("recall_search_history")
+        .select("id", { count: "exact", head: true }),
+      supabaseAdmin
+        .from("recall_search_history")
+        .select("id", { count: "exact", head: true })
+        .gte("created_at", cutoff),
+    ]);
+  }
+
   const unavailableMetrics: string[] = [];
 
-  function countOrNull(
-    result: { count: number | null; error: { message: string } | null },
-    metricName: string
-  ) {
-    if (result.error) {
+  function countOrNull(result: CountResult | null, metricName: string) {
+    if (!result || result.error) {
       unavailableMetrics.push(metricName);
       return null;
     }

--- a/web/src/lib/admin/monitoring.ts
+++ b/web/src/lib/admin/monitoring.ts
@@ -63,7 +63,18 @@ export function getNextAction(metrics: AdminMonitoringMetrics): {
     };
   }
 
-  if ((metrics.books.created_7d ?? 0) === 0) {
+  if (
+    metrics.books.created_7d === null ||
+    metrics.reading.records_7d === null
+  ) {
+    return {
+      title: "핵심 행동 지표 연결을 확인하세요",
+      description:
+        "최근 7일 책 등록 또는 독서 기록 수치를 불러오지 못했습니다. 데이터 연결 상태를 먼저 확인하세요.",
+    };
+  }
+
+  if (metrics.books.created_7d === 0) {
     return {
       title: "책 등록 진입 흐름을 점검하세요",
       description:
@@ -71,7 +82,7 @@ export function getNextAction(metrics: AdminMonitoringMetrics): {
     };
   }
 
-  if ((metrics.reading.records_7d ?? 0) < (metrics.books.created_7d ?? 0)) {
+  if (metrics.reading.records_7d < metrics.books.created_7d) {
     return {
       title: "첫 독서 기록 전환을 개선하세요",
       description:

--- a/web/src/lib/admin/monitoring.ts
+++ b/web/src/lib/admin/monitoring.ts
@@ -1,0 +1,87 @@
+import type {
+  AdminMonitoringMetrics,
+  MetricValue,
+} from "@/types/monitoring";
+
+export function percentage(
+  numerator: MetricValue,
+  denominator: MetricValue
+): number | null {
+  if (numerator === null || denominator === null || denominator <= 0) {
+    return null;
+  }
+
+  return Math.round((numerator / denominator) * 1000) / 10;
+}
+
+export function formatMetric(value: MetricValue): string {
+  return value === null ? "연결 필요" : value.toLocaleString("ko-KR");
+}
+
+export function formatPercentage(value: number | null): string {
+  return value === null ? "계산 불가" : `${value.toFixed(1)}%`;
+}
+
+export function formatGeneratedAt(value: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  })
+    .formatToParts(new Date(value))
+    .reduce<Record<string, string>>((result, part) => {
+      result[part.type] = part.value;
+      return result;
+    }, {});
+
+  return `${parts.year}.${parts.month}.${parts.day} ${parts.hour}:${parts.minute} KST`;
+}
+
+export function getNextAction(metrics: AdminMonitoringMetrics): {
+  title: string;
+  description: string;
+} {
+  const activeUsers = metrics.users.active_7d;
+
+  if (activeUsers === null) {
+    return {
+      title: "활성 사용자 집계를 먼저 연결하세요",
+      description:
+        "성장 지표 RPC가 배포되면 사용자 식별정보를 노출하지 않고 최근 7일 활성 사용자를 확인할 수 있습니다.",
+    };
+  }
+
+  if (activeUsers < 30) {
+    return {
+      title: "표본을 늘리고 추세만 관찰하세요",
+      description:
+        "최근 7일 활성 사용자가 30명 미만입니다. 비율 최적화보다 첫 독서 기록까지의 사용성 문제를 직접 관찰하는 편이 안전합니다.",
+    };
+  }
+
+  if ((metrics.books.created_7d ?? 0) === 0) {
+    return {
+      title: "책 등록 진입 흐름을 점검하세요",
+      description:
+        "최근 7일 책 등록이 없습니다. 검색, 직접 입력, 표지 촬영 흐름에서 이탈 지점을 확인하세요.",
+    };
+  }
+
+  if ((metrics.reading.records_7d ?? 0) < (metrics.books.created_7d ?? 0)) {
+    return {
+      title: "첫 독서 기록 전환을 개선하세요",
+      description:
+        "최근 책 등록보다 독서 기록 수가 적습니다. 등록 직후 첫 페이지 기록으로 이어지는 안내를 우선 점검하세요.",
+    };
+  }
+
+  return {
+    title: "AI Recall 재사용 경험을 관찰하세요",
+    description:
+      "핵심 독서 행동은 발생하고 있습니다. 독서 기록이 실제 Recall 검색으로 이어지는지 사용자 인터뷰와 함께 확인하세요.",
+  };
+}

--- a/web/src/lib/admin/monitoring.ts
+++ b/web/src/lib/admin/monitoring.ts
@@ -1,7 +1,40 @@
 import type {
   AdminMonitoringMetrics,
+  GrowthMetricsRpc,
   MetricValue,
 } from "@/types/monitoring";
+
+const growthMetricKeys: Array<keyof GrowthMetricsRpc> = [
+  "total_users",
+  "new_users_7d",
+  "active_users_7d",
+  "total_books",
+  "books_created_7d",
+  "users_with_books",
+  "total_reading_records",
+  "reading_records_7d",
+  "users_with_reading_records",
+  "total_ai_recalls",
+  "ai_recalls_7d",
+  "users_with_ai_recall",
+];
+
+export function normalizeGrowthMetrics(
+  value: unknown
+): GrowthMetricsRpc | null {
+  const candidate = Array.isArray(value) ? value[0] : value;
+
+  if (!candidate || typeof candidate !== "object") {
+    return null;
+  }
+
+  const record = candidate as Record<string, unknown>;
+  const isValid = growthMetricKeys.every(
+    (key) => typeof record[key] === "number" && Number.isFinite(record[key])
+  );
+
+  return isValid ? (record as GrowthMetricsRpc) : null;
+}
 
 export function percentage(
   numerator: MetricValue,
@@ -23,6 +56,12 @@ export function formatPercentage(value: number | null): string {
 }
 
 export function formatGeneratedAt(value: string): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "시간 정보 없음";
+  }
+
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone: "Asia/Seoul",
     year: "numeric",
@@ -32,7 +71,7 @@ export function formatGeneratedAt(value: string): string {
     minute: "2-digit",
     hourCycle: "h23",
   })
-    .formatToParts(new Date(value))
+    .formatToParts(date)
     .reduce<Record<string, string>>((result, part) => {
       result[part.type] = part.value;
       return result;

--- a/web/src/lib/admin/monitoring.ts
+++ b/web/src/lib/admin/monitoring.ts
@@ -19,6 +19,8 @@ const growthMetricKeys: Array<keyof GrowthMetricsRpc> = [
   "users_with_ai_recall",
 ];
 
+const maximumMetricCount = 1_000_000_000;
+
 export function normalizeGrowthMetrics(
   value: unknown
 ): GrowthMetricsRpc | null {
@@ -30,7 +32,11 @@ export function normalizeGrowthMetrics(
 
   const record = candidate as Record<string, unknown>;
   const isValid = growthMetricKeys.every(
-    (key) => typeof record[key] === "number" && Number.isFinite(record[key])
+    (key) =>
+      typeof record[key] === "number" &&
+      Number.isSafeInteger(record[key]) &&
+      record[key] >= 0 &&
+      record[key] <= maximumMetricCount
   );
 
   return isValid ? (record as GrowthMetricsRpc) : null;

--- a/web/src/types/monitoring.ts
+++ b/web/src/types/monitoring.ts
@@ -1,5 +1,20 @@
 export type MetricValue = number | null;
 
+export type GrowthMetricsRpc = {
+  total_users: number;
+  new_users_7d: number;
+  active_users_7d: number;
+  total_books: number;
+  books_created_7d: number;
+  users_with_books: number;
+  total_reading_records: number;
+  reading_records_7d: number;
+  users_with_reading_records: number;
+  total_ai_recalls: number;
+  ai_recalls_7d: number;
+  users_with_ai_recall: number;
+};
+
 export type AdminMonitoringMetrics = {
   generated_at: string;
   period_days: number;

--- a/web/src/types/monitoring.ts
+++ b/web/src/types/monitoring.ts
@@ -1,0 +1,32 @@
+export type MetricValue = number | null;
+
+export type AdminMonitoringMetrics = {
+  generated_at: string;
+  period_days: number;
+  source_status: "connected" | "partial";
+  unavailable_metrics: string[];
+  users: {
+    total: MetricValue;
+    new_7d: MetricValue;
+    active_7d: MetricValue;
+  };
+  books: {
+    total: MetricValue;
+    created_7d: MetricValue;
+    users_with_books: MetricValue;
+  };
+  reading: {
+    total_records: MetricValue;
+    records_7d: MetricValue;
+    users_with_records: MetricValue;
+  };
+  recall: {
+    total: MetricValue;
+    created_7d: MetricValue;
+    users_with_recall: MetricValue;
+  };
+  push: {
+    sent_7d: MetricValue;
+    clicked_7d: MetricValue;
+  };
+};

--- a/web/tests/monitoring.test.mjs
+++ b/web/tests/monitoring.test.mjs
@@ -39,3 +39,43 @@ test("next action prioritizes an unavailable active-user metric", () => {
 
   assert.equal(action.title, "활성 사용자 집계를 먼저 연결하세요");
 });
+
+test("next action does not treat an unavailable book metric as zero", () => {
+  const action = getNextAction({
+    generated_at: "2026-07-29T04:00:00.000Z",
+    period_days: 7,
+    source_status: "partial",
+    unavailable_metrics: ["books_created_7d"],
+    users: { total: 50, new_7d: 12, active_7d: 35 },
+    books: { total: 80, created_7d: null, users_with_books: 42 },
+    reading: {
+      total_records: 140,
+      records_7d: 20,
+      users_with_records: 31,
+    },
+    recall: { total: 36, created_7d: 8, users_with_recall: 18 },
+    push: { sent_7d: 45, clicked_7d: 9 },
+  });
+
+  assert.equal(action.title, "핵심 행동 지표 연결을 확인하세요");
+});
+
+test("next action does not compare an unavailable reading metric", () => {
+  const action = getNextAction({
+    generated_at: "2026-07-29T04:00:00.000Z",
+    period_days: 7,
+    source_status: "partial",
+    unavailable_metrics: ["reading_records_7d"],
+    users: { total: 50, new_7d: 12, active_7d: 35 },
+    books: { total: 80, created_7d: 18, users_with_books: 42 },
+    reading: {
+      total_records: 140,
+      records_7d: null,
+      users_with_records: 31,
+    },
+    recall: { total: 36, created_7d: 8, users_with_recall: 18 },
+    push: { sent_7d: 45, clicked_7d: 9 },
+  });
+
+  assert.equal(action.title, "핵심 행동 지표 연결을 확인하세요");
+});

--- a/web/tests/monitoring.test.mjs
+++ b/web/tests/monitoring.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  formatGeneratedAt,
+  getNextAction,
+  percentage,
+} from "../src/lib/admin/monitoring.ts";
+
+test("percentage returns a rounded rate and preserves unavailable values", () => {
+  assert.equal(percentage(1, 3), 33.3);
+  assert.equal(percentage(null, 3), null);
+  assert.equal(percentage(1, 0), null);
+});
+
+test("generated time is stable in Korea Standard Time", () => {
+  assert.equal(
+    formatGeneratedAt("2026-07-29T04:00:00.000Z"),
+    "2026.07.29 13:00 KST"
+  );
+});
+
+test("next action prioritizes an unavailable active-user metric", () => {
+  const action = getNextAction({
+    generated_at: "2026-07-29T04:00:00.000Z",
+    period_days: 7,
+    source_status: "partial",
+    unavailable_metrics: ["active_users_7d"],
+    users: { total: 12, new_7d: 2, active_7d: null },
+    books: { total: 18, created_7d: 4, users_with_books: null },
+    reading: {
+      total_records: 43,
+      records_7d: 9,
+      users_with_records: null,
+    },
+    recall: { total: 6, created_7d: 2, users_with_recall: null },
+    push: { sent_7d: 21, clicked_7d: 4 },
+  });
+
+  assert.equal(action.title, "활성 사용자 집계를 먼저 연결하세요");
+});

--- a/web/tests/monitoring.test.mjs
+++ b/web/tests/monitoring.test.mjs
@@ -4,8 +4,24 @@ import test from "node:test";
 import {
   formatGeneratedAt,
   getNextAction,
+  normalizeGrowthMetrics,
   percentage,
 } from "../src/lib/admin/monitoring.ts";
+
+const growthMetricsRow = {
+  total_users: 12,
+  new_users_7d: 2,
+  active_users_7d: 5,
+  total_books: 18,
+  books_created_7d: 4,
+  users_with_books: 7,
+  total_reading_records: 43,
+  reading_records_7d: 9,
+  users_with_reading_records: 6,
+  total_ai_recalls: 6,
+  ai_recalls_7d: 2,
+  users_with_ai_recall: 3,
+};
 
 test("percentage returns a rounded rate and preserves unavailable values", () => {
   assert.equal(percentage(1, 3), 33.3);
@@ -18,6 +34,21 @@ test("generated time is stable in Korea Standard Time", () => {
     formatGeneratedAt("2026-07-29T04:00:00.000Z"),
     "2026.07.29 13:00 KST"
   );
+});
+
+test("generated time falls back for an invalid timestamp", () => {
+  assert.equal(formatGeneratedAt("not-a-date"), "시간 정보 없음");
+});
+
+test("growth metrics normalize a single RPC row from array responses", () => {
+  assert.deepEqual(normalizeGrowthMetrics([growthMetricsRow]), growthMetricsRow);
+  assert.deepEqual(normalizeGrowthMetrics(growthMetricsRow), growthMetricsRow);
+});
+
+test("growth metrics reject empty or incomplete RPC responses", () => {
+  assert.equal(normalizeGrowthMetrics([]), null);
+  assert.equal(normalizeGrowthMetrics({ total_users: 12 }), null);
+  assert.equal(normalizeGrowthMetrics(null), null);
 });
 
 test("next action prioritizes an unavailable active-user metric", () => {

--- a/web/tests/monitoring.test.mjs
+++ b/web/tests/monitoring.test.mjs
@@ -51,6 +51,24 @@ test("growth metrics reject empty or incomplete RPC responses", () => {
   assert.equal(normalizeGrowthMetrics(null), null);
 });
 
+test("growth metrics reject invalid count values", () => {
+  assert.equal(
+    normalizeGrowthMetrics({ ...growthMetricsRow, total_users: -1 }),
+    null
+  );
+  assert.equal(
+    normalizeGrowthMetrics({ ...growthMetricsRow, total_users: 0.5 }),
+    null
+  );
+  assert.equal(
+    normalizeGrowthMetrics({
+      ...growthMetricsRow,
+      total_users: 1_000_000_001,
+    }),
+    null
+  );
+});
+
 test("next action prioritizes an unavailable active-user metric", () => {
   const action = getNextAction({
     generated_at: "2026-07-29T04:00:00.000Z",


### PR DESCRIPTION
Target-Delivery-Unit: web
Target-Version: 1.0.1
Delivery-Profile: web-release-train

## 목적

기존 `version/web/1.0.0`에 남아 있던 유효 관리자 성장 대시보드 변경을 활성 Web 1.0.1 라인에 강제 push 없이 재통합합니다.

## 주요 변경

- 제품 행동 집계 관리자 대시보드와 인증된 monitoring API를 이관했습니다.
- 집계 불가 값을 0으로 오인하지 않도록 부분 연결 상태와 다음 관찰 우선순위를 보존했습니다.
- High 의존성 취약점을 비강제 잠금 파일 갱신으로 제거했습니다.
- 904px와 390px에서 관리자 내비게이션이 깨지지 않도록 2행 구조, 내부 가로 스크롤, 현재 페이지 및 키보드 포커스 단서를 적용했습니다.

## 출처 보존

- `c1bc2f67146b4b132b83f50e9e12f25cb4bc0ba2` → `5b2b58be4f247c876ac689241e6e619ce4c5096f`
- `dff1259d22db6a0772a89119bcaeb5455e901ec8` → `96df8ac053f2544893de87beb10dbd405ac3e151`
- `5bc6634b9e04d4523668883cadbbda5a1b181a4d` → `61138fb496782a77e84080372240061ec6997c92`

## 검증

- `npm run test:monitoring` — 9/9 통과, Node 22 호환 실행기 사용
- `npm run lint` — 통과
- `npm run build` — 통과
- `npm audit --audit-level=moderate` — 취약점 0건
- 비인증 `/admin` → 307 `/admin/login`
- 비인증 `/api/admin/monitoring` → 401
- 인증된 Dev 관리자 partial-data 화면을 904px·390px에서 통합 검증
- Product Designer — APPROVE

## 제한과 후속

- 로컬 화면 검증은 Production이 아닌 Supabase Dev 경계에서 수행했습니다.
- BOK-403으로 발견한 PostCSS 경로는 호환 가능한 패치 override로 제거했고 안정판 Next.js 강제 전환은 하지 않았습니다.
- 이 PR은 Web version line 통합용이며 Production 배포를 수행하지 않습니다.

## 관련 이슈

- BOK-401
- BOK-403
