### PR TITLE
docs(mobile): attest 1.0.2 roadmap evidence on current line

### DIFF
--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -1,6 +1,6 @@
 # Bookgolas Product Roadmap
 
-Last updated: 2026-07-25
+Last updated: 2026-08-04
 
 ## Target Delivery Contract
 

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-07-25
 
+## Target Delivery Contract
+
+Target-Delivery-Unit: mobile
+Target-Version: 1.0.2
+Delivery-Profile: mobile-store
+
 ## Priority order
 
 Bookgolas follows this release order:


### PR DESCRIPTION
## 목적

현재 Mobile 1.0.2 version line의 권위 있는 문서 증빙을 최신 quality-gate base 위에 기록합니다.

## 주요 변경

- `docs/product-roadmap.md`에 Mobile 1.0.2 delivery contract 메타데이터 추가
- roadmap의 `Last updated` 날짜를 증빙 변경일과 정합화
- 기존 PR #329의 문서 변경을 현재 Mobile line에서 출처 보존 방식으로 재적용

## 배경

Mobile 1.0.2 line에 source attestation 계약을 적용하려면 현재 라인에서 해시 가능한 문서 증빙이 필요합니다. Quality workflow 동기화와 truncation fail-closed 보강이 병합된 최신 base를 사용합니다.

## 검증

- delivery metadata 각 1회 확인
- git diff --check
- Target Delivery preflight: mobile / 1.0.2 / mobile-store

## 관련 이슈

- BOK-401

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store