### PR TITLE
docs(mobile): attest 1.0.2 roadmap evidence

### DIFF
--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -1,6 +1,6 @@
 # Bookgolas Product Roadmap
 
-Last updated: 2026-07-25
+Last updated: 2026-08-04
 
 ## Target Delivery Contract
 

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-07-25
 
+## Target Delivery Contract
+
+Target-Delivery-Unit: mobile
+Target-Version: 1.0.2
+Delivery-Profile: mobile-store
+
 ## Priority order
 
 Bookgolas follows this release order:


### PR DESCRIPTION
## 목적

Company OS의 강화된 version-line 검증을 Bookgolas에 도입하기 전에 현재 Mobile 1.0.2 라인의 권위 있는 문서 증빙을 준비합니다.

## 주요 변경

- `docs/product-roadmap.md`에 Mobile 1.0.2 delivery contract 메타데이터 추가
- delivery unit, target version, profile을 각각 정확히 한 번 기록

## 배경

BOK-401의 Web 1.0.2 복구 과정에서 신뢰 validator가 모든 활성 version-line의 attestation을 검증하게 됩니다. 기존 Mobile 1.0.2를 중단시키지 않으려면 현재 라인에도 해시 가능한 문서 증빙이 필요합니다.

## 검증

- 세 메타데이터 라인 각각 1회 확인
- `git diff --check`
- Target Delivery preflight: mobile / 1.0.2 / mobile-store

## 관련 이슈

- BOK-401

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product roadmap with target delivery contract specifications for mobile delivery version 1.0.2 and mobile-store delivery profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->