### PR TITLE
fix(ci): fail closed on truncated quality scope

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -38,6 +38,19 @@ jobs:
                 per_page: 100,
               },
             );
+            const expectedFileCount = Number(
+              context.payload.pull_request.changed_files,
+            );
+            if (!Number.isSafeInteger(expectedFileCount)) {
+              core.setFailed("PR changed-file count is unavailable");
+              return;
+            }
+            if (files.length !== expectedFileCount) {
+              core.setFailed(
+                `Changed-file evidence is incomplete: collected ${files.length}, expected ${expectedFileCount}`,
+              );
+              return;
+            }
             const paths = files
               .flatMap((file) =>
                 file.status === "renamed"


### PR DESCRIPTION
## 목적

GitHub Pull Request files API가 대형 PR에서 반환을 잘랐을 때 품질 검사 scope를 성공 no-op으로 오판하지 않도록 trusted workflow를 보강합니다.

## 주요 변경

- `context.payload.pull_request.changed_files`와 수집된 파일 수를 비교
- 파일 증거가 없거나 불완전하면 scope job을 fail-closed
- 기존 rename-aware 경로 수집과 surface별 체크 이름은 유지

## 검증

- actionlint .github/workflows/quality.yml
- git diff --check
- Target Delivery preflight: governance / 1.0.0 / package-or-local

## 관련 이슈

- BOK-404

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local