### PR TITLE
fix(governance): scope quality gates by changed surface

### DIFF
--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -53,6 +53,9 @@
       "sync_bases": [
         "dev",
         "version/mobile/1.0.2"
+      ],
+      "sync_only_paths": [
+        ".github/workflows/quality.yml"
       ]
     },
     "web": {

--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -43,6 +43,7 @@
         ".github/workflows/daily-nudge.yml",
         ".github/workflows/ios-production.yml",
         ".github/workflows/ios-testflight.yml",
+        ".github/workflows/quality.yml",
         ".github/workflows/schema-check.yml",
         "README.md",
         "app/**",

--- a/.github/scripts/validate_target_version_pr.py
+++ b/.github/scripts/validate_target_version_pr.py
@@ -172,6 +172,32 @@ def validate(
             + ", ".join(invalid_paths[:5])
         )
 
+    sync_only_paths = policy.get("sync_only_paths", [])
+    if not isinstance(sync_only_paths, list) or not all(
+        isinstance(pattern, str) and pattern for pattern in sync_only_paths
+    ):
+        raise PolicyError(f"delivery unit {unit} has invalid sync_only_paths policy")
+    restricted_paths = [
+        path
+        for path in changed_files
+        if any(
+            fnmatch.fnmatchcase(path, pattern)
+            for pattern in sync_only_paths
+        )
+    ]
+    if restricted_paths:
+        if branch_type != "sync":
+            raise PolicyError(
+                f"sync-only paths require a sync branch for {unit}: "
+                + ", ".join(restricted_paths[:5])
+            )
+        mixed_paths = [path for path in changed_files if path not in restricted_paths]
+        if mixed_paths:
+            raise PolicyError(
+                f"sync-only paths cannot be mixed with other changes for {unit}: "
+                + ", ".join(mixed_paths[:5])
+            )
+
     expected = {
         "Target-Delivery-Unit": unit,
         "Target-Version": version,

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,21 +12,74 @@ concurrency:
   group: quality-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  changes:
+    name: Resolve Quality Scope
+    runs-on: ubuntu-latest
+    outputs:
+      flutter: ${{ steps.scope.outputs.flutter }}
+      web: ${{ steps.scope.outputs.web }}
+      edge: ${{ steps.scope.outputs.edge }}
+    steps:
+      - id: scope
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+              },
+            );
+            const paths = files
+              .flatMap((file) =>
+                file.status === "renamed"
+                  ? [file.previous_filename, file.filename]
+                  : [file.filename],
+              )
+              .filter(Boolean);
+            core.setOutput(
+              "flutter",
+              paths.some((path) =>
+                path === ".env.example" || path.startsWith("app/"),
+              ),
+            );
+            core.setOutput(
+              "web",
+              paths.some((path) => path.startsWith("web/")),
+            );
+            core.setOutput(
+              "edge",
+              paths.some((path) => path.startsWith("supabase/functions/")),
+            );
+
   flutter:
     name: Flutter Analyze and Test
+    needs: changes
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: app
     steps:
-      - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
+      - if: needs.changes.outputs.flutter != 'true'
+        run: echo "No Flutter changes detected"
+      - if: needs.changes.outputs.flutter == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.flutter == 'true'
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.35.0'
           channel: stable
           cache: true
       - name: Create test environment
+        if: needs.changes.outputs.flutter == 'true'
         run: |
           printf '%s\n' \
             'ALADIN_TTB_KEY=test' \
@@ -37,38 +90,57 @@ jobs:
             'GOOGLE_CLOUD_VISION_API_KEY=test' \
             'REVENUECAT_PUBLIC_KEY=test' \
             'ENVIRONMENT=development' > .env
-      - run: flutter pub get
-      - run: flutter gen-l10n
-      - run: flutter analyze --no-fatal-infos
-      - run: flutter test --no-pub
+      - if: needs.changes.outputs.flutter == 'true'
+        run: flutter pub get
+      - if: needs.changes.outputs.flutter == 'true'
+        run: flutter gen-l10n
+      - if: needs.changes.outputs.flutter == 'true'
+        run: flutter analyze --no-fatal-infos
+      - if: needs.changes.outputs.flutter == 'true'
+        run: flutter test --no-pub
 
   web:
     name: Web Audit, Lint, and Build
