### PR TITLE
chore(governance): allow web quality workflow sync

### DIFF
--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -68,6 +68,7 @@
       "production_branch": "main",
       "allowed_paths": [
         "AGENTS.md",
+        ".github/workflows/quality.yml",
         "docs/**",
         "web/**"
       ]


### PR DESCRIPTION
## 목적
Web 1.0.2 version-line PR에서 저장소 ruleset이 요구하는 Flutter/Web/Edge quality checks가 생성되도록 공용 quality workflow를 Web delivery allowlist에 포함한다.

## 주요 변경
- Web allowed_paths에 .github/workflows/quality.yml 추가
- Web version-line에서 최신 quality workflow를 sync할 수 있는 governance 경계 명시

## 검증
- governance 1.0.0 Target Delivery Contract preflight 통과
- git diff --check 통과

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local

Related issue: BOK-405