### PR TITLE
chore(governance): activate Web 1.0.2 evidence line

### DIFF
--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -62,11 +62,12 @@
       "profile": "web-release-train",
       "mode": "version-line",
       "active_versions": [
-        "1.0.1"
+        "1.0.2"
       ],
       "target_version_source": ".byungskerlab/release-lines.json",
       "production_branch": "main",
       "allowed_paths": [
+        "AGENTS.md",
         "docs/**",
         "web/**"
       ]

--- a/.byungskerlab/release-lines.json
+++ b/.byungskerlab/release-lines.json
@@ -27,9 +27,10 @@
     },
     "web": {
       "active_versions": [
-        "1.0.1"
+        "1.0.2"
       ],
       "evidence_refs": [
+        "AGENTS.md",
         "docs/product-roadmap.md"
       ],
       "promotion_sources": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,8 +152,8 @@ UI (lib/ui/) → ViewModel → Repository → Service
 - 기계 검증 가능한 활성 버전 원본은 `release-lines.json`이며, 현재
   승인된 모바일 타깃 `1.0.2`의 근거는 `docs/product-roadmap.md`이다.
   현재 앱 매니페스트 버전은 후속 모바일 작업에서 타깃 버전에 맞춘다.
-  웹 또는 독립 backend는 승인된 다음 버전이 아직 없으므로 버전 원본과
-  active version을 먼저 갱신하기 전에는 브랜치나 PR을 만들 수 없다.
+  독립 Web admin의 승인된 parallel release train은 `1.0.2`이며,
+  `AGENTS.md`와 `docs/product-roadmap.md`가 그 evidence를 함께 기록한다.
 - active version을 여는 정책 변경은 byungsker 검토가 필요한
   `chore/governance/1.0.0/<scope>` PR로만 수행한다.
 - `daily/*`는 사용하지 않는다.

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -66,7 +66,7 @@ unverified.
 - Verify the public listing, install, sign-in, core reading flow, analytics,
   support entrypoint, and rollback/hold criteria after approval.
 
-## Parallel track — web 1.0.0 data-informed admin
+## Parallel track — web 1.0.2 data-informed admin
 
 - Replace direct browser-side operational queries with an authenticated
   server-side aggregate metrics boundary.

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -1,6 +1,16 @@
 # Bookgolas Product Roadmap
 
-Last updated: 2026-07-29
+Last updated: 2026-08-05
+
+## Target Delivery Contract
+
+Target-Delivery-Unit: mobile
+Target-Version: 1.0.2
+Delivery-Profile: mobile-store
+
+Target-Delivery-Unit: web
+Target-Version: 1.0.2
+Delivery-Profile: web-release-train
 
 ## Priority order
 
@@ -11,7 +21,7 @@ Bookgolas follows this release order:
 3. Publish the Android release to Google Play after the test and policy gates pass.
 
 The independently delivered web admin has an approved parallel release train:
-**web 1.0.0**. It does not change the mobile 1.0.2 binary scope.
+**web 1.0.2**. It does not change the mobile 1.0.2 binary scope.
 
 ## P0 — 1.0.2 patch release
 


### PR DESCRIPTION
## 목적

보존된 Web 1.0.1 topology와 분리해 Web 1.0.2 parallel release train을 열고, 권위 문서를 active registry와 정합화합니다.

## 주요 변경

- Web active version을 1.0.1에서 1.0.2로 전환
- policy와 release registry의 active version/evidence refs 정합화
- `AGENTS.md`와 `docs/product-roadmap.md`에 승인된 Web 1.0.2 기록
- activation branch를 `chore/governance/1.0.0` 계약으로 교정

## 배경

기존 Web 1.0.1 line은 dev 거버넌스에서 생성되어 production main 기반 규칙과 충돌합니다. 기존 line은 보존하고, 다음 정상 line은 current main에서 생성합니다.

## 검증

- branch-policy/release-lines JSON parse
- Target Delivery preflight: governance / 1.0.0 / package-or-local
- git diff --check

## 관련 이슈

- BOK-405

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the product roadmap with the latest planning date and delivery contracts for mobile and web version 1.0.2.
  * Clarified the independent web release track and its supporting documentation.

* **Chores**
  * Updated release governance and workflow guidance to recognize web version 1.0.2 as the approved release train.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->