+    needs: changes
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - if: needs.changes.outputs.web != 'true'
+        run: echo "No Web changes detected"
+      - if: needs.changes.outputs.web == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.web == 'true'
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: web/package-lock.json
-      - run: npm ci
-      - run: npm audit --audit-level=high
-      - run: npm run lint
-      - run: npm run build
+      - if: needs.changes.outputs.web == 'true'
+        run: npm ci
+      - if: needs.changes.outputs.web == 'true'
+        run: npm audit --audit-level=high
+      - if: needs.changes.outputs.web == 'true'
+        run: npm run lint
+      - if: needs.changes.outputs.web == 'true'
+        run: npm run build
 
   edge-functions:
     name: Edge Function Type Check
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: denoland/setup-deno@v2
+      - if: needs.changes.outputs.edge != 'true'
+        run: echo "No Edge Function changes detected"
+      - if: needs.changes.outputs.edge == 'true'
+        uses: actions/checkout@v4
+      - if: needs.changes.outputs.edge == 'true'
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
       - name: Check all functions
+        if: needs.changes.outputs.edge == 'true'
         run: |
           while IFS= read -r entry; do
             config="$(dirname "$entry")/deno.json"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -69,6 +69,7 @@ jobs:
         working-directory: app
     steps:
       - if: needs.changes.outputs.flutter != 'true'
+        working-directory: .
         run: echo "No Flutter changes detected"
       - if: needs.changes.outputs.flutter == 'true'
         uses: actions/checkout@v4
@@ -108,6 +109,7 @@ jobs:
         working-directory: web
     steps:
       - if: needs.changes.outputs.web != 'true'
+        working-directory: .
         run: echo "No Web changes detected"
       - if: needs.changes.outputs.web == 'true'
         uses: actions/checkout@v4

--- a/.github/workflows/target-version-gate.yml
+++ b/.github/workflows/target-version-gate.yml
@@ -32,7 +32,17 @@ jobs:
               --paginate \
               --slurp \
               "repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files?per_page=100" |
-              jq -c '[.[][] | .filename]' |
+              jq -c '[
+                .[][] |
+                (
+                  if .status == "renamed" then
+                    .previous_filename, .filename
+                  else
+                    .filename
+                  end
+                ) |
+                select(type == "string" and length > 0)
+              ]' |
               openssl base64 -A
           )"
           test -n "$changed_files_b64"


### PR DESCRIPTION
## 목적

각 PR이 실제로 변경한 surface에만 무거운 품질 검사를 실행하면서 기존 체크 이름과 성공 상태를 유지합니다.

## 주요 변경

- GitHub API로 rename 이전·이후를 포함한 전체 변경 경로 수집
- Flutter, Web, Edge Function 검사 범위를 각 디렉터리로 분리
- 변경 없는 surface는 성공한 no-op step으로 종료
- 품질 워크플로 변경은 Mobile sync 브랜치의 단독 변경으로만 허용
- 제품 코드와 품질 워크플로를 섞거나 보호 경로를 rename해 검사를 우회하는 PR을 trusted validator에서 차단

## 배경

Mobile 문서만 변경한 PR이 변경하지 않은 Web lockfile의 신규 보안 공지 때문에 실패했습니다. Web 변경 PR에서는 audit를 그대로 필수로 유지하고, unrelated surface가 다른 delivery unit의 거버넌스·문서 작업을 막는 결합만 제거합니다.

## 검증

- actionlint .github/workflows/quality.yml .github/workflows/target-version-gate.yml
- python3 -m py_compile .github/scripts/validate_target_version_pr.py
- branch-policy JSON parse
- sync-only positive/negative validator contract tests
- rename 이전·이후 경로 수집 및 보호 경로 rename 우회 회귀 테스트
- git diff --check
- Target Delivery preflight: governance / 1.0.0 / package-or-local

## 관련 이슈

- BOK-404

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local