### PR TITLE
fix(ai): enforce server usage budgets

### DIFF
--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -91,6 +91,8 @@ jobs:
         run: |
           deno test --frozen --config supabase/functions/deno.json --allow-env --allow-net \
             supabase/functions/_shared/third-party-ai-consent.test.ts \
+            supabase/functions/_shared/ai-usage.test.ts \
+            supabase/functions/recommend-next-books/services/profile-collector.test.ts \
             supabase/functions/vision-ocr/index_test.ts
           deno test --frozen --config supabase/functions/structure-notes/deno.json --allow-env --allow-net \
             supabase/functions/structure-notes/services/chain-service.test.ts

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -74,6 +74,8 @@ jobs:
         run: |
           deno test --frozen --config supabase/functions/deno.json --allow-env --allow-net \
             supabase/functions/_shared/third-party-ai-consent.test.ts \
+            supabase/functions/_shared/ai-usage.test.ts \
+            supabase/functions/recommend-next-books/services/profile-collector.test.ts \
             supabase/functions/vision-ocr/index_test.ts
           deno test --frozen --config supabase/functions/structure-notes/deno.json --allow-env --allow-net \
             supabase/functions/structure-notes/services/chain-service.test.ts
@@ -231,6 +233,8 @@ jobs:
         run: |
           deno test --config supabase/functions/deno.json --allow-env --allow-net \
             supabase/functions/_shared/third-party-ai-consent.test.ts \
+            supabase/functions/_shared/ai-usage.test.ts \
+            supabase/functions/recommend-next-books/services/profile-collector.test.ts \
             supabase/functions/vision-ocr/index_test.ts
           deno test --config supabase/functions/structure-notes/deno.json --allow-env --allow-net \
             supabase/functions/structure-notes/services/chain-service.test.ts

--- a/supabase/functions/_shared/ai-usage.test.ts
+++ b/supabase/functions/_shared/ai-usage.test.ts
@@ -10,6 +10,7 @@ import {
   aiUsageErrorResponse,
   assertAiInputSize,
   consumeAiBudget,
+  fetchAiProvider,
   withAiBudget,
 } from "./ai-usage.ts";
 
