### PR TITLE
docs(web): record 1.0.2 release-line evidence

### DIFF
--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -12,6 +12,13 @@ Target-Delivery-Unit: web
 Target-Version: 1.0.2
 Delivery-Profile: web-release-train
 
+Web 1.0.2 release-line evidence:
+
+- Source baseline: `main@80c78d030a5290f047b1aa6d00e43a5331913803`.
+- Governance seed: PR #336 merge commit
+  `b165870b75d16df0f6c3986581d85301dc8a2d09`.
+- Version line: `version/web/1.0.2`.
+
 ## Priority order
 
 Bookgolas follows this release order:

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -15,8 +15,9 @@ Delivery-Profile: web-release-train
 Web 1.0.2 release-line evidence:
 
 - Source baseline: `main@80c78d030a5290f047b1aa6d00e43a5331913803`.
-- Governance seed: PR #336 merge commit
-  `b165870b75d16df0f6c3986581d85301dc8a2d09`.
+- Reviewed governance change source: PR #336 merge commit
+  `b165870b75d16df0f6c3986581d85301dc8a2d09` on `dev`; its reviewed change
+  was cherry-picked into the version line as `fe2b5b1b7c766a5b83b586e4d0ccbd36786f1579`.
 - Version line: `version/web/1.0.2`.
 
 ## Priority order


### PR DESCRIPTION
## 목적
최신 Web 1.0.2 version line에서 main 기준점과 governance/quality 동기화 lineage를 추적 가능하게 문서화한다.

## 주요 변경
- main source baseline 기록
- PR #336 governance source와 version-line 반영 커밋 구분
- version/web/1.0.2 line 기록

## 검증
- Web 1.0.2 Target Delivery Contract preflight 통과
- git diff --check 통과

Target-Delivery-Unit: web
Target-Version: 1.0.2
Delivery-Profile: web-release-train

Related issue: BOK-405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release-line evidence for web version 1.0.2, including the source baseline, governance review, cherry-pick record, and version details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->