### PR TITLE
chore(governance): activate Web 1.0.2 from production main

### DIFF
--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -62,11 +62,12 @@
       "profile": "web-release-train",
       "mode": "version-line",
       "active_versions": [
-        "1.0.1"
+        "1.0.2"
       ],
       "target_version_source": ".byungskerlab/release-lines.json",
       "production_branch": "main",
       "allowed_paths": [
+        "AGENTS.md",
         "docs/**",
         "web/**"
       ]

--- a/.byungskerlab/release-lines.json
+++ b/.byungskerlab/release-lines.json
@@ -27,9 +27,10 @@
     },
     "web": {
       "active_versions": [
-        "1.0.1"
+        "1.0.2"
       ],
       "evidence_refs": [
+        "AGENTS.md",
         "docs/product-roadmap.md"
       ],
       "promotion_sources": {


### PR DESCRIPTION
## 목적

보존된 Web 1.0.1 topology를 건드리지 않고, 검증된 production main에서 Web 1.0.2 release line을 여는 거버넌스 변경입니다.

## 주요 변경

- Web active version을 1.0.1에서 1.0.2로 전환
- Web policy와 release registry의 active version을 동일하게 갱신
- 이후 문서 동기화를 위해 `AGENTS.md`와 `docs/product-roadmap.md`를 Web allowlist/evidence refs에 추가

## 배경

기존 Web 1.0.1 line은 dev 거버넌스에서 생성되어 production main 기반 규칙과 맞지 않습니다. 기존 line은 보존하고, 다음 정상 line은 현재 main SHA에서 생성합니다.

## 검증

- branch-policy/release-lines JSON parse
- Target Delivery preflight: governance / 1.0.0 / package-or-local
- git diff --check

## 관련 이슈

- BOK-404

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local