### PR TITLE
ci(governance): scope monorepo quality gates

### DIFF
--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -43,6 +43,7 @@
         ".github/workflows/daily-nudge.yml",
         ".github/workflows/ios-production.yml",
         ".github/workflows/ios-testflight.yml",
+        ".github/workflows/quality.yml",
         ".github/workflows/schema-check.yml",
         "README.md",
         "app/**",

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,21 +12,74 @@ concurrency:
   group: quality-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  changes:
+    name: Resolve Quality Scope
+    runs-on: ubuntu-latest
+    outputs:
+      flutter: ${{ steps.scope.outputs.flutter }}
+      web: ${{ steps.scope.outputs.web }}
+      edge: ${{ steps.scope.outputs.edge }}
+    steps:
+      - id: scope
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+              },
+            );
+            const paths = files
+              .flatMap((file) =>
+                file.status === "renamed"
+                  ? [file.previous_filename, file.filename]
+                  : [file.filename],
+              )
+              .filter(Boolean);
+            core.setOutput(
+              "flutter",
+              paths.some((path) =>
+                path === ".env.example" || path.startsWith("app/"),
+              ),
+            );
+            core.setOutput(
+              "web",
+              paths.some((path) => path.startsWith("web/")),
+            );
+            core.setOutput(
+              "edge",
+              paths.some((path) => path.startsWith("supabase/functions/")),
+            );
+
   flutter:
     name: Flutter Analyze and Test
+    needs: changes
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: app
     steps:
-      - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
+      - if: needs.changes.outputs.flutter != 'true'
+        run: echo "No Flutter changes detected"
+      - if: needs.changes.outputs.flutter == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.flutter == 'true'
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.35.0'
           channel: stable
           cache: true
       - name: Create test environment
+        if: needs.changes.outputs.flutter == 'true'
         run: |
           printf '%s\n' \
             'ALADIN_TTB_KEY=test' \
@@ -37,38 +90,57 @@ jobs:
             'GOOGLE_CLOUD_VISION_API_KEY=test' \
             'REVENUECAT_PUBLIC_KEY=test' \
             'ENVIRONMENT=development' > .env
-      - run: flutter pub get
-      - run: flutter gen-l10n
-      - run: flutter analyze --no-fatal-infos
-      - run: flutter test --no-pub
+      - if: needs.changes.outputs.flutter == 'true'
+        run: flutter pub get
+      - if: needs.changes.outputs.flutter == 'true'
+        run: flutter gen-l10n
+      - if: needs.changes.outputs.flutter == 'true'
+        run: flutter analyze --no-fatal-infos
+      - if: needs.changes.outputs.flutter == 'true'
+        run: flutter test --no-pub
 
   web:
     name: Web Audit, Lint, and Build
+    needs: changes
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - if: needs.changes.outputs.web != 'true'
+        run: echo "No Web changes detected"
+      - if: needs.changes.outputs.web == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.web == 'true'
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: web/package-lock.json
-      - run: npm ci
-      - run: npm audit --audit-level=high
-      - run: npm run lint
-      - run: npm run build
+      - if: needs.changes.outputs.web == 'true'
+        run: npm ci
+      - if: needs.changes.outputs.web == 'true'
+        run: npm audit --audit-level=high
+      - if: needs.changes.outputs.web == 'true'
+        run: npm run lint
+      - if: needs.changes.outputs.web == 'true'
+        run: npm run build
 
   edge-functions:
     name: Edge Function Type Check
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: denoland/setup-deno@v2
+      - if: needs.changes.outputs.edge != 'true'
+        run: echo "No Edge Function changes detected"
+      - if: needs.changes.outputs.edge == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.edge == 'true'
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
       - name: Check all functions
+        if: needs.changes.outputs.edge == 'true'
         run: |
           while IFS= read -r entry; do
             config="$(dirname "$entry")/deno.json"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -69,6 +69,7 @@ jobs:
         working-directory: app
     steps:
       - if: needs.changes.outputs.flutter != 'true'
+        working-directory: .
         run: echo "No Flutter changes detected"
       - if: needs.changes.outputs.flutter == 'true'
         uses: actions/checkout@v4
@@ -108,6 +109,7 @@ jobs:
         working-directory: web
     steps:
       - if: needs.changes.outputs.web != 'true'
+        working-directory: .
         run: echo "No Web changes detected"
       - if: needs.changes.outputs.web == 'true'
         uses: actions/checkout@v4


### PR DESCRIPTION
## 목적

각 PR이 실제로 변경한 surface에만 무거운 품질 검사를 실행하면서 기존 체크 이름과 성공 상태를 유지합니다.

## 주요 변경

- GitHub API로 rename 이전·이후를 포함한 전체 변경 경로 수집
- Flutter, Web, Edge Function 검사 범위를 각 디렉터리로 분리
- 변경 없는 surface는 성공한 no-op step으로 종료
- Mobile version-line에서 동일 quality workflow를 동기화할 수 있도록 allowlist 추가

## 배경

PR #329는 Mobile 문서만 변경했지만 변경하지 않은 Web lockfile의 신규 보안 공지 때문에 Web Audit가 실패했습니다. Web 변경 PR에서는 audit를 그대로 필수로 유지하고, unrelated surface가 다른 delivery unit의 거버넌스·문서 작업을 막는 결합만 제거합니다.

## 검증

- `actionlint .github/workflows/quality.yml`
- branch-policy JSON parse
- `git diff --check`
- Target Delivery preflight: governance / 1.0.0 / package-or-local

## 관련 이슈

- BOK-401
- BOK-403

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local