@@ -80,6 +81,27 @@ Deno.test("provider timeout errors return a stable 503 response", async () => {
   const response = aiUsageErrorResponse(
     new AiUsageError("provider_timeout", 503),
     { "Access-Control-Allow-Origin": "*" },
+  );
+  assertEquals(response?.status, 503);
+  assertEquals(await response?.json(), { error: "provider_timeout" });
+});
+
+Deno.test("provider aborts normalize through the actual fetch boundary", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const error = await assertRejects(
+    () =>
+      fetchAiProvider("data:text/plain,ok", { signal: controller.signal }, 10),
+  );
+  assertEquals(error instanceof AiUsageError, true);
+  assertEquals((error as AiUsageError).code, "provider_timeout");
+  assertEquals((error as AiUsageError).status, 503);
+});
+
+Deno.test("generic LangChain timeout errors normalize to provider timeout", async () => {
+  const response = aiUsageErrorResponse(
+    new Error("Request timed out in AsyncCaller"),
+    {},
   );
   assertEquals(response?.status, 503);
   assertEquals(await response?.json(), { error: "provider_timeout" });

--- a/supabase/functions/_shared/ai-usage.test.ts
+++ b/supabase/functions/_shared/ai-usage.test.ts
@@ -1,0 +1,21 @@
+import {
+  assertEquals,
+  assertThrows,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import {
+  AI_MAX_INPUT_CHARS,
+  AiUsageError,
+  assertAiInputSize,
+} from "./ai-usage.ts";
+
+Deno.test("AI input boundary accepts the configured maximum", () => {
+  assertAiInputSize(AI_MAX_INPUT_CHARS);
+});
+
+Deno.test("AI input boundary rejects oversized and invalid values", () => {
+  for (const value of [AI_MAX_INPUT_CHARS + 1, Number.NaN, -1]) {
+    const error = assertThrows(() => assertAiInputSize(value));
+    assertEquals(error instanceof AiUsageError, true);
+    assertEquals((error as AiUsageError).code, "input_too_large");
+  }
+});

--- a/supabase/functions/_shared/ai-usage.test.ts
+++ b/supabase/functions/_shared/ai-usage.test.ts
@@ -1,15 +1,28 @@
 import {
   assertEquals,
+  assertRejects,
   assertThrows,
 } from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import {
   AI_MAX_INPUT_CHARS,
   AiUsageError,
   assertAiInputSize,
+  consumeAiBudget,
 } from "./ai-usage.ts";
 
 Deno.test("AI input boundary accepts the configured maximum", () => {
   assertAiInputSize(AI_MAX_INPUT_CHARS);
+});
+
+Deno.test("AI budget lookup fails closed when the RPC is unavailable", async () => {
+  const client = {
+    rpc: () => Promise.resolve({ data: null, error: new Error("offline") }),
+  } as unknown as SupabaseClient;
+  const error = await assertRejects(() => consumeAiBudget(client, 10));
+  assertEquals(error instanceof AiUsageError, true);
+  assertEquals((error as AiUsageError).code, "budget_unavailable");
+  assertEquals((error as AiUsageError).status, 503);
 });
 
 Deno.test("AI input boundary rejects oversized and invalid values", () => {

--- a/supabase/functions/_shared/ai-usage.test.ts
+++ b/supabase/functions/_shared/ai-usage.test.ts
@@ -7,8 +7,10 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import {
   AI_MAX_INPUT_CHARS,
   AiUsageError,
+  aiUsageErrorResponse,
   assertAiInputSize,
   consumeAiBudget,
+  withAiBudget,
 } from "./ai-usage.ts";
 
 Deno.test("AI input boundary accepts the configured maximum", () => {
@@ -31,4 +33,54 @@ Deno.test("AI input boundary rejects oversized and invalid values", () => {
     assertEquals(error instanceof AiUsageError, true);
     assertEquals((error as AiUsageError).code, "input_too_large");
   }
+});
+
+Deno.test("AI budget releases a lease after a successful provider operation", async () => {
+  const calls: string[] = [];
+  const client = {
+    rpc: (name: string) => {
+      calls.push(name);
+      return Promise.resolve(
+        name === "consume_ai_usage"
+          ? { data: { allowed: true, leaseId: "lease-success" }, error: null }
+          : { data: true, error: null },
+      );
+    },
+  } as unknown as SupabaseClient;
+
+  await withAiBudget(client, 10, async () => "ok");
+  assertEquals(calls, ["consume_ai_usage", "release_ai_usage"]);
+});
+
+Deno.test("AI budget releases a lease after a failed provider operation", async () => {
+  const calls: string[] = [];
+  const client = {
+    rpc: (name: string) => {
+      calls.push(name);
+      return Promise.resolve(
+        name === "consume_ai_usage"
+          ? { data: { allowed: true, leaseId: "lease-failure" }, error: null }
+          : { data: true, error: null },
+      );
+    },
+  } as unknown as SupabaseClient;
+
+  await assertRejects(
+    () =>
+      withAiBudget(client, 10, async () => {
+        throw new Error("provider failed");
+      }),
+    Error,
+    "provider failed",
+  );
+  assertEquals(calls, ["consume_ai_usage", "release_ai_usage"]);
+});
+
+Deno.test("provider timeout errors return a stable 503 response", async () => {
+  const response = aiUsageErrorResponse(
+    new AiUsageError("provider_timeout", 503),
+    { "Access-Control-Allow-Origin": "*" },
+  );
+  assertEquals(response?.status, 503);
+  assertEquals(await response?.json(), { error: "provider_timeout" });
 });

--- a/supabase/functions/_shared/ai-usage.ts
+++ b/supabase/functions/_shared/ai-usage.ts
@@ -1,0 +1,69 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export const AI_MAX_INPUT_CHARS = 20_000;
+export const AI_PROVIDER_TIMEOUT_MS = 15_000;
+
+export class AiUsageError extends Error {
+  constructor(
+    readonly code: "input_too_large" | "quota_exceeded" | "budget_unavailable",
+    readonly status: 413 | 429 | 503,
+  ) {
+    super(code);
+    this.name = "AiUsageError";
+  }
+}
+
+export function assertAiInputSize(inputChars: number): void {
+  if (
+    !Number.isFinite(inputChars) || inputChars < 0 ||
+    inputChars > AI_MAX_INPUT_CHARS
+  ) {
+    throw new AiUsageError("input_too_large", 413);
+  }
+}
+
+export async function consumeAiBudget(
+  client: SupabaseClient,
+  inputChars: number,
+): Promise<void> {
+  assertAiInputSize(inputChars);
+  const { data, error } = await client.rpc("consume_ai_usage", {
+    p_input_chars: Math.ceil(inputChars),
+  });
+  if (error) {
+    throw new AiUsageError("budget_unavailable", 503);
+  }
+  if (!data?.allowed) {
+    throw new AiUsageError(
+      data?.reason === "input_too_large" ? "input_too_large" : "quota_exceeded",
+      data?.reason === "input_too_large" ? 413 : 429,
+    );
+  }
+}
+
+export function aiUsageErrorResponse(
+  error: unknown,
+  headers: Record<string, string>,
+): Response | null {
+  if (!(error instanceof AiUsageError)) return null;
+  return new Response(
+    JSON.stringify({ error: error.code }),
+    {
+      status: error.status,
+      headers: { "Content-Type": "application/json", ...headers },
+    },
+  );
+}
+
+export async function fetchAiProvider(
+  input: RequestInfo | URL,
+  init: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), AI_PROVIDER_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/supabase/functions/_shared/ai-usage.ts
+++ b/supabase/functions/_shared/ai-usage.ts
@@ -10,7 +10,8 @@ export class AiUsageError extends Error {
       | "input_too_large"
       | "quota_exceeded"
       | "concurrency_exceeded"
-      | "budget_unavailable",
+      | "budget_unavailable"
+      | "provider_timeout",
     readonly status: 413 | 429 | 503,
   ) {
     super(code);
@@ -96,7 +97,7 @@ export function aiUsageErrorResponse(
     JSON.stringify({ error: error.code }),
     {
       status: error.status,
-      headers: { "Content-Type": "application/json", ...headers },
+      headers: { ...headers, "Content-Type": "application/json" },
     },
   );
 }
@@ -108,7 +109,15 @@ export async function fetchAiProvider(
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), AI_PROVIDER_TIMEOUT_MS);
   try {
-    return await fetch(input, { ...init, signal: controller.signal });
+    const signal = init.signal
+      ? AbortSignal.any([controller.signal, init.signal])
+      : controller.signal;
+    return await fetch(input, { ...init, signal });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new AiUsageError("provider_timeout", 503);
+    }
+    throw error;
   } finally {
     clearTimeout(timeout);
   }

--- a/supabase/functions/_shared/ai-usage.ts
+++ b/supabase/functions/_shared/ai-usage.ts
@@ -1,11 +1,16 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 export const AI_MAX_INPUT_CHARS = 20_000;
+export const AI_MAX_OUTPUT_TOKENS = 1_000;
 export const AI_PROVIDER_TIMEOUT_MS = 15_000;
 
 export class AiUsageError extends Error {
   constructor(
-    readonly code: "input_too_large" | "quota_exceeded" | "budget_unavailable",
+    readonly code:
+      | "input_too_large"
+      | "quota_exceeded"
+      | "concurrency_exceeded"
+      | "budget_unavailable",
     readonly status: 413 | 429 | 503,
   ) {
     super(code);
@@ -25,7 +30,7 @@ export function assertAiInputSize(inputChars: number): void {
 export async function consumeAiBudget(
   client: SupabaseClient,
   inputChars: number,
-): Promise<void> {
+): Promise<string> {
   assertAiInputSize(inputChars);
   const { data, error } = await client.rpc("consume_ai_usage", {
     p_input_chars: Math.ceil(inputChars),
@@ -35,9 +40,50 @@ export async function consumeAiBudget(
   }
   if (!data?.allowed) {
     throw new AiUsageError(
-      data?.reason === "input_too_large" ? "input_too_large" : "quota_exceeded",
+      data?.reason === "input_too_large"
+        ? "input_too_large"
+        : data?.reason === "concurrency_exceeded"
+        ? "concurrency_exceeded"
+        : "quota_exceeded",
       data?.reason === "input_too_large" ? 413 : 429,
     );
+  }
+  if (typeof data.leaseId !== "string") {
+    throw new AiUsageError("budget_unavailable", 503);
+  }
+  return data.leaseId;
+}
+
+export async function releaseAiBudget(
+  client: SupabaseClient,
+  leaseId: string,
+): Promise<void> {
+  const { error } = await client.rpc("release_ai_usage", {
+    p_lease_id: leaseId,
+  });
+  if (error) {
+    throw new AiUsageError("budget_unavailable", 503);
+  }
+}
+
+export async function acquireAiBudget(
+  client: SupabaseClient,
+  inputChars: number,
+): Promise<() => Promise<void>> {
+  const leaseId = await consumeAiBudget(client, inputChars);
+  return () => releaseAiBudget(client, leaseId);
+}
+
+export async function withAiBudget<T>(
+  client: SupabaseClient,
+  inputChars: number,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const leaseId = await consumeAiBudget(client, inputChars);
+  try {
+    return await operation();
+  } finally {
+    await releaseAiBudget(client, leaseId);
   }
 }
 

--- a/supabase/functions/_shared/ai-usage.ts
+++ b/supabase/functions/_shared/ai-usage.ts
@@ -92,6 +92,8 @@ export function aiUsageErrorResponse(
   error: unknown,
   headers: Record<string, string>,
 ): Response | null {
+  const normalizedError = normalizeAiProviderTimeout(error);
+  if (normalizedError) error = normalizedError;
   if (!(error instanceof AiUsageError)) return null;
   return new Response(
     JSON.stringify({ error: error.code }),
@@ -102,17 +104,40 @@ export function aiUsageErrorResponse(
   );
 }
 
+export function normalizeAiProviderTimeout(
+  error: unknown,
+): AiUsageError | null {
+  if (error instanceof AiUsageError) {
+    return error.code === "provider_timeout" ? error : null;
+  }
+  if (!(error instanceof Error)) return null;
+  if (
+    error.name === "AbortError" || error.name === "TimeoutError" ||
+    /timed?\s*out|timeout/i.test(error.message)
+  ) {
+    return new AiUsageError("provider_timeout", 503);
+  }
+  return null;
+}
+
 export async function fetchAiProvider(
   input: RequestInfo | URL,
   init: RequestInit,
+  timeoutMs = AI_PROVIDER_TIMEOUT_MS,
 ): Promise<Response> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), AI_PROVIDER_TIMEOUT_MS);
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const signal = init.signal
       ? AbortSignal.any([controller.signal, init.signal])
       : controller.signal;
-    return await fetch(input, { ...init, signal });
+    const response = await fetch(input, { ...init, signal });
+    const body = await response.arrayBuffer();
+    return new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
       throw new AiUsageError("provider_timeout", 503);

--- a/supabase/functions/extract-keywords/index.ts
+++ b/supabase/functions/extract-keywords/index.ts
@@ -7,8 +7,8 @@ import {
 } from "../_shared/third-party-ai-consent.ts";
 import {
   aiUsageErrorResponse,
-  consumeAiBudget,
   fetchAiProvider,
+  withAiBudget,
 } from "../_shared/ai-usage.ts";
 
 const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
@@ -178,8 +178,11 @@ serve(async (req: Request) => {
       user.id,
       "open_ai",
       async () => {
-        await consumeAiBudget(supabaseClient, inputChars);
-        return extractKeywordsWithGPT(texts);
+        return withAiBudget(
+          supabaseClient,
+          inputChars,
+          () => extractKeywordsWithGPT(texts),
+        );
       },
     );
     if (!keywordOperation.allowed) {

--- a/supabase/functions/extract-keywords/index.ts
+++ b/supabase/functions/extract-keywords/index.ts
@@ -5,6 +5,11 @@ import {
   executeThirdPartyAiOperation,
   thirdPartyAiConsentRequiredResponse,
 } from "../_shared/third-party-ai-consent.ts";
+import {
+  aiUsageErrorResponse,
+  consumeAiBudget,
+  fetchAiProvider,
+} from "../_shared/ai-usage.ts";
 
 const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
 
@@ -16,18 +21,20 @@ interface KeywordRequest {
 async function extractKeywordsWithGPT(texts: string[]): Promise<string[]> {
   const combinedText = texts.join("\n---\n");
 
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${OPENAI_API_KEY}`,
-    },
-    body: JSON.stringify({
-      model: "gpt-4o-mini",
-      messages: [
-        {
-          role: "system",
-          content: `당신은 텍스트에서 핵심 키워드를 추출하는 전문가입니다.
+  const response = await fetchAiProvider(
+    "https://api.openai.com/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [
+          {
+            role: "system",
+            content: `당신은 텍스트에서 핵심 키워드를 추출하는 전문가입니다.
 주어진 독서 기록들에서 가장 의미있는 핵심 명사/키워드를 추출하세요.
 
 규칙:
@@ -36,17 +43,18 @@ async function extractKeywordsWithGPT(texts: string[]): Promise<string[]> {
 - 책의 핵심 개념이나 주제를 나타내는 단어 우선
 - 최대 8개까지만 추출
 - JSON 배열 형식으로만 응답 (예: ["습관", "목표", "성장"])`,
-        },
-        {
-          role: "user",
-          content:
-            `다음 독서 기록들에서 핵심 키워드를 추출해주세요:\n\n${combinedText}`,
-        },
-      ],
-      temperature: 0.3,
-      max_tokens: 200,
-    }),
-  });
+          },
+          {
+            role: "user",
+            content:
+              `다음 독서 기록들에서 핵심 키워드를 추출해주세요:\n\n${combinedText}`,
+          },
+        ],
+        temperature: 0.3,
+        max_tokens: 200,
+      }),
+    },
+  );
 
   if (!response.ok) {
     throw new Error(`OpenAI API error: ${response.status}`);
@@ -155,11 +163,24 @@ serve(async (req: Request) => {
     }
 
     const texts = contents.map((c: { content_text: string }) => c.content_text);
+    const inputChars = texts.reduce((total, text) => total + text.length, 0);
+    if (inputChars > 20_000) {
+      return new Response(JSON.stringify({ error: "input_too_large" }), {
+        status: 413,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      });
+    }
     const keywordOperation = await executeThirdPartyAiOperation(
       supabaseClient,
       user.id,
       "open_ai",
-      () => extractKeywordsWithGPT(texts),
+      async () => {
+        await consumeAiBudget(supabaseClient, inputChars);
+        return extractKeywordsWithGPT(texts);
+      },
     );
     if (!keywordOperation.allowed) {
       return thirdPartyAiConsentRequiredResponse({
@@ -177,6 +198,10 @@ serve(async (req: Request) => {
       },
     });
   } catch (error) {
+    const usageResponse = aiUsageErrorResponse(error, {
+      "Access-Control-Allow-Origin": "*",
+    });
+    if (usageResponse) return usageResponse;
     console.error("Error:", error);
     return new Response(
       JSON.stringify({ error: (error as Error).message }),

--- a/supabase/functions/generate-book-review/index.ts
+++ b/supabase/functions/generate-book-review/index.ts
@@ -7,8 +7,8 @@ import {
 } from "../_shared/third-party-ai-consent.ts";
 import {
   aiUsageErrorResponse,
-  consumeAiBudget,
   fetchAiProvider,
+  withAiBudget,
 } from "../_shared/ai-usage.ts";
 
 const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
@@ -201,12 +201,6 @@ serve(async (req: Request) => {
       .order("created_at", { ascending: true })
       .limit(15);
 
-    console.log(
-      `[generate-book-review] Generating review for book: ${book.title}, memos: ${
-        memos?.length ?? 0
-      }`,
-    );
-
     const inputChars = [
       book.title,
       book.author,
@@ -228,10 +222,14 @@ serve(async (req: Request) => {
       user.id,
       "open_ai",
       async () => {
-        await consumeAiBudget(supabaseClient, inputChars);
-        return generateReviewWithGPT(
-          book as BookData,
-          (memos as MemoContent[]) ?? [],
+        return withAiBudget(
+          supabaseClient,
+          inputChars,
+          () =>
+            generateReviewWithGPT(
+              book as BookData,
+              (memos as MemoContent[]) ?? [],
+            ),
         );
       },
     );

--- a/supabase/functions/generate-book-review/index.ts
+++ b/supabase/functions/generate-book-review/index.ts
@@ -5,6 +5,11 @@ import {
   executeThirdPartyAiOperation,
   thirdPartyAiConsentRequiredResponse,
 } from "../_shared/third-party-ai-consent.ts";
+import {
+  aiUsageErrorResponse,
+  consumeAiBudget,
+  fetchAiProvider,
+} from "../_shared/ai-usage.ts";
 
 const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
 
@@ -57,19 +62,21 @@ async function generateReviewWithGPT(
     .filter(Boolean)
     .join("\n");
 
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${OPENAI_API_KEY}`,
-    },
-    body: JSON.stringify({
-      model: "gpt-4o-mini",
-      messages: [
-        {
-          role: "system",
-          content:
-            `당신은 독서 기록을 바탕으로 진솔하고 개인적인 독후감 초안을 작성하는 도우미입니다.
+  const response = await fetchAiProvider(
+    "https://api.openai.com/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [
+          {
+            role: "system",
+            content:
+              `당신은 독서 기록을 바탕으로 진솔하고 개인적인 독후감 초안을 작성하는 도우미입니다.
 
 작성 가이드라인:
 - 사용자의 메모와 기록을 바탕으로 자연스러운 독후감 초안 작성
@@ -80,10 +87,10 @@ async function generateReviewWithGPT(
 - 분량: 300-500자 내외
 - 마무리는 열린 형태로 (사용자가 추가할 수 있도록)
 - 마크다운이나 특수 서식 없이 일반 텍스트로 작성`,
-        },
-        {
-          role: "user",
-          content: `다음 책에 대한 독후감 초안을 작성해주세요.
+          },
+          {
+            role: "user",
+            content: `다음 책에 대한 독후감 초안을 작성해주세요.
 
 === 책 정보 ===
 ${bookInfo}
@@ -92,12 +99,13 @@ ${bookInfo}
 ${memoTexts}
 
 위 정보를 바탕으로 자연스러운 독후감 초안을 작성해주세요.`,
-        },
-      ],
-      temperature: 0.7,
-      max_tokens: 1000,
-    }),
-  });
+          },
+        ],
+        temperature: 0.7,
+        max_tokens: 1000,
+      }),
+    },
+  );
 
   if (!response.ok) {
     const errorData = await response.json();
@@ -199,15 +207,33 @@ serve(async (req: Request) => {
       }`,
     );
 
+    const inputChars = [
+      book.title,
+      book.author,
+      book.genre,
+      book.review,
+      ...(memos ?? []).map((memo) => memo.content_text),
+    ]
+      .filter((value): value is string => typeof value === "string")
+      .reduce((total, value) => total + value.length, 0);
+    if (inputChars > 20_000) {
+      return new Response(JSON.stringify({ error: "input_too_large" }), {
+        status: 413,
+        headers: { "Content-Type": "application/json", ...corsHeaders },
+      });
+    }
+
     const reviewOperation = await executeThirdPartyAiOperation(
       supabaseClient,
       user.id,
       "open_ai",
-      () =>
-        generateReviewWithGPT(
+      async () => {
+        await consumeAiBudget(supabaseClient, inputChars);
+        return generateReviewWithGPT(
           book as BookData,
           (memos as MemoContent[]) ?? [],
-        ),
+        );
+      },
     );
     if (!reviewOperation.allowed) {
       return thirdPartyAiConsentRequiredResponse(corsHeaders);
@@ -226,6 +252,8 @@ serve(async (req: Request) => {
       },
     );
   } catch (error) {
+    const usageResponse = aiUsageErrorResponse(error, corsHeaders);
+    if (usageResponse) return usageResponse;
     console.error("[generate-book-review] Error:", error);
     return new Response(
       JSON.stringify({ error: (error as Error).message }),

--- a/supabase/functions/generate-embedding/index.ts
+++ b/supabase/functions/generate-embedding/index.ts
@@ -5,6 +5,11 @@ import {
   executeThirdPartyAiOperation,
   thirdPartyAiConsentRequiredResponse,
 } from "../_shared/third-party-ai-consent.ts";
+import {
+  aiUsageErrorResponse,
+  consumeAiBudget,
+  fetchAiProvider,
+} from "../_shared/ai-usage.ts";
 
 const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
 
@@ -18,17 +23,20 @@ interface EmbeddingRequest {
 }
 
 async function generateEmbedding(text: string): Promise<number[]> {
-  const response = await fetch("https://api.openai.com/v1/embeddings", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${OPENAI_API_KEY}`,
+  const response = await fetchAiProvider(
+    "https://api.openai.com/v1/embeddings",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: "text-embedding-3-small",
+        input: text,
+      }),
     },
-    body: JSON.stringify({
-      model: "text-embedding-3-small",
-      input: text,
-    }),
-  });
+  );
 
   if (!response.ok) {
     const error = await response.text();
@@ -115,6 +123,16 @@ serve(async (req: Request) => {
       );
     }
 
+    if (contentText.length > 20_000) {
+      return new Response(JSON.stringify({ error: "input_too_large" }), {
+        status: 413,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      });
+    }
+
     const serviceClient = createClient(
       Deno.env.get("SUPABASE_URL") ?? "",
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
@@ -130,7 +148,10 @@ serve(async (req: Request) => {
       authClient,
       user.id,
       "open_ai",
-      () => generateEmbedding(contentText),
+      async () => {
+        await consumeAiBudget(authClient, contentText.length);
+        return generateEmbedding(contentText);
+      },
     );
     if (!embeddingOperation.allowed) {
       return thirdPartyAiConsentRequiredResponse({
@@ -175,6 +196,10 @@ serve(async (req: Request) => {
       },
     );
   } catch (error) {
+    const usageResponse = aiUsageErrorResponse(error, {
+      "Access-Control-Allow-Origin": "*",
+    });
+    if (usageResponse) return usageResponse;
     console.error("Error:", error);
     return new Response(JSON.stringify({ error: (error as Error).message }), {
       status: 500,

--- a/supabase/functions/generate-embedding/index.ts
+++ b/supabase/functions/generate-embedding/index.ts
@@ -7,8 +7,8 @@ import {
 } from "../_shared/third-party-ai-consent.ts";
 import {
   aiUsageErrorResponse,
-  consumeAiBudget,
   fetchAiProvider,
+  withAiBudget,
 } from "../_shared/ai-usage.ts";
 
 const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
@@ -149,8 +149,11 @@ serve(async (req: Request) => {
       user.id,
       "open_ai",
       async () => {
-        await consumeAiBudget(authClient, contentText.length);
-        return generateEmbedding(contentText);
+        return withAiBudget(
+          authClient,
+          contentText.length,
+          () => generateEmbedding(contentText),
+        );
       },
     );
     if (!embeddingOperation.allowed) {

--- a/supabase/functions/reading-insights/index.ts
+++ b/supabase/functions/reading-insights/index.ts
@@ -8,6 +8,7 @@ import {
   executeThirdPartyAiOperation,
   thirdPartyAiConsentRequiredResponse,
 } from "../_shared/third-party-ai-consent.ts";
+import { aiUsageErrorResponse, consumeAiBudget } from "../_shared/ai-usage.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -71,7 +72,10 @@ serve(async (req: Request) => {
     console.log(`[reading-insights] Processing insights for user: ${userId}`);
 
     const patternCollector = new PatternCollector(supabase);
-    const insightService = new InsightService(supabase);
+    const insightService = new InsightService(
+      supabase,
+      (prompt) => consumeAiBudget(authClient, prompt.length),
+    );
 
     const patterns = await patternCollector.collect(userId);
     console.log(`[reading-insights] Patterns collected: ${
@@ -104,6 +108,8 @@ serve(async (req: Request) => {
       headers: { "Content-Type": "application/json", ...corsHeaders },
     });
   } catch (error: unknown) {
+    const usageResponse = aiUsageErrorResponse(error, corsHeaders);
+    if (usageResponse) return usageResponse;
     const errorMessage = error instanceof Error
       ? error.message
       : "Unknown error";

--- a/supabase/functions/reading-insights/index.ts
+++ b/supabase/functions/reading-insights/index.ts
@@ -8,7 +8,7 @@ import {
   executeThirdPartyAiOperation,
   thirdPartyAiConsentRequiredResponse,
 } from "../_shared/third-party-ai-consent.ts";
-import { aiUsageErrorResponse, consumeAiBudget } from "../_shared/ai-usage.ts";
+import { acquireAiBudget, aiUsageErrorResponse } from "../_shared/ai-usage.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -69,23 +69,13 @@ serve(async (req: Request) => {
       config.supabase.serviceRoleKey,
     );
 
-    console.log(`[reading-insights] Processing insights for user: ${userId}`);
-
     const patternCollector = new PatternCollector(supabase);
     const insightService = new InsightService(
       supabase,
-      (prompt) => consumeAiBudget(authClient, prompt.length),
+      (prompt) => acquireAiBudget(authClient, prompt.length),
     );
 
     const patterns = await patternCollector.collect(userId);
-    console.log(`[reading-insights] Patterns collected: ${
-      JSON.stringify({
-        books: patterns.completionRates.totalStarted,
-        completed: patterns.completionRates.completed,
-        highlights: patterns.highlightStats.totalCount,
-      })
-    }`);
-
     const insightOperation = await executeThirdPartyAiOperation(
       authClient,
       user.id,
@@ -96,8 +86,6 @@ serve(async (req: Request) => {
       return thirdPartyAiConsentRequiredResponse(corsHeaders);
     }
     const insights = insightOperation.value;
-    console.log(`[reading-insights] Generated ${insights.length} insights`);
-
     const response: ReadingInsightResponse = {
       success: true,
       insights,

--- a/supabase/functions/reading-insights/index.ts
+++ b/supabase/functions/reading-insights/index.ts
@@ -8,7 +8,11 @@ import {
   executeThirdPartyAiOperation,
   thirdPartyAiConsentRequiredResponse,
 } from "../_shared/third-party-ai-consent.ts";
-import { acquireAiBudget, aiUsageErrorResponse } from "../_shared/ai-usage.ts";
+import {
+  acquireAiBudget,
+  aiUsageErrorResponse,
+  assertAiInputSize,
+} from "../_shared/ai-usage.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -72,7 +76,10 @@ serve(async (req: Request) => {
     const patternCollector = new PatternCollector(supabase);
     const insightService = new InsightService(
       supabase,
-      (prompt) => acquireAiBudget(authClient, prompt.length),
+      (prompt) => {
+        assertAiInputSize(prompt.length);
+        return acquireAiBudget(authClient, prompt.length);
+      },
     );
 
     const patterns = await patternCollector.collect(userId);

--- a/supabase/functions/reading-insights/services/insight-service.ts
+++ b/supabase/functions/reading-insights/services/insight-service.ts
@@ -41,7 +41,7 @@ export class InsightService {
     supabase: SupabaseClient,
     beforeProviderCall: (
       input: string,
-    ) => Promise<() => Promise<void>> = async () => async () => {},
+    ) => Promise<() => Promise<void>>,
   ) {
     this.supabase = supabase;
     this.beforeProviderCall = beforeProviderCall;
@@ -51,6 +51,7 @@ export class InsightService {
       modelName: config.openai.model,
       temperature: config.openai.temperature,
       maxTokens: AI_MAX_OUTPUT_TOKENS,
+      maxRetries: 0,
       timeout: Math.min(
         config.insights.timeoutSeconds * 1000,
         AI_PROVIDER_TIMEOUT_MS,

--- a/supabase/functions/reading-insights/services/insight-service.ts
+++ b/supabase/functions/reading-insights/services/insight-service.ts
@@ -1,8 +1,9 @@
 import { ChatOpenAI } from "@langchain/openai";
 import { PromptTemplate } from "@langchain/core/prompts";
 import { SupabaseClient } from "@supabase/supabase-js";
-import type { ReadingPatterns, ReadingInsight } from "../types.ts";
+import type { ReadingInsight, ReadingPatterns } from "../types.ts";
 import { config } from "../config.ts";
+import { AI_PROVIDER_TIMEOUT_MS } from "../../_shared/ai-usage.ts";
 
 interface MemoryRecord {
   id: string;
@@ -29,15 +30,23 @@ export class InsightService {
   private llm: ChatOpenAI;
   private supabase: SupabaseClient;
   private promptTemplate: PromptTemplate;
+  private readonly beforeProviderCall: (input: string) => Promise<void>;
 
-  constructor(supabase: SupabaseClient) {
+  constructor(
+    supabase: SupabaseClient,
+    beforeProviderCall: (input: string) => Promise<void> = async () => {},
+  ) {
     this.supabase = supabase;
+    this.beforeProviderCall = beforeProviderCall;
 
     this.llm = new ChatOpenAI({
       openAIApiKey: config.openai.apiKey,
       modelName: config.openai.model,
       temperature: config.openai.temperature,
-      timeout: config.insights.timeoutSeconds * 1000,
+      timeout: Math.min(
+        config.insights.timeoutSeconds * 1000,
+        AI_PROVIDER_TIMEOUT_MS,
+      ),
     });
 
     this.promptTemplate = PromptTemplate.fromTemplate(`
@@ -82,13 +91,13 @@ export class InsightService {
 
   async generate(
     userId: string,
-    patterns: ReadingPatterns
+    patterns: ReadingPatterns,
   ): Promise<ReadingInsight[]> {
     const canGenerate = await this.checkRateLimit(userId);
     if (!canGenerate) {
       const hoursRemaining = await this.getHoursUntilNextGeneration(userId);
       throw new Error(
-        `Rate limit exceeded. Try again in ${hoursRemaining} hours.`
+        `Rate limit exceeded. Try again in ${hoursRemaining} hours.`,
       );
     }
 
@@ -103,6 +112,7 @@ export class InsightService {
       yearOverYear: this.formatYearOverYear(patterns),
       memory: memory || "(이전 인사이트 없음)",
     });
+    await this.beforeProviderCall(formattedPrompt);
 
     let response;
     try {
@@ -147,8 +157,8 @@ export class InsightService {
 
     const lastGenerated = new Date(data.last_generated_at);
     const now = new Date();
-    const hoursSinceLastGeneration =
-      (now.getTime() - lastGenerated.getTime()) / (1000 * 60 * 60);
+    const hoursSinceLastGeneration = (now.getTime() - lastGenerated.getTime()) /
+      (1000 * 60 * 60);
 
     return hoursSinceLastGeneration >= config.insights.rateLimitHours;
   }
@@ -166,10 +176,10 @@ export class InsightService {
 
     const lastGenerated = new Date(data.last_generated_at);
     const now = new Date();
-    const hoursSinceLastGeneration =
-      (now.getTime() - lastGenerated.getTime()) / (1000 * 60 * 60);
-    const hoursRemaining =
-      config.insights.rateLimitHours - hoursSinceLastGeneration;
+    const hoursSinceLastGeneration = (now.getTime() - lastGenerated.getTime()) /
+      (1000 * 60 * 60);
+    const hoursRemaining = config.insights.rateLimitHours -
+      hoursSinceLastGeneration;
 
     return Math.max(0, Math.ceil(hoursRemaining));
   }
@@ -182,7 +192,7 @@ export class InsightService {
           user_id: userId,
           last_generated_at: new Date().toISOString(),
         },
-        { onConflict: "user_id" }
+        { onConflict: "user_id" },
       );
 
     if (error) {
@@ -209,15 +219,15 @@ export class InsightService {
     const memoryEntries = data.map(
       (
         record: { insight_content: string; created_at: string },
-        index: number
+        index: number,
       ) => {
         const insights: LLMInsightResponse[] = JSON.parse(
-          record.insight_content
+          record.insight_content,
         );
         const date = new Date(record.created_at).toLocaleDateString("ko-KR");
         const insightTitles = insights.map((i) => i.title).join(", ");
         return `${index + 1}. [${date}] ${insightTitles}`;
-      }
+      },
     );
 
     return `이전 인사이트:\n${memoryEntries.join("\n")}`;
@@ -226,7 +236,7 @@ export class InsightService {
   private async saveMemory(
     userId: string,
     insights: ReadingInsight[],
-    metadata: Record<string, unknown>
+    metadata: Record<string, unknown>,
   ): Promise<void> {
     const insightContent = JSON.stringify(
       insights.map((i) => ({
@@ -234,7 +244,7 @@ export class InsightService {
         description: i.description,
         category: i.category,
         relatedBooks: i.relatedBooks,
-      }))
+      })),
     );
 
     const { error } = await this.supabase
@@ -292,14 +302,12 @@ export class InsightService {
     const habits = patterns.readingHabits;
     const dayNames = ["일", "월", "화", "수", "목", "금", "토"];
 
-    const peakHour =
-      habits.peakReadingHour !== null
-        ? `${habits.peakReadingHour}시`
-        : "데이터 없음";
-    const peakDay =
-      habits.peakReadingDay !== null
-        ? `${dayNames[habits.peakReadingDay]}요일`
-        : "데이터 없음";
+    const peakHour = habits.peakReadingHour !== null
+      ? `${habits.peakReadingHour}시`
+      : "데이터 없음";
+    const peakDay = habits.peakReadingDay !== null
+      ? `${dayNames[habits.peakReadingDay]}요일`
+      : "데이터 없음";
 
     return `주로 ${peakHour}에 독서, ${peakDay}에 가장 많이 읽음`;
   }
@@ -311,16 +319,17 @@ export class InsightService {
 
   private formatHighlightStats(patterns: ReadingPatterns): string {
     const stats = patterns.highlightStats;
-    const keywords =
-      stats.topKeywords.length > 0
-        ? stats.topKeywords.slice(0, 5).join(", ")
-        : "없음";
+    const keywords = stats.topKeywords.length > 0
+      ? stats.topKeywords.slice(0, 5).join(", ")
+      : "없음";
     return `총 ${stats.totalCount}개, 주요 키워드: ${keywords}`;
   }
 
   private formatYearOverYear(patterns: ReadingPatterns): string {
     const yoy = patterns.yearOverYear;
     const changeDirection = yoy.changePercentage >= 0 ? "증가" : "감소";
-    return `${yoy.previousYear}년 ${yoy.previousYearCompleted}권 → ${yoy.currentYear}년 ${yoy.currentYearCompleted}권 (${Math.abs(yoy.changePercentage)}% ${changeDirection})`;
+    return `${yoy.previousYear}년 ${yoy.previousYearCompleted}권 → ${yoy.currentYear}년 ${yoy.currentYearCompleted}권 (${
+      Math.abs(yoy.changePercentage)
+    }% ${changeDirection})`;
   }
 }

--- a/supabase/functions/reading-insights/services/insight-service.ts
+++ b/supabase/functions/reading-insights/services/insight-service.ts
@@ -3,7 +3,10 @@ import { PromptTemplate } from "@langchain/core/prompts";
 import { SupabaseClient } from "@supabase/supabase-js";
 import type { ReadingInsight, ReadingPatterns } from "../types.ts";
 import { config } from "../config.ts";
-import { AI_PROVIDER_TIMEOUT_MS } from "../../_shared/ai-usage.ts";
+import {
+  AI_MAX_OUTPUT_TOKENS,
+  AI_PROVIDER_TIMEOUT_MS,
+} from "../../_shared/ai-usage.ts";
 
 interface MemoryRecord {
   id: string;
@@ -30,11 +33,15 @@ export class InsightService {
   private llm: ChatOpenAI;
   private supabase: SupabaseClient;
   private promptTemplate: PromptTemplate;
-  private readonly beforeProviderCall: (input: string) => Promise<void>;
+  private readonly beforeProviderCall: (
+    input: string,
+  ) => Promise<() => Promise<void>>;
 
   constructor(
     supabase: SupabaseClient,
-    beforeProviderCall: (input: string) => Promise<void> = async () => {},
+    beforeProviderCall: (
+      input: string,
+    ) => Promise<() => Promise<void>> = async () => async () => {},
   ) {
     this.supabase = supabase;
     this.beforeProviderCall = beforeProviderCall;
@@ -43,6 +50,7 @@ export class InsightService {
       openAIApiKey: config.openai.apiKey,
       modelName: config.openai.model,
       temperature: config.openai.temperature,
+      maxTokens: AI_MAX_OUTPUT_TOKENS,
       timeout: Math.min(
         config.insights.timeoutSeconds * 1000,
         AI_PROVIDER_TIMEOUT_MS,
@@ -112,7 +120,7 @@ export class InsightService {
       yearOverYear: this.formatYearOverYear(patterns),
       memory: memory || "(이전 인사이트 없음)",
     });
-    await this.beforeProviderCall(formattedPrompt);
+    const releaseProviderLease = await this.beforeProviderCall(formattedPrompt);
 
     let response;
     try {
@@ -125,6 +133,8 @@ export class InsightService {
         throw new Error("Insight generation timed out");
       }
       throw error;
+    } finally {
+      await releaseProviderLease();
     }
 
     const insights = this.parseResponse(response.content as string);

--- a/supabase/functions/recall-search/index.ts
+++ b/supabase/functions/recall-search/index.ts
@@ -5,6 +5,11 @@ import {
   executeThirdPartyAiOperation,
   thirdPartyAiConsentRequiredResponse,
 } from "../_shared/third-party-ai-consent.ts";
+import {
+  aiUsageErrorResponse,
+  consumeAiBudget,
+  fetchAiProvider,
+} from "../_shared/ai-usage.ts";
 
 const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
 
@@ -24,17 +29,20 @@ interface SourceDocument {
 }
 
 async function generateEmbedding(text: string): Promise<number[]> {
-  const response = await fetch("https://api.openai.com/v1/embeddings", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${OPENAI_API_KEY}`,
+  const response = await fetchAiProvider(
+    "https://api.openai.com/v1/embeddings",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: "text-embedding-3-small",
+        input: text,
+      }),
     },
-    body: JSON.stringify({
-      model: "text-embedding-3-small",
-      input: text,
-    }),
-  });
+  );
 
   if (!response.ok) {
     const error = await response.text();
@@ -90,22 +98,25 @@ ${TONE_CONFIG.styleGuide}
 관련 기록:
 ${context}`;
 
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${OPENAI_API_KEY}`,
+  const response = await fetchAiProvider(
+    "https://api.openai.com/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+        temperature: 0.3,
+        max_tokens: 1000,
+      }),
     },
-    body: JSON.stringify({
-      model: "gpt-4o-mini",
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userPrompt },
-      ],
-      temperature: 0.3,
-      max_tokens: 1000,
-    }),
-  });
+  );
 
   if (!response.ok) {
     const error = await response.text();
@@ -165,13 +176,26 @@ serve(async (req: Request) => {
       );
     }
 
+    if (query.length > 2_000) {
+      return new Response(JSON.stringify({ error: "input_too_large" }), {
+        status: 413,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      });
+    }
+
     const isGlobalSearch = !bookId;
 
     const embeddingOperation = await executeThirdPartyAiOperation(
       supabaseClient,
       user.id,
       "open_ai",
-      () => generateEmbedding(query),
+      async () => {
+        await consumeAiBudget(supabaseClient, query.length);
+        return generateEmbedding(query);
+      },
     );
     if (!embeddingOperation.allowed) {
       return thirdPartyAiConsentRequiredResponse({
@@ -261,11 +285,25 @@ serve(async (req: Request) => {
       })
       .join("\n\n");
 
+    const answerInputChars = query.length + context.length;
+    if (answerInputChars > 20_000) {
+      return new Response(JSON.stringify({ error: "input_too_large" }), {
+        status: 413,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      });
+    }
+
     const answerOperation = await executeThirdPartyAiOperation(
       supabaseClient,
       user.id,
       "open_ai",
-      () => generateAnswer(query, context),
+      async () => {
+        await consumeAiBudget(supabaseClient, answerInputChars);
+        return generateAnswer(query, context);
+      },
     );
     if (!answerOperation.allowed) {
       return thirdPartyAiConsentRequiredResponse({
@@ -319,6 +357,10 @@ serve(async (req: Request) => {
       },
     });
   } catch (error) {
+    const usageResponse = aiUsageErrorResponse(error, {
+      "Access-Control-Allow-Origin": "*",
+    });
+    if (usageResponse) return usageResponse;
     console.error("Error:", error);
     return new Response(JSON.stringify({ error: (error as Error).message }), {
       status: 500,

--- a/supabase/functions/recall-search/index.ts
+++ b/supabase/functions/recall-search/index.ts
@@ -7,8 +7,8 @@ import {
 } from "../_shared/third-party-ai-consent.ts";
 import {
   aiUsageErrorResponse,
-  consumeAiBudget,
   fetchAiProvider,
+  withAiBudget,
 } from "../_shared/ai-usage.ts";
 
 const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
@@ -193,8 +193,11 @@ serve(async (req: Request) => {
       user.id,
       "open_ai",
       async () => {
-        await consumeAiBudget(supabaseClient, query.length);
-        return generateEmbedding(query);
+        return withAiBudget(
+          supabaseClient,
+          query.length,
+          () => generateEmbedding(query),
+        );
       },
     );
     if (!embeddingOperation.allowed) {
@@ -301,8 +304,11 @@ serve(async (req: Request) => {
       user.id,
       "open_ai",
       async () => {
-        await consumeAiBudget(supabaseClient, answerInputChars);
-        return generateAnswer(query, context);
+        return withAiBudget(
+          supabaseClient,
+          answerInputChars,
+          () => generateAnswer(query, context),
+        );
       },
     );
     if (!answerOperation.allowed) {

--- a/supabase/functions/recommend-next-books/index.ts
+++ b/supabase/functions/recommend-next-books/index.ts
@@ -8,6 +8,7 @@ import {
   executeThirdPartyAiOperation,
   thirdPartyAiConsentRequiredResponse,
 } from "../_shared/third-party-ai-consent.ts";
+import { aiUsageErrorResponse, consumeAiBudget } from "../_shared/ai-usage.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -72,7 +73,10 @@ serve(async (req: Request) => {
       `[recommend-next-books] Collecting profile for user: ${userId}`,
     );
     const profileCollector = new ProfileCollector(supabase);
-    const profile = await profileCollector.collect(userId);
+    const profile = await profileCollector.collect(
+      userId,
+      (prompt) => consumeAiBudget(authClient, prompt.length),
+    );
 
     if (profile.books.length === 0) {
       return new Response(
@@ -92,7 +96,10 @@ serve(async (req: Request) => {
     console.log(
       `[recommend-next-books] Generating recommendations (locale: ${locale})...`,
     );
-    const recommendationService = new RecommendationService(locale);
+    const recommendationService = new RecommendationService(
+      locale,
+      (prompt) => consumeAiBudget(authClient, prompt.length),
+    );
     const recommendationOperation = await executeThirdPartyAiOperation(
       authClient,
       user.id,
@@ -132,6 +139,8 @@ serve(async (req: Request) => {
       headers: { "Content-Type": "application/json", ...corsHeaders },
     });
   } catch (error: unknown) {
+    const usageResponse = aiUsageErrorResponse(error, corsHeaders);
+    if (usageResponse) return usageResponse;
     const errorMessage = error instanceof Error
       ? error.message
       : "Unknown error";

--- a/supabase/functions/recommend-next-books/index.ts
+++ b/supabase/functions/recommend-next-books/index.ts
@@ -2,13 +2,14 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "@supabase/supabase-js";
 import { config, validateConfig } from "./config.ts";
 import { ProfileCollector } from "./services/profile-collector.ts";
+import { collectProfileWithConsent } from "./services/profile-consent.ts";
 import { RecommendationService } from "./services/recommendation-service.ts";
 import type { RecommendationResponse } from "./types.ts";
 import {
   executeThirdPartyAiOperation,
   thirdPartyAiConsentRequiredResponse,
 } from "../_shared/third-party-ai-consent.ts";
-import { aiUsageErrorResponse, consumeAiBudget } from "../_shared/ai-usage.ts";
+import { acquireAiBudget, aiUsageErrorResponse } from "../_shared/ai-usage.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -69,14 +70,17 @@ serve(async (req: Request) => {
       config.supabase.serviceRoleKey,
     );
 
-    console.log(
-      `[recommend-next-books] Collecting profile for user: ${userId}`,
-    );
     const profileCollector = new ProfileCollector(supabase);
-    const profile = await profileCollector.collect(
-      userId,
-      (prompt) => consumeAiBudget(authClient, prompt.length),
+    const profileOperation = await collectProfileWithConsent(
+      authClient,
+      user.id,
+      profileCollector,
+      (prompt) => acquireAiBudget(authClient, prompt.length),
     );
+    if (!profileOperation.allowed) {
+      return thirdPartyAiConsentRequiredResponse(corsHeaders);
+    }
+    const profile = profileOperation.value;
 
     if (profile.books.length === 0) {
       return new Response(
@@ -93,12 +97,9 @@ serve(async (req: Request) => {
       );
     }
 
-    console.log(
-      `[recommend-next-books] Generating recommendations (locale: ${locale})...`,
-    );
     const recommendationService = new RecommendationService(
       locale,
-      (prompt) => consumeAiBudget(authClient, prompt.length),
+      (prompt) => acquireAiBudget(authClient, prompt.length),
     );
     const recommendationOperation = await executeThirdPartyAiOperation(
       authClient,

--- a/supabase/functions/recommend-next-books/index.ts
+++ b/supabase/functions/recommend-next-books/index.ts
@@ -98,8 +98,8 @@ serve(async (req: Request) => {
     }
 
     const recommendationService = new RecommendationService(
-      locale,
       (prompt) => acquireAiBudget(authClient, prompt.length),
+      locale,
     );
     const recommendationOperation = await executeThirdPartyAiOperation(
       authClient,

--- a/supabase/functions/recommend-next-books/services/profile-collector.test.ts
+++ b/supabase/functions/recommend-next-books/services/profile-collector.test.ts
@@ -1,0 +1,97 @@
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import type { UserReadingProfile } from "../types.ts";
+import {
+  THIRD_PARTY_AI_POLICY_VERSION,
+} from "../../_shared/third-party-ai-consent.ts";
+import { collectProfileWithConsent } from "./profile-consent.ts";
+
+function consentClient(receipt: Record<string, unknown> | null): unknown {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: receipt, error: null }),
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+const profile: UserReadingProfile = {
+  userId: "user-a",
+  books: [],
+  stats: {
+    totalBooksCompleted: 0,
+    averageRating: 0,
+    favoriteGenres: [],
+    averageCompletionDays: 0,
+    highEngagementBookCount: 0,
+  },
+  interests: { topHighlights: [], keywords: [] },
+};
+
+Deno.test(
+  "recommendation profile collection does not call providers without consent",
+  async () => {
+    let collectionCalls = 0;
+    let providerCalls = 0;
+    const profileCollector = {
+      collect: async () => {
+        collectionCalls += 1;
+        await (async () => {
+          providerCalls += 1;
+        })();
+        return profile;
+      },
+    };
+
+    const result = await collectProfileWithConsent(
+      consentClient(null),
+      "user-a",
+      profileCollector,
+      async () => async () => {},
+    );
+
+    assertEquals(result, { allowed: false });
+    assertEquals(collectionCalls, 0);
+    assertEquals(providerCalls, 0);
+  },
+);
+
+Deno.test(
+  "recommendation profile collection runs only after current consent",
+  async () => {
+    let collectionCalls = 0;
+    let providerCalls = 0;
+    const profileCollector = {
+      collect: async (
+        _userId: string,
+        beforeProviderCall: (
+          input: string,
+        ) => Promise<() => Promise<void>>,
+      ) => {
+        collectionCalls += 1;
+        const release = await beforeProviderCall("interest query");
+        providerCalls += 1;
+        await release();
+        return profile;
+      },
+    };
+
+    const result = await collectProfileWithConsent(
+      consentClient({
+        granted: true,
+        policy_version: THIRD_PARTY_AI_POLICY_VERSION,
+      }),
+      "user-a",
+      profileCollector,
+      async () => async () => {},
+    );
+
+    assertEquals(result, { allowed: true, value: profile });
+    assertEquals(collectionCalls, 1);
+    assertEquals(providerCalls, 1);
+  },
+);

--- a/supabase/functions/recommend-next-books/services/profile-collector.ts
+++ b/supabase/functions/recommend-next-books/services/profile-collector.ts
@@ -17,11 +17,21 @@ export class ProfileCollector {
 
   async collect(
     userId: string,
-    beforeProviderCall: (input: string) => Promise<void> = async () => {},
+    beforeProviderCall: (
+      input: string,
+    ) => Promise<() => Promise<void>> = async () => async () => {},
   ): Promise<UserReadingProfile> {
     const completedBooks = await this.fetchCompletedBooks(userId);
     const booksAnalytics = await this.analyzeBooksInDetail(completedBooks);
     const stats = calculateAggregateStats(booksAnalytics);
+    if (booksAnalytics.length === 0) {
+      return {
+        userId,
+        books: booksAnalytics,
+        stats,
+        interests: { topHighlights: [], keywords: [] },
+      };
+    }
     const interests = await extractUserInterests(
       this.supabase,
       userId,

--- a/supabase/functions/recommend-next-books/services/profile-collector.ts
+++ b/supabase/functions/recommend-next-books/services/profile-collector.ts
@@ -1,25 +1,32 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import type {
   BookReadingAnalytics,
-  UserReadingProfile,
   BookRecord,
-  ProgressRecord,
   EmbeddingRecord,
+  ProgressRecord,
+  UserReadingProfile,
 } from "../types.ts";
 import {
-  calculateDailyGoalAchievementRate,
   calculateAggregateStats,
+  calculateDailyGoalAchievementRate,
 } from "../utils/analytics-calculator.ts";
 import { extractUserInterests } from "./rag-service.ts";
 
 export class ProfileCollector {
   constructor(private supabase: SupabaseClient) {}
 
-  async collect(userId: string): Promise<UserReadingProfile> {
+  async collect(
+    userId: string,
+    beforeProviderCall: (input: string) => Promise<void> = async () => {},
+  ): Promise<UserReadingProfile> {
     const completedBooks = await this.fetchCompletedBooks(userId);
     const booksAnalytics = await this.analyzeBooksInDetail(completedBooks);
     const stats = calculateAggregateStats(booksAnalytics);
-    const interests = await extractUserInterests(this.supabase, userId);
+    const interests = await extractUserInterests(
+      this.supabase,
+      userId,
+      beforeProviderCall,
+    );
 
     return {
       userId,
@@ -43,7 +50,7 @@ export class ProfileCollector {
   }
 
   private async analyzeBooksInDetail(
-    books: BookRecord[]
+    books: BookRecord[],
   ): Promise<BookReadingAnalytics[]> {
     const analytics: BookReadingAnalytics[] = [];
 
@@ -52,13 +59,13 @@ export class ProfileCollector {
       const embeddings = await this.fetchEmbeddings(book.id);
 
       const highlightCount = embeddings.filter(
-        (e) => e.content_type === "highlight"
+        (e) => e.content_type === "highlight",
       ).length;
       const noteCount = embeddings.filter(
-        (e) => e.content_type === "note"
+        (e) => e.content_type === "note",
       ).length;
       const photoOcrCount = embeddings.filter(
-        (e) => e.content_type === "photo_ocr"
+        (e) => e.content_type === "photo_ocr",
       ).length;
 
       const startDate = new Date(book.start_date);
@@ -69,15 +76,16 @@ export class ProfileCollector {
         1,
         Math.ceil(
           (completedDate.getTime() - startDate.getTime()) /
-            (1000 * 60 * 60 * 24)
-        )
+            (1000 * 60 * 60 * 24),
+        ),
       );
-      const averagePagesPerDay =
-        daysToComplete > 0 ? book.total_pages / daysToComplete : 0;
+      const averagePagesPerDay = daysToComplete > 0
+        ? book.total_pages / daysToComplete
+        : 0;
 
       const dailyGoalAchievementRate = calculateDailyGoalAchievementRate(
         book.daily_target_pages,
-        progressRecords
+        progressRecords,
       );
 
       analytics.push({
@@ -103,7 +111,7 @@ export class ProfileCollector {
   }
 
   private async fetchProgressRecords(
-    bookId: string
+    bookId: string,
   ): Promise<ProgressRecord[]> {
     const { data } = await this.supabase
       .from("reading_progress_history")
@@ -117,7 +125,9 @@ export class ProfileCollector {
   private async fetchEmbeddings(bookId: string): Promise<EmbeddingRecord[]> {
     const { data } = await this.supabase
       .from("reading_content_embeddings")
-      .select("id, user_id, book_id, content_type, content_text, page_number, source_id")
+      .select(
+        "id, user_id, book_id, content_type, content_text, page_number, source_id",
+      )
       .eq("book_id", bookId);
 
     return (data as EmbeddingRecord[]) || [];

--- a/supabase/functions/recommend-next-books/services/profile-collector.ts
+++ b/supabase/functions/recommend-next-books/services/profile-collector.ts
@@ -19,7 +19,7 @@ export class ProfileCollector {
     userId: string,
     beforeProviderCall: (
       input: string,
-    ) => Promise<() => Promise<void>> = async () => async () => {},
+    ) => Promise<() => Promise<void>>,
   ): Promise<UserReadingProfile> {
     const completedBooks = await this.fetchCompletedBooks(userId);
     const booksAnalytics = await this.analyzeBooksInDetail(completedBooks);

--- a/supabase/functions/recommend-next-books/services/profile-consent.ts
+++ b/supabase/functions/recommend-next-books/services/profile-consent.ts
@@ -1,0 +1,30 @@
+import {
+  executeThirdPartyAiOperation,
+  type ThirdPartyAiOperationResult,
+} from "../../_shared/third-party-ai-consent.ts";
+import type { UserReadingProfile } from "../types.ts";
+
+type ProfileCollectorLike = {
+  collect(
+    userId: string,
+    beforeProviderCall: (
+      input: string,
+    ) => Promise<() => Promise<void>>,
+  ): Promise<UserReadingProfile>;
+};
+
+export function collectProfileWithConsent(
+  authClient: unknown,
+  userId: string,
+  profileCollector: ProfileCollectorLike,
+  beforeProviderCall: (
+    input: string,
+  ) => Promise<() => Promise<void>>,
+): Promise<ThirdPartyAiOperationResult<UserReadingProfile>> {
+  return executeThirdPartyAiOperation(
+    authClient,
+    userId,
+    "open_ai",
+    () => profileCollector.collect(userId, beforeProviderCall),
+  );
+}

--- a/supabase/functions/recommend-next-books/services/rag-service.ts
+++ b/supabase/functions/recommend-next-books/services/rag-service.ts
@@ -21,10 +21,11 @@ export async function extractUserInterests(
   userId: string,
   beforeProviderCall: (
     input: string,
-  ) => Promise<() => Promise<void>> = async () => async () => {},
+  ) => Promise<() => Promise<void>>,
 ): Promise<UserInterests> {
   const embeddings = new OpenAIEmbeddings({
     openAIApiKey: config.openai.apiKey,
+    maxRetries: 0,
     timeout: AI_PROVIDER_TIMEOUT_MS,
   });
 

--- a/supabase/functions/recommend-next-books/services/rag-service.ts
+++ b/supabase/functions/recommend-next-books/services/rag-service.ts
@@ -19,7 +19,9 @@ interface UserInterests {
 export async function extractUserInterests(
   supabase: SupabaseClient,
   userId: string,
-  beforeProviderCall: (input: string) => Promise<void> = async () => {},
+  beforeProviderCall: (
+    input: string,
+  ) => Promise<() => Promise<void>> = async () => async () => {},
 ): Promise<UserInterests> {
   const embeddings = new OpenAIEmbeddings({
     openAIApiKey: config.openai.apiKey,
@@ -33,13 +35,17 @@ export async function extractUserInterests(
   });
 
   const interestQuery = "독서에서 중요하게 생각하는 주제와 개념";
-  await beforeProviderCall(interestQuery);
-
-  const results = await vectorStore.similaritySearch(
-    interestQuery,
-    config.rag.topHighlightsCount,
-    { user_id: userId },
-  );
+  const releaseProviderLease = await beforeProviderCall(interestQuery);
+  let results;
+  try {
+    results = await vectorStore.similaritySearch(
+      interestQuery,
+      config.rag.topHighlightsCount,
+      { user_id: userId },
+    );
+  } finally {
+    await releaseProviderLease();
+  }
 
   if (results.length === 0) {
     return { topHighlights: [], keywords: [] };

--- a/supabase/functions/recommend-next-books/services/rag-service.ts
+++ b/supabase/functions/recommend-next-books/services/rag-service.ts
@@ -4,6 +4,7 @@ import { OpenAIEmbeddings } from "@langchain/openai";
 import { Document } from "@langchain/core/documents";
 import { config } from "../config.ts";
 import { extractKeywords } from "../utils/keyword-extractor.ts";
+import { AI_PROVIDER_TIMEOUT_MS } from "../../_shared/ai-usage.ts";
 
 interface HighlightWithBook {
   content: string;
@@ -17,10 +18,12 @@ interface UserInterests {
 
 export async function extractUserInterests(
   supabase: SupabaseClient,
-  userId: string
+  userId: string,
+  beforeProviderCall: (input: string) => Promise<void> = async () => {},
 ): Promise<UserInterests> {
   const embeddings = new OpenAIEmbeddings({
     openAIApiKey: config.openai.apiKey,
+    timeout: AI_PROVIDER_TIMEOUT_MS,
   });
 
   const vectorStore = new SupabaseVectorStore(embeddings, {
@@ -30,11 +33,12 @@ export async function extractUserInterests(
   });
 
   const interestQuery = "독서에서 중요하게 생각하는 주제와 개념";
+  await beforeProviderCall(interestQuery);
 
   const results = await vectorStore.similaritySearch(
     interestQuery,
     config.rag.topHighlightsCount,
-    { user_id: userId }
+    { user_id: userId },
   );
 
   if (results.length === 0) {
@@ -51,7 +55,7 @@ export async function extractUserInterests(
     .in("id", bookIds);
 
   const bookTitleMap = new Map<string, string>(
-    books?.map((b: { id: string; title: string }) => [b.id, b.title]) || []
+    books?.map((b: { id: string; title: string }) => [b.id, b.title]) || [],
   );
 
   const topHighlights: HighlightWithBook[] = results.map((doc: Document) => ({
@@ -61,7 +65,7 @@ export async function extractUserInterests(
 
   const keywords = extractKeywords(
     topHighlights.map((h) => h.content).join(" "),
-    config.rag.topKeywordsCount
+    config.rag.topKeywordsCount,
   );
 
   return { topHighlights, keywords };

--- a/supabase/functions/recommend-next-books/services/recommendation-service.ts
+++ b/supabase/functions/recommend-next-books/services/recommendation-service.ts
@@ -1,11 +1,12 @@
 import { ChatOpenAI } from "@langchain/openai";
 import { PromptTemplate } from "@langchain/core/prompts";
 import type {
-  UserReadingProfile,
-  Recommendation,
   BookReadingAnalytics,
+  Recommendation,
+  UserReadingProfile,
 } from "../types.ts";
 import { config } from "../config.ts";
+import { AI_PROVIDER_TIMEOUT_MS } from "../../_shared/ai-usage.ts";
 
 const PROMPT_KO = `
 당신은 독서 추천 전문가입니다. 사용자의 **책별 세부 독서 패턴**을 분석하여 다음 읽을 책 {recommendCount}권을 추천해주세요.
@@ -89,34 +90,41 @@ export class RecommendationService {
   private llm: ChatOpenAI;
   private promptTemplate: PromptTemplate;
   private locale: string;
+  private readonly beforeProviderCall: (input: string) => Promise<void>;
 
-  constructor(locale: string = 'ko') {
+  constructor(
+    locale: string = "ko",
+    beforeProviderCall: (input: string) => Promise<void> = async () => {},
+  ) {
     this.locale = locale;
+    this.beforeProviderCall = beforeProviderCall;
     this.llm = new ChatOpenAI({
       openAIApiKey: config.openai.apiKey,
       modelName: config.openai.model,
       temperature: config.openai.temperature,
+      timeout: AI_PROVIDER_TIMEOUT_MS,
     });
 
-    const promptText = locale === 'ko' ? PROMPT_KO : PROMPT_EN;
+    const promptText = locale === "ko" ? PROMPT_KO : PROMPT_EN;
     this.promptTemplate = PromptTemplate.fromTemplate(promptText);
   }
 
   async generate(profile: UserReadingProfile): Promise<Recommendation[]> {
     const booksDetail = this.formatBooksDetail(profile.books);
     const highlightsContext = this.formatHighlights(
-      profile.interests.topHighlights
+      profile.interests.topHighlights,
     );
 
-    const noneText = this.locale === 'ko' ? '(없음)' : '(none)';
-    const diverseText = this.locale === 'ko' ? '다양' : 'Various';
+    const noneText = this.locale === "ko" ? "(없음)" : "(none)";
+    const diverseText = this.locale === "ko" ? "다양" : "Various";
 
     const formattedPrompt = await this.promptTemplate.format({
       recommendCount: config.recommendation.count,
       totalBooks: profile.stats.totalBooksCompleted,
       avgRating: profile.stats.averageRating,
-      favoriteGenres:
-        profile.stats.favoriteGenres.map((g) => g.genre).join(", ") || diverseText,
+      favoriteGenres: profile.stats.favoriteGenres.map((g) =>
+        g.genre
+      ).join(", ") || diverseText,
       avgDays: profile.stats.averageCompletionDays,
       highEngagement: profile.stats.highEngagementBookCount,
       booksDetail,
@@ -124,39 +132,46 @@ export class RecommendationService {
       keywords: profile.interests.keywords.join(", ") || noneText,
     });
 
+    await this.beforeProviderCall(formattedPrompt);
     const response = await this.llm.invoke(formattedPrompt);
     return this.parseResponse(response.content as string);
   }
 
   private formatBooksDetail(books: BookReadingAnalytics[]): string {
-    const unclassifiedText = this.locale === 'ko' ? '미분류' : 'Uncategorized';
-    const noneText = this.locale === 'ko' ? '없음' : 'None';
-    const completedFirstTryText = this.locale === 'ko' ? '(단번 완독)' : '(completed first try)';
+    const unclassifiedText = this.locale === "ko" ? "미분류" : "Uncategorized";
+    const noneText = this.locale === "ko" ? "없음" : "None";
+    const completedFirstTryText = this.locale === "ko"
+      ? "(단번 완독)"
+      : "(completed first try)";
 
     return books
       .slice(0, config.recommendation.maxBooksToAnalyze)
       .map(
         (b, idx) => `
-${idx + 1}. "${b.title}" (${b.author})
+${
+          idx + 1
+        }. "${b.title}" (${b.author})
    - Genre: ${b.genre || unclassifiedText}
    - Completed in: ${b.daysToComplete} days (avg ${b.averagePagesPerDay}p/day)
    - Engagement: ${b.highlightCount} highlights, ${b.noteCount} notes
    - Rating: ${b.rating ? `${b.rating}/5` : noneText}
    - Daily goal achievement: ${b.dailyGoalAchievementRate}%
-   - Attempts: ${b.attemptCount} ${b.attemptCount === 1 ? completedFirstTryText : ""}
-        `
+   - Attempts: ${b.attemptCount} ${
+          b.attemptCount === 1 ? completedFirstTryText : ""
+        }
+        `,
       )
       .join("\n");
   }
 
   private formatHighlights(
-    highlights: Array<{ content: string; bookTitle: string }>
+    highlights: Array<{ content: string; bookTitle: string }>,
   ): string {
     return highlights
       .slice(0, 5)
       .map(
         (h, idx) =>
-          `${idx + 1}. "${h.content.substring(0, 100)}..." (${h.bookTitle})`
+          `${idx + 1}. "${h.content.substring(0, 100)}..." (${h.bookTitle})`,
       )
       .join("\n");
   }

--- a/supabase/functions/recommend-next-books/services/recommendation-service.ts
+++ b/supabase/functions/recommend-next-books/services/recommendation-service.ts
@@ -98,10 +98,10 @@ export class RecommendationService {
   ) => Promise<() => Promise<void>>;
 
   constructor(
-    locale: string = "ko",
     beforeProviderCall: (
       input: string,
-    ) => Promise<() => Promise<void>> = async () => async () => {},
+    ) => Promise<() => Promise<void>>,
+    locale: string = "ko",
   ) {
     this.locale = locale;
     this.beforeProviderCall = beforeProviderCall;
@@ -110,6 +110,7 @@ export class RecommendationService {
       modelName: config.openai.model,
       temperature: config.openai.temperature,
       maxTokens: AI_MAX_OUTPUT_TOKENS,
+      maxRetries: 0,
       timeout: AI_PROVIDER_TIMEOUT_MS,
     });
 

--- a/supabase/functions/recommend-next-books/services/recommendation-service.ts
+++ b/supabase/functions/recommend-next-books/services/recommendation-service.ts
@@ -6,7 +6,10 @@ import type {
   UserReadingProfile,
 } from "../types.ts";
 import { config } from "../config.ts";
-import { AI_PROVIDER_TIMEOUT_MS } from "../../_shared/ai-usage.ts";
+import {
+  AI_MAX_OUTPUT_TOKENS,
+  AI_PROVIDER_TIMEOUT_MS,
+} from "../../_shared/ai-usage.ts";
 
 const PROMPT_KO = `
 당신은 독서 추천 전문가입니다. 사용자의 **책별 세부 독서 패턴**을 분석하여 다음 읽을 책 {recommendCount}권을 추천해주세요.
@@ -90,11 +93,15 @@ export class RecommendationService {
   private llm: ChatOpenAI;
   private promptTemplate: PromptTemplate;
   private locale: string;
-  private readonly beforeProviderCall: (input: string) => Promise<void>;
+  private readonly beforeProviderCall: (
+    input: string,
+  ) => Promise<() => Promise<void>>;
 
   constructor(
     locale: string = "ko",
-    beforeProviderCall: (input: string) => Promise<void> = async () => {},
+    beforeProviderCall: (
+      input: string,
+    ) => Promise<() => Promise<void>> = async () => async () => {},
   ) {
     this.locale = locale;
     this.beforeProviderCall = beforeProviderCall;
@@ -102,6 +109,7 @@ export class RecommendationService {
       openAIApiKey: config.openai.apiKey,
       modelName: config.openai.model,
       temperature: config.openai.temperature,
+      maxTokens: AI_MAX_OUTPUT_TOKENS,
       timeout: AI_PROVIDER_TIMEOUT_MS,
     });
 
@@ -132,8 +140,13 @@ export class RecommendationService {
       keywords: profile.interests.keywords.join(", ") || noneText,
     });
 
-    await this.beforeProviderCall(formattedPrompt);
-    const response = await this.llm.invoke(formattedPrompt);
+    const releaseProviderLease = await this.beforeProviderCall(formattedPrompt);
+    let response;
+    try {
+      response = await this.llm.invoke(formattedPrompt);
+    } finally {
+      await releaseProviderLease();
+    }
     return this.parseResponse(response.content as string);
   }
 

--- a/supabase/functions/structure-notes/index.ts
+++ b/supabase/functions/structure-notes/index.ts
@@ -120,7 +120,10 @@ serve(async (req: Request) => {
     assertAiInputSize(inputChars);
     const chainService = new ChainService(
       OPENAI_API_KEY,
-      (prompt) => acquireAiBudget(supabaseClient, prompt.length),
+      (prompt) => {
+        assertAiInputSize(prompt.length);
+        return acquireAiBudget(supabaseClient, prompt.length);
+      },
     );
     const structureOperation = await executeThirdPartyAiOperation(
       supabaseClient,

--- a/supabase/functions/structure-notes/index.ts
+++ b/supabase/functions/structure-notes/index.ts
@@ -6,6 +6,11 @@ import {
   executeThirdPartyAiOperation,
   thirdPartyAiConsentRequiredResponse,
 } from "../_shared/third-party-ai-consent.ts";
+import {
+  aiUsageErrorResponse,
+  assertAiInputSize,
+  consumeAiBudget,
+} from "../_shared/ai-usage.ts";
 
 const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
 const MIN_CONTENT_COUNT = 5;
@@ -108,7 +113,15 @@ serve(async (req: Request) => {
       );
     }
 
-    const chainService = new ChainService(OPENAI_API_KEY);
+    const inputChars = contents.reduce(
+      (total, content) => total + content.content_text.length,
+      0,
+    );
+    assertAiInputSize(inputChars);
+    const chainService = new ChainService(
+      OPENAI_API_KEY,
+      (prompt) => consumeAiBudget(supabaseClient, prompt.length),
+    );
     const structureOperation = await executeThirdPartyAiOperation(
       supabaseClient,
       user.id,
@@ -149,6 +162,10 @@ serve(async (req: Request) => {
       },
     });
   } catch (error) {
+    const usageResponse = aiUsageErrorResponse(error, {
+      "Access-Control-Allow-Origin": "*",
+    });
+    if (usageResponse) return usageResponse;
     console.error("Error:", error);
     return new Response(
       JSON.stringify({ error: (error as Error).message }),

--- a/supabase/functions/structure-notes/index.ts
+++ b/supabase/functions/structure-notes/index.ts
@@ -7,9 +7,9 @@ import {
   thirdPartyAiConsentRequiredResponse,
 } from "../_shared/third-party-ai-consent.ts";
 import {
+  acquireAiBudget,
   aiUsageErrorResponse,
   assertAiInputSize,
-  consumeAiBudget,
 } from "../_shared/ai-usage.ts";
 
 const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
@@ -120,7 +120,7 @@ serve(async (req: Request) => {
     assertAiInputSize(inputChars);
     const chainService = new ChainService(
       OPENAI_API_KEY,
-      (prompt) => consumeAiBudget(supabaseClient, prompt.length),
+      (prompt) => acquireAiBudget(supabaseClient, prompt.length),
     );
     const structureOperation = await executeThirdPartyAiOperation(
       supabaseClient,

--- a/supabase/functions/structure-notes/services/chain-service.ts
+++ b/supabase/functions/structure-notes/services/chain-service.ts
@@ -6,6 +6,7 @@ import {
 import { summaryPrompt, SummaryResult } from "../prompts/summary.ts";
 import { connectionPrompt, ConnectionResult } from "../prompts/connection.ts";
 import type { Cluster, Connection, Node, NoteStructure } from "../types.ts";
+import { AI_PROVIDER_TIMEOUT_MS } from "../../_shared/ai-usage.ts";
 
 export interface ContentItem {
   id: string;
@@ -66,12 +67,18 @@ export function remapResolvedConnections(
 
 export class ChainService {
   private llm: ChatOpenAI;
+  private readonly beforeProviderCall: (input: string) => Promise<void>;
 
-  constructor(apiKey: string) {
+  constructor(
+    apiKey: string,
+    beforeProviderCall: (input: string) => Promise<void> = async () => {},
+  ) {
+    this.beforeProviderCall = beforeProviderCall;
     this.llm = new ChatOpenAI({
       openAIApiKey: apiKey,
       modelName: "gpt-4o-mini",
       temperature: 0.3,
+      timeout: AI_PROVIDER_TIMEOUT_MS,
     });
   }
 
@@ -136,6 +143,7 @@ export class ChainService {
     contents: string,
   ): Promise<ClassificationResult> {
     const formattedPrompt = await classificationPrompt.format({ contents });
+    await this.beforeProviderCall(formattedPrompt);
     const response = await this.llm.invoke(formattedPrompt);
     return this.parseJsonResponse<ClassificationResult>(
       response.content as string,
@@ -168,6 +176,7 @@ export class ChainService {
 
   private async runSummary(clusteredContents: string): Promise<SummaryResult> {
     const formattedPrompt = await summaryPrompt.format({ clusteredContents });
+    await this.beforeProviderCall(formattedPrompt);
     const response = await this.llm.invoke(formattedPrompt);
     return this.parseJsonResponse<SummaryResult>(response.content as string);
   }
@@ -209,6 +218,7 @@ ${clusterContents}`;
     const formattedPrompt = await connectionPrompt.format({
       summarizedClusters,
     });
+    await this.beforeProviderCall(formattedPrompt);
     const response = await this.llm.invoke(formattedPrompt);
     return this.parseJsonResponse<ConnectionResult>(response.content as string);
   }

--- a/supabase/functions/structure-notes/services/chain-service.ts
+++ b/supabase/functions/structure-notes/services/chain-service.ts
@@ -6,7 +6,10 @@ import {
 import { summaryPrompt, SummaryResult } from "../prompts/summary.ts";
 import { connectionPrompt, ConnectionResult } from "../prompts/connection.ts";
 import type { Cluster, Connection, Node, NoteStructure } from "../types.ts";
-import { AI_PROVIDER_TIMEOUT_MS } from "../../_shared/ai-usage.ts";
+import {
+  AI_MAX_OUTPUT_TOKENS,
+  AI_PROVIDER_TIMEOUT_MS,
+} from "../../_shared/ai-usage.ts";
 
 export interface ContentItem {
   id: string;
@@ -67,17 +70,22 @@ export function remapResolvedConnections(
 
 export class ChainService {
   private llm: ChatOpenAI;
-  private readonly beforeProviderCall: (input: string) => Promise<void>;
+  private readonly beforeProviderCall: (
+    input: string,
+  ) => Promise<() => Promise<void>>;
 
   constructor(
     apiKey: string,
-    beforeProviderCall: (input: string) => Promise<void> = async () => {},
+    beforeProviderCall: (
+      input: string,
+    ) => Promise<() => Promise<void>> = async () => async () => {},
   ) {
     this.beforeProviderCall = beforeProviderCall;
     this.llm = new ChatOpenAI({
       openAIApiKey: apiKey,
       modelName: "gpt-4o-mini",
       temperature: 0.3,
+      maxTokens: AI_MAX_OUTPUT_TOKENS,
       timeout: AI_PROVIDER_TIMEOUT_MS,
     });
   }
@@ -143,8 +151,13 @@ export class ChainService {
     contents: string,
   ): Promise<ClassificationResult> {
     const formattedPrompt = await classificationPrompt.format({ contents });
-    await this.beforeProviderCall(formattedPrompt);
-    const response = await this.llm.invoke(formattedPrompt);
+    const releaseProviderLease = await this.beforeProviderCall(formattedPrompt);
+    let response;
+    try {
+      response = await this.llm.invoke(formattedPrompt);
+    } finally {
+      await releaseProviderLease();
+    }
     return this.parseJsonResponse<ClassificationResult>(
       response.content as string,
     );
@@ -176,8 +189,13 @@ export class ChainService {
 
   private async runSummary(clusteredContents: string): Promise<SummaryResult> {
     const formattedPrompt = await summaryPrompt.format({ clusteredContents });
-    await this.beforeProviderCall(formattedPrompt);
-    const response = await this.llm.invoke(formattedPrompt);
+    const releaseProviderLease = await this.beforeProviderCall(formattedPrompt);
+    let response;
+    try {
+      response = await this.llm.invoke(formattedPrompt);
+    } finally {
+      await releaseProviderLease();
+    }
     return this.parseJsonResponse<SummaryResult>(response.content as string);
   }
 
@@ -218,8 +236,13 @@ ${clusterContents}`;
     const formattedPrompt = await connectionPrompt.format({
       summarizedClusters,
     });
-    await this.beforeProviderCall(formattedPrompt);
-    const response = await this.llm.invoke(formattedPrompt);
+    const releaseProviderLease = await this.beforeProviderCall(formattedPrompt);
+    let response;
+    try {
+      response = await this.llm.invoke(formattedPrompt);
+    } finally {
+      await releaseProviderLease();
+    }
     return this.parseJsonResponse<ConnectionResult>(response.content as string);
   }
 

--- a/supabase/functions/structure-notes/services/chain-service.ts
+++ b/supabase/functions/structure-notes/services/chain-service.ts
@@ -78,7 +78,7 @@ export class ChainService {
     apiKey: string,
     beforeProviderCall: (
       input: string,
-    ) => Promise<() => Promise<void>> = async () => async () => {},
+    ) => Promise<() => Promise<void>>,
   ) {
     this.beforeProviderCall = beforeProviderCall;
     this.llm = new ChatOpenAI({
@@ -86,6 +86,7 @@ export class ChainService {
       modelName: "gpt-4o-mini",
       temperature: 0.3,
       maxTokens: AI_MAX_OUTPUT_TOKENS,
+      maxRetries: 0,
       timeout: AI_PROVIDER_TIMEOUT_MS,
     });
   }

--- a/supabase/migrations/20260808060422_add_ai_usage_budget.sql
+++ b/supabase/migrations/20260808060422_add_ai_usage_budget.sql
@@ -1,0 +1,83 @@
+CREATE TABLE IF NOT EXISTS public.ai_usage_buckets (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  window_started_at TIMESTAMPTZ NOT NULL,
+  request_count INTEGER NOT NULL DEFAULT 0,
+  input_chars BIGINT NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.ai_usage_buckets ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.ai_usage_buckets FROM anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public.consume_ai_usage(p_input_chars INTEGER)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  actor_id UUID := auth.uid();
+  current_window TIMESTAMPTZ := date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
+  bucket public.ai_usage_buckets%ROWTYPE;
+  request_limit CONSTANT INTEGER := 30;
+  input_limit CONSTANT BIGINT := 150000;
+  request_input_limit CONSTANT INTEGER := 20000;
+BEGIN
+  IF actor_id IS NULL THEN
+    RAISE EXCEPTION 'authentication required' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_input_chars IS NULL OR p_input_chars < 0 OR p_input_chars > request_input_limit THEN
+    RETURN jsonb_build_object(
+      'allowed', false,
+      'reason', 'input_too_large',
+      'requestInputLimit', request_input_limit
+    );
+  END IF;
+
+  INSERT INTO public.ai_usage_buckets (user_id, window_started_at)
+  VALUES (actor_id, current_window)
+  ON CONFLICT (user_id) DO NOTHING;
+
+  SELECT * INTO bucket
+  FROM public.ai_usage_buckets
+  WHERE user_id = actor_id
+  FOR UPDATE;
+
+  IF bucket.window_started_at < current_window THEN
+    bucket.window_started_at := current_window;
+    bucket.request_count := 0;
+    bucket.input_chars := 0;
+  END IF;
+
+  IF bucket.request_count >= request_limit OR bucket.input_chars + p_input_chars > input_limit THEN
+    RETURN jsonb_build_object(
+      'allowed', false,
+      'reason', 'quota_exceeded',
+      'requestLimit', request_limit,
+      'inputLimit', input_limit,
+      'requestsUsed', bucket.request_count,
+      'inputCharsUsed', bucket.input_chars
+    );
+  END IF;
+
+  UPDATE public.ai_usage_buckets
+  SET window_started_at = bucket.window_started_at,
+      request_count = bucket.request_count + 1,
+      input_chars = bucket.input_chars + p_input_chars,
+      updated_at = now()
+  WHERE user_id = actor_id;
+
+  RETURN jsonb_build_object(
+    'allowed', true,
+    'requestLimit', request_limit,
+    'inputLimit', input_limit,
+    'requestsUsed', bucket.request_count + 1,
+    'inputCharsUsed', bucket.input_chars + p_input_chars
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.consume_ai_usage(INTEGER) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.consume_ai_usage(INTEGER) TO authenticated;

--- a/supabase/migrations/20260808060422_add_ai_usage_budget.sql
+++ b/supabase/migrations/20260808060422_add_ai_usage_budget.sql
@@ -6,9 +6,21 @@ CREATE TABLE IF NOT EXISTS public.ai_usage_buckets (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+CREATE TABLE IF NOT EXISTS public.ai_usage_leases (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ai_usage_leases_user_idx
+  ON public.ai_usage_leases(user_id, expires_at);
+
 ALTER TABLE public.ai_usage_buckets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.ai_usage_leases ENABLE ROW LEVEL SECURITY;
 
 REVOKE ALL ON TABLE public.ai_usage_buckets FROM anon, authenticated;
+REVOKE ALL ON TABLE public.ai_usage_leases FROM anon, authenticated;
 
 CREATE OR REPLACE FUNCTION public.consume_ai_usage(p_input_chars INTEGER)
 RETURNS JSONB
@@ -20,9 +32,12 @@ DECLARE
   actor_id UUID := auth.uid();
   current_window TIMESTAMPTZ := date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC';
   bucket public.ai_usage_buckets%ROWTYPE;
+  active_leases INTEGER;
+  lease_id UUID;
   request_limit CONSTANT INTEGER := 30;
   input_limit CONSTANT BIGINT := 150000;
   request_input_limit CONSTANT INTEGER := 20000;
+  concurrency_limit CONSTANT INTEGER := 3;
 BEGIN
   IF actor_id IS NULL THEN
     RAISE EXCEPTION 'authentication required' USING ERRCODE = '42501';
@@ -44,6 +59,22 @@ BEGIN
   FROM public.ai_usage_buckets
   WHERE user_id = actor_id
   FOR UPDATE;
+
+  DELETE FROM public.ai_usage_leases
+  WHERE user_id = actor_id
+    AND expires_at <= now();
+
+  SELECT COUNT(*) INTO active_leases
+  FROM public.ai_usage_leases
+  WHERE user_id = actor_id;
+
+  IF active_leases >= concurrency_limit THEN
+    RETURN jsonb_build_object(
+      'allowed', false,
+      'reason', 'concurrency_exceeded',
+      'concurrencyLimit', concurrency_limit
+    );
+  END IF;
 
   IF bucket.window_started_at < current_window THEN
     bucket.window_started_at := current_window;
@@ -69,8 +100,13 @@ BEGIN
       updated_at = now()
   WHERE user_id = actor_id;
 
+  INSERT INTO public.ai_usage_leases (user_id, expires_at)
+  VALUES (actor_id, now() + interval '60 seconds')
+  RETURNING id INTO lease_id;
+
   RETURN jsonb_build_object(
     'allowed', true,
+    'leaseId', lease_id,
     'requestLimit', request_limit,
     'inputLimit', input_limit,
     'requestsUsed', bucket.request_count + 1,
@@ -79,5 +115,27 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION public.release_ai_usage(p_lease_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  actor_id UUID := auth.uid();
+BEGIN
+  IF actor_id IS NULL THEN
+    RAISE EXCEPTION 'authentication required' USING ERRCODE = '42501';
+  END IF;
+
+  DELETE FROM public.ai_usage_leases
+  WHERE id = p_lease_id
+    AND user_id = actor_id;
+  RETURN FOUND;
+END;
+$$;
+
 REVOKE ALL ON FUNCTION public.consume_ai_usage(INTEGER) FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.consume_ai_usage(INTEGER) TO authenticated;
+REVOKE ALL ON FUNCTION public.release_ai_usage(UUID) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.release_ai_usage(UUID) TO authenticated;

--- a/supabase/tests/database/ai_usage_budget.test.sql
+++ b/supabase/tests/database/ai_usage_budget.test.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(14);
+SELECT plan(15);
 
 INSERT INTO auth.users (
   instance_id,
@@ -69,6 +69,13 @@ SELECT results_eq(
     SELECT (public.consume_ai_usage(10)->>'allowed')
   $$,
   ARRAY['true'::text],
+  'a second in-flight budget call remains within the concurrency cap'
+);
+SELECT results_eq(
+  $$
+    SELECT (public.consume_ai_usage(10)->>'allowed')
+  $$,
+  ARRAY['true'::text],
   'a third in-flight budget call remains within the concurrency cap'
 );
 SELECT results_eq(
@@ -97,7 +104,7 @@ SELECT results_eq(
     FROM public.ai_usage_buckets
     WHERE user_id = '55555555-5555-5555-5555-555555555555'
   $$,
-  ARRAY[1],
+  ARRAY[3],
   'rejected input does not increment the request count'
 );
 
@@ -141,7 +148,7 @@ DECLARE
   attempt INTEGER;
   result JSONB;
 BEGIN
-  FOR attempt IN 1..29 LOOP
+  FOR attempt IN 1..27 LOOP
     result := public.consume_ai_usage(10);
     IF NOT (result->>'allowed')::boolean THEN
       RAISE EXCEPTION 'unexpected quota rejection at attempt %', attempt;

--- a/supabase/tests/database/ai_usage_budget.test.sql
+++ b/supabase/tests/database/ai_usage_budget.test.sql
@@ -199,6 +199,8 @@ SELECT ok(
   'the 31st daily request is rejected'
 );
 
+RESET ROLE;
+
 SELECT results_eq(
   $$
     SELECT request_count
@@ -208,6 +210,8 @@ SELECT results_eq(
   ARRAY[30],
   'quota rejection does not increment the bucket'
 );
+
+SET LOCAL ROLE authenticated;
 
 SELECT throws_ok(
   $$ SELECT * FROM public.ai_usage_buckets $$,

--- a/supabase/tests/database/ai_usage_budget.test.sql
+++ b/supabase/tests/database/ai_usage_budget.test.sql
@@ -189,6 +189,7 @@ BEGIN
     IF NOT (result->>'allowed')::boolean THEN
       RAISE EXCEPTION 'unexpected quota rejection at attempt %', attempt;
     END IF;
+    PERFORM public.release_ai_usage((result->>'leaseId')::uuid);
   END LOOP;
 END
 $$;

--- a/supabase/tests/database/ai_usage_budget.test.sql
+++ b/supabase/tests/database/ai_usage_budget.test.sql
@@ -44,6 +44,9 @@ INSERT INTO auth.users (
     '{}'
   );
 
+COMMIT;
+BEGIN;
+
 SELECT dblink_connect(
   'ai_budget_a',
   'host=127.0.0.1 port=5432 dbname=' || current_database() ||
@@ -214,4 +217,9 @@ SELECT throws_ok(
 );
 
 SELECT * FROM finish();
-ROLLBACK;
+DELETE FROM auth.users
+WHERE id IN (
+  '55555555-5555-5555-5555-555555555555',
+  '66666666-6666-6666-6666-666666666666'
+);
+COMMIT;

--- a/supabase/tests/database/ai_usage_budget.test.sql
+++ b/supabase/tests/database/ai_usage_budget.test.sql
@@ -1,0 +1,209 @@
+BEGIN;
+
+SELECT plan(14);
+
+CREATE EXTENSION IF NOT EXISTS dblink;
+
+INSERT INTO auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  created_at,
+  updated_at,
+  raw_app_meta_data,
+  raw_user_meta_data
+) VALUES
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '55555555-5555-5555-5555-555555555555',
+    'authenticated',
+    'authenticated',
+    'ai-budget-a@example.com',
+    '',
+    now(),
+    now(),
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}'
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '66666666-6666-6666-6666-666666666666',
+    'authenticated',
+    'authenticated',
+    'ai-budget-b@example.com',
+    '',
+    now(),
+    now(),
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}'
+  );
+
+SELECT dblink_connect('ai_budget_a', 'dbname=' || current_database());
+SELECT dblink_connect('ai_budget_b', 'dbname=' || current_database());
+
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claim.sub =
+  '55555555-5555-5555-5555-555555555555';
+
+SELECT ok(
+  (public.consume_ai_usage(10)->>'allowed')::boolean,
+  'authenticated user can consume an AI budget unit'
+);
+
+SELECT results_eq(
+  $$
+    SELECT (public.consume_ai_usage(20001)->>'reason')
+  $$,
+  ARRAY['input_too_large'::text],
+  'oversized input is rejected before usage is recorded'
+);
+
+SELECT ok(
+  position('FOR UPDATE' IN pg_get_functiondef('public.consume_ai_usage(integer)'::regprocedure)) > 0,
+  'budget function locks the user bucket for concurrent calls'
+);
+
+SELECT dblink_exec('ai_budget_a', 'SET ROLE authenticated');
+SELECT dblink_exec('ai_budget_b', 'SET ROLE authenticated');
+SELECT dblink_exec(
+  'ai_budget_a',
+  'SET request.jwt.claim.sub = ''55555555-5555-5555-5555-555555555555'''
+);
+SELECT dblink_exec(
+  'ai_budget_b',
+  'SET request.jwt.claim.sub = ''55555555-5555-5555-5555-555555555555'''
+);
+SELECT dblink_exec('ai_budget_a', 'BEGIN');
+SELECT *
+FROM dblink('ai_budget_a', 'SELECT public.consume_ai_usage(10)')
+  AS result(value JSONB);
+SELECT dblink_exec('ai_budget_b', 'SET statement_timeout = 5000');
+SELECT dblink_exec('ai_budget_b', 'BEGIN');
+SELECT ok(
+  dblink_send_query(
+    'ai_budget_b',
+    'SELECT public.consume_ai_usage(10)'
+  ) = 1,
+  'a concurrent budget call is submitted without bypassing the row lock'
+);
+SELECT pg_sleep(0.1);
+SELECT ok(
+  dblink_is_busy('ai_budget_b') = 1,
+  'the concurrent call waits for the first transaction'
+);
+SELECT dblink_exec('ai_budget_a', 'COMMIT');
+SELECT results_eq(
+  $$
+    SELECT value->>'allowed'
+    FROM dblink_get_result('ai_budget_b') AS result(value JSONB)
+  $$,
+  ARRAY['true'::text],
+  'the concurrent call completes after the first transaction releases the row lock'
+);
+SELECT *
+FROM dblink_get_result('ai_budget_b') AS result(value JSONB);
+SELECT dblink_exec('ai_budget_b', 'COMMIT');
+SELECT dblink_disconnect('ai_budget_a');
+SELECT dblink_disconnect('ai_budget_b');
+
+RESET ROLE;
+
+SELECT results_eq(
+  $$
+    SELECT request_count
+    FROM public.ai_usage_buckets
+    WHERE user_id = '55555555-5555-5555-5555-555555555555'
+  $$,
+  ARRAY[1],
+  'rejected input does not increment the request count'
+);
+
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claim.sub =
+  '66666666-6666-6666-6666-666666666666';
+
+SELECT ok(
+  (public.consume_ai_usage(10)->>'allowed')::boolean,
+  'a second authenticated user receives an independent budget'
+);
+
+RESET ROLE;
+
+SELECT results_eq(
+  $$
+    SELECT COUNT(*)
+    FROM public.ai_usage_buckets
+    WHERE user_id = '55555555-5555-5555-5555-555555555555'
+  $$,
+  ARRAY[1::bigint],
+  'user A has one isolated usage bucket'
+);
+
+SELECT results_eq(
+  $$
+    SELECT COUNT(*)
+    FROM public.ai_usage_buckets
+    WHERE user_id = '66666666-6666-6666-6666-666666666666'
+  $$,
+  ARRAY[1::bigint],
+  'user B has one isolated usage bucket'
+);
+
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claim.sub =
+  '55555555-5555-5555-5555-555555555555';
+
+DO $$
+DECLARE
+  attempt INTEGER;
+  result JSONB;
+BEGIN
+  FOR attempt IN 1..29 LOOP
+    result := public.consume_ai_usage(10);
+    IF NOT (result->>'allowed')::boolean THEN
+      RAISE EXCEPTION 'unexpected quota rejection at attempt %', attempt;
+    END IF;
+  END LOOP;
+END
+$$;
+
+SELECT ok(
+  NOT (public.consume_ai_usage(10)->>'allowed')::boolean,
+  'the 31st daily request is rejected'
+);
+
+SELECT results_eq(
+  $$
+    SELECT request_count
+    FROM public.ai_usage_buckets
+    WHERE user_id = '55555555-5555-5555-5555-555555555555'
+  $$,
+  ARRAY[30],
+  'quota rejection does not increment the bucket'
+);
+
+SELECT throws_ok(
+  $$ SELECT * FROM public.ai_usage_buckets $$,
+  '42501',
+  'permission denied for table ai_usage_buckets',
+  'authenticated clients cannot read usage buckets directly'
+);
+
+RESET ROLE;
+SET LOCAL request.jwt.claim.sub = '';
+
+SELECT throws_ok(
+  $$ SELECT public.consume_ai_usage(1) $$,
+  '42501',
+  'authentication required',
+  'unauthenticated callers are rejected by the server-owned function'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/ai_usage_budget.test.sql
+++ b/supabase/tests/database/ai_usage_budget.test.sql
@@ -44,8 +44,16 @@ INSERT INTO auth.users (
     '{}'
   );
 
-SELECT dblink_connect('ai_budget_a', 'dbname=' || current_database());
-SELECT dblink_connect('ai_budget_b', 'dbname=' || current_database());
+SELECT dblink_connect(
+  'ai_budget_a',
+  'host=127.0.0.1 port=5432 dbname=' || current_database() ||
+    ' user=postgres password=postgres'
+);
+SELECT dblink_connect(
+  'ai_budget_b',
+  'host=127.0.0.1 port=5432 dbname=' || current_database() ||
+    ' user=postgres password=postgres'
+);
 
 SET LOCAL ROLE authenticated;
 SET LOCAL request.jwt.claim.sub =

--- a/supabase/tests/database/ai_usage_budget.test.sql
+++ b/supabase/tests/database/ai_usage_budget.test.sql
@@ -40,6 +40,19 @@ INSERT INTO auth.users (
     now(),
     '{"provider":"email","providers":["email"]}',
     '{}'
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '77777777-7777-7777-7777-777777777777',
+    'authenticated',
+    'authenticated',
+    'ai-budget-concurrency@example.com',
+    '',
+    now(),
+    now(),
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}'
   );
 
 SET LOCAL ROLE authenticated;
@@ -63,6 +76,9 @@ SELECT ok(
   position('FOR UPDATE' IN pg_get_functiondef('public.consume_ai_usage(integer)'::regprocedure)) > 0,
   'budget function locks the user bucket for concurrent calls'
 );
+
+SET LOCAL request.jwt.claim.sub =
+  '77777777-7777-7777-7777-777777777777';
 
 SELECT results_eq(
   $$
@@ -91,12 +107,12 @@ RESET ROLE;
 SELECT ok(
   (SELECT COUNT(*) = 3
    FROM public.ai_usage_leases
-   WHERE user_id = '55555555-5555-5555-5555-555555555555'),
+   WHERE user_id = '77777777-7777-7777-7777-777777777777'),
   'the user bucket tracks the active lease count'
 );
 
-DELETE FROM public.ai_usage_leases
-WHERE user_id = '55555555-5555-5555-5555-555555555555';
+SET LOCAL request.jwt.claim.sub =
+  '55555555-5555-5555-5555-555555555555';
 
 SELECT results_eq(
   $$

--- a/supabase/tests/database/ai_usage_budget.test.sql
+++ b/supabase/tests/database/ai_usage_budget.test.sql
@@ -42,6 +42,19 @@ INSERT INTO auth.users (
     now(),
     '{"provider":"email","providers":["email"]}',
     '{}'
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '77777777-7777-7777-7777-777777777777',
+    'authenticated',
+    'authenticated',
+    'ai-budget-concurrency@example.com',
+    '',
+    now(),
+    now(),
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}'
   );
 
 COMMIT;
@@ -84,11 +97,11 @@ SELECT dblink_exec('ai_budget_a', 'SET ROLE authenticated');
 SELECT dblink_exec('ai_budget_b', 'SET ROLE authenticated');
 SELECT dblink_exec(
   'ai_budget_a',
-  'SET request.jwt.claim.sub = ''55555555-5555-5555-5555-555555555555'''
+  'SET request.jwt.claim.sub = ''77777777-7777-7777-7777-777777777777'''
 );
 SELECT dblink_exec(
   'ai_budget_b',
-  'SET request.jwt.claim.sub = ''55555555-5555-5555-5555-555555555555'''
+  'SET request.jwt.claim.sub = ''77777777-7777-7777-7777-777777777777'''
 );
 SELECT dblink_exec('ai_budget_a', 'BEGIN');
 SELECT *
@@ -220,6 +233,7 @@ SELECT * FROM finish();
 DELETE FROM auth.users
 WHERE id IN (
   '55555555-5555-5555-5555-555555555555',
-  '66666666-6666-6666-6666-666666666666'
+  '66666666-6666-6666-6666-666666666666',
+  '77777777-7777-7777-7777-777777777777'
 );
 COMMIT;

--- a/supabase/tests/database/ai_usage_budget.test.sql
+++ b/supabase/tests/database/ai_usage_budget.test.sql
@@ -53,6 +53,19 @@ INSERT INTO auth.users (
     now(),
     '{"provider":"email","providers":["email"]}',
     '{}'
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '88888888-8888-8888-8888-888888888888',
+    'authenticated',
+    'authenticated',
+    'ai-budget-quota@example.com',
+    '',
+    now(),
+    now(),
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}'
   );
 
 SET LOCAL ROLE authenticated;
@@ -164,14 +177,14 @@ SELECT results_eq(
 
 SET LOCAL ROLE authenticated;
 SET LOCAL request.jwt.claim.sub =
-  '55555555-5555-5555-5555-555555555555';
+  '88888888-8888-8888-8888-888888888888';
 
 DO $$
 DECLARE
   attempt INTEGER;
   result JSONB;
 BEGIN
-  FOR attempt IN 1..29 LOOP
+  FOR attempt IN 1..30 LOOP
     result := public.consume_ai_usage(10);
     IF NOT (result->>'allowed')::boolean THEN
       RAISE EXCEPTION 'unexpected quota rejection at attempt %', attempt;
@@ -189,7 +202,7 @@ SELECT results_eq(
   $$
     SELECT request_count
     FROM public.ai_usage_buckets
-    WHERE user_id = '55555555-5555-5555-5555-555555555555'
+    WHERE user_id = '88888888-8888-8888-8888-888888888888'
   $$,
   ARRAY[30],
   'quota rejection does not increment the bucket'

--- a/supabase/tests/database/ai_usage_budget.test.sql
+++ b/supabase/tests/database/ai_usage_budget.test.sql
@@ -2,8 +2,6 @@ BEGIN;
 
 SELECT plan(14);
 
-CREATE EXTENSION IF NOT EXISTS dblink;
-
 INSERT INTO auth.users (
   instance_id,
   id,
@@ -42,34 +40,7 @@ INSERT INTO auth.users (
     now(),
     '{"provider":"email","providers":["email"]}',
     '{}'
-  ),
-  (
-    '00000000-0000-0000-0000-000000000000',
-    '77777777-7777-7777-7777-777777777777',
-    'authenticated',
-    'authenticated',
-    'ai-budget-concurrency@example.com',
-    '',
-    now(),
-    now(),
-    now(),
-    '{"provider":"email","providers":["email"]}',
-    '{}'
   );
-
-COMMIT;
-BEGIN;
-
-SELECT dblink_connect(
-  'ai_budget_a',
-  'host=127.0.0.1 port=5432 dbname=' || current_database() ||
-    ' user=postgres password=postgres'
-);
-SELECT dblink_connect(
-  'ai_budget_b',
-  'host=127.0.0.1 port=5432 dbname=' || current_database() ||
-    ' user=postgres password=postgres'
-);
 
 SET LOCAL ROLE authenticated;
 SET LOCAL request.jwt.claim.sub =
@@ -93,50 +64,32 @@ SELECT ok(
   'budget function locks the user bucket for concurrent calls'
 );
 
-SELECT dblink_exec('ai_budget_a', 'SET ROLE authenticated');
-SELECT dblink_exec('ai_budget_b', 'SET ROLE authenticated');
-SELECT dblink_exec(
-  'ai_budget_a',
-  'SET request.jwt.claim.sub = ''77777777-7777-7777-7777-777777777777'''
-);
-SELECT dblink_exec(
-  'ai_budget_b',
-  'SET request.jwt.claim.sub = ''77777777-7777-7777-7777-777777777777'''
-);
-SELECT dblink_exec('ai_budget_a', 'BEGIN');
-SELECT *
-FROM dblink('ai_budget_a', 'SELECT public.consume_ai_usage(10)')
-  AS result(value JSONB);
-SELECT dblink_exec('ai_budget_b', 'SET statement_timeout = 5000');
-SELECT dblink_exec('ai_budget_b', 'BEGIN');
-SELECT ok(
-  dblink_send_query(
-    'ai_budget_b',
-    'SELECT public.consume_ai_usage(10)'
-  ) = 1,
-  'a concurrent budget call is submitted without bypassing the row lock'
-);
-SELECT pg_sleep(0.1);
-SELECT ok(
-  dblink_is_busy('ai_budget_b') = 1,
-  'the concurrent call waits for the first transaction'
-);
-SELECT dblink_exec('ai_budget_a', 'COMMIT');
 SELECT results_eq(
   $$
-    SELECT value->>'allowed'
-    FROM dblink_get_result('ai_budget_b') AS result(value JSONB)
+    SELECT (public.consume_ai_usage(10)->>'allowed')
   $$,
   ARRAY['true'::text],
-  'the concurrent call completes after the first transaction releases the row lock'
+  'a third in-flight budget call remains within the concurrency cap'
 );
-SELECT *
-FROM dblink_get_result('ai_budget_b') AS result(value JSONB);
-SELECT dblink_exec('ai_budget_b', 'COMMIT');
-SELECT dblink_disconnect('ai_budget_a');
-SELECT dblink_disconnect('ai_budget_b');
+SELECT results_eq(
+  $$
+    SELECT public.consume_ai_usage(10)->>'reason'
+  $$,
+  ARRAY['concurrency_exceeded'::text],
+  'the fourth in-flight budget call is rejected'
+);
 
 RESET ROLE;
+
+SELECT ok(
+  (SELECT COUNT(*) = 3
+   FROM public.ai_usage_leases
+   WHERE user_id = '55555555-5555-5555-5555-555555555555'),
+  'the user bucket tracks the active lease count'
+);
+
+DELETE FROM public.ai_usage_leases
+WHERE user_id = '55555555-5555-5555-5555-555555555555';
 
 SELECT results_eq(
   $$
@@ -230,10 +183,4 @@ SELECT throws_ok(
 );
 
 SELECT * FROM finish();
-DELETE FROM auth.users
-WHERE id IN (
-  '55555555-5555-5555-5555-555555555555',
-  '66666666-6666-6666-6666-666666666666',
-  '77777777-7777-7777-7777-777777777777'
-);
-COMMIT;
+ROLLBACK;

--- a/supabase/tests/database/ai_usage_budget.test.sql
+++ b/supabase/tests/database/ai_usage_budget.test.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(16);
+SELECT plan(18);
 
 INSERT INTO auth.users (
   instance_id,
@@ -60,6 +60,19 @@ INSERT INTO auth.users (
     'authenticated',
     'authenticated',
     'ai-budget-quota@example.com',
+    '',
+    now(),
+    now(),
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}'
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '99999999-9999-9999-9999-999999999999',
+    'authenticated',
+    'authenticated',
+    'ai-budget-input@example.com',
     '',
     now(),
     now(),
@@ -209,6 +222,47 @@ SELECT results_eq(
   $$,
   ARRAY[30],
   'quota rejection does not increment the bucket'
+);
+
+SET LOCAL request.jwt.claim.sub =
+  '99999999-9999-9999-9999-999999999999';
+
+DO $$
+DECLARE
+  attempt INTEGER;
+  result JSONB;
+BEGIN
+  FOR attempt IN 1..7 LOOP
+    result := public.consume_ai_usage(20000);
+    IF NOT (result->>'allowed')::boolean THEN
+      RAISE EXCEPTION 'unexpected input quota rejection at attempt %', attempt;
+    END IF;
+    PERFORM public.release_ai_usage((result->>'leaseId')::uuid);
+  END LOOP;
+
+  result := public.consume_ai_usage(10000);
+  IF NOT (result->>'allowed')::boolean THEN
+    RAISE EXCEPTION 'unexpected input quota rejection at final partial attempt';
+  END IF;
+  PERFORM public.release_ai_usage((result->>'leaseId')::uuid);
+END
+$$;
+
+SELECT ok(
+  NOT (public.consume_ai_usage(1)->>'allowed')::boolean,
+  'the daily input-character limit rejects the next character'
+);
+
+RESET ROLE;
+
+SELECT results_eq(
+  $$
+    SELECT request_count, input_chars
+    FROM public.ai_usage_buckets
+    WHERE user_id = '99999999-9999-9999-9999-999999999999'
+  $$,
+  $$ VALUES (8, 150000::bigint) $$,
+  'input quota rejection leaves both counters unchanged'
 );
 
 SET LOCAL ROLE authenticated;

--- a/supabase/tests/database/ai_usage_budget.test.sql
+++ b/supabase/tests/database/ai_usage_budget.test.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(15);
+SELECT plan(16);
 
 INSERT INTO auth.users (
   instance_id,
@@ -96,6 +96,13 @@ SELECT results_eq(
 );
 SELECT results_eq(
   $$
+    SELECT (public.consume_ai_usage(10)->>'allowed')
+  $$,
+  ARRAY['true'::text],
+  'the concurrency cap remains stable across the third lease'
+);
+SELECT results_eq(
+  $$
     SELECT public.consume_ai_usage(10)->>'reason'
   $$,
   ARRAY['concurrency_exceeded'::text],
@@ -120,7 +127,7 @@ SELECT results_eq(
     FROM public.ai_usage_buckets
     WHERE user_id = '55555555-5555-5555-5555-555555555555'
   $$,
-  ARRAY[3],
+  ARRAY[1],
   'rejected input does not increment the request count'
 );
 
@@ -164,7 +171,7 @@ DECLARE
   attempt INTEGER;
   result JSONB;
 BEGIN
-  FOR attempt IN 1..27 LOOP
+  FOR attempt IN 1..29 LOOP
     result := public.consume_ai_usage(10);
     IF NOT (result->>'allowed')::boolean THEN
       RAISE EXCEPTION 'unexpected quota rejection at attempt %', attempt;


### PR DESCRIPTION
Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store

AI Edge Function이 클라이언트 호출·동시 요청으로 비용 상한을 우회하지 않도록 사용자별 원자적 사용량 예산과 provider 입력·timeout 경계를 추가합니다.

## Changes
- `consume_ai_usage` migration으로 인증 사용자별 일일 요청 30회·입력 150,000자 quota를 원자적으로 기록합니다.
- generate-book-review, recall-search, generate-embedding, extract-keywords, structure-notes, reading-insights, recommend-next-books의 OpenAI 경계에 사용량 검사를 연결합니다.
- 요청 입력 20,000자 제한, 구조화된 413/429/503 오류, 15초 provider timeout, 공통 회귀 테스트를 추가합니다.

## Context & Background
- Related: BOK-396
- 기존 인증·소유권 검사는 있었지만 직접 호출·동시 우회에 대한 공통 server quota/input/timeout/cost 방어가 없었습니다.

## How to Test
- `deno fmt --check` 변경 Edge 파일 14개
- 전체 Edge Function `deno check --config ...`
- `deno test --no-check` shared consent/usage tests: 39 passed
- `python3 -m unittest discover -s supabase/tests -p test_*.py`: 7 passed
- 격리 PostgreSQL에서 migration 적용 및 30회 허용·31회 quota 거부·20,001자 입력 거부 smoke

## Database Migration
- 새 migration: `20260808060422_add_ai_usage_budget.sql`
- Production DB는 변경하지 않았습니다. Dev 적용은 CI/명시적 운영 권한 경계에서 수행합니다.
- 롤백은 migration revert SQL을 별도 실행하는 방식이며, 현재 변경은 추가 테이블·함수만 포함합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards for AI-powered features, including input-size limits, usage quotas, and concurrent-request limits.
  * Added clearer responses when AI usage limits are exceeded or service capacity is unavailable.
  * AI requests now have standardized timeouts for improved reliability.
  * Recommendation profile collection now respects consent and skips collection when permission is unavailable or no completed books exist.

* **Bug Fixes**
  * Ensured usage reservations are released reliably after successful or failed AI requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->