### PR TITLE
chore(governance): allow web version-line policy sync

### DIFF
--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -16,6 +16,11 @@
         "dev",
         "main"
       ],
+      "sync_bases": [
+        "dev",
+        "main",
+        "version/web/1.0.2"
+      ],
       "allowed_paths": [
         ".byungskerlab/branch-policy.json",
         ".byungskerlab/release-lines.json",


### PR DESCRIPTION
## 목적
승인된 Web policy와 quality workflow를 version/web/1.0.2로 전달할 수 있도록 governance delivery의 정식 sync base를 추가한다.

## 주요 변경
- governance sync_bases에 version/web/1.0.2 추가
- Web version-line policy sync를 PR 경계 안에서 수행하도록 경로 명시

## 검증
- governance 1.0.0 Target Delivery Contract preflight 통과
- git diff --check 통과

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local

Related issue: BOK-405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch governance settings to synchronize the `dev`, `main`, and web version branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->