### PR TITLE
chore(governance): restrict web quality workflow sync

### DIFF
--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -71,6 +71,9 @@
         ".github/workflows/quality.yml",
         "docs/**",
         "web/**"
+      ],
+      "sync_only_paths": [
+        ".github/workflows/quality.yml"
       ]
     },
     "backend": {


### PR DESCRIPTION
## 목적
Web quality workflow를 일반 Web 기능 변경과 혼합하지 못하도록 sync-only 정책을 추가한다.

## 주요 변경
- Web delivery unit의 .github/workflows/quality.yml을 sync-only로 지정
- 기존 allowlist는 유지하면서 workflow 단독 동기화만 허용

## 검증
- governance 1.0.0 Target Delivery Contract preflight 통과
- git diff --check 통과
- validator가 sync-only 경로와 mixed paths를 fail-closed로 검사

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local

Related issue: BOK-405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted automated synchronization for the web delivery unit to the quality workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->