### PR TITLE
fix(web): publish AdMob app-ads declaration

### DIFF
--- a/web/public/app-ads.txt
+++ b/web/public/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-2826132306659672, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## 목적
AdMob이 개발자 웹사이트 루트에서 크롤링할 수 있도록 `app-ads.txt`를 Web 1.0.2 release line에 포함합니다. 현재 공개 URL은 HTTP 404를 반환해 Bookgolas 앱 인증이 제한된 상태였습니다.

## 주요 변경
- `web/public/app-ads.txt`를 추적 파일로 추가
- Google publisher의 단일 DIRECT 레코드 유지
- 배포 후 `https://book-golas.vercel.app/app-ads.txt`에서 HTTP 200과 본문 확인 가능하도록 구성

## 배경
- AdMob 콘솔에서 Bookgolas 앱이 `검토 필요`·`광고 게재가 제한됨`·`Verify app to lift limit` 상태
- 로컬에는 동일 파일이 있었지만 Git 추적 및 공개 배포 산출물에 포함되지 않아 공개 URL이 404

## 검증
- `git diff --check`
- `npm ci`
- `npm run lint`
- `npm run build`
- 로컬 Next production server `GET /app-ads.txt` → HTTP 200
- 응답 본문이 단일 publisher 레코드와 일치
- UI 변경이 아니므로 시뮬레이터 캡처 없음

Target-Delivery-Unit: web
Target-Version: 1.0.2
Delivery-Profile: web-release-train

Related issue: BOK-395


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a Google publisher entry to the app advertising authorization file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->