### PR TITLE
chore(governance): allow mobile deploy workflow validation

### DIFF
--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -46,6 +46,7 @@
         ".byungskerlab/release.yaml",
         ".env.example",
         ".github/workflows/daily-nudge.yml",
+        ".github/workflows/deploy-edge-functions.yml",
         ".github/workflows/ios-production.yml",
         ".github/workflows/ios-testflight.yml",
         ".github/workflows/quality.yml",


### PR DESCRIPTION
## 목적
모바일 1.0.2의 production Edge 배포 경계를 검증하는 변경이 Target Version Contract의 모바일 경로 정책을 통과하도록 거버넌스 허용 목록을 정합화합니다.

## 변경 내용
- 모바일 delivery unit의 허용 경로에 `.github/workflows/deploy-edge-functions.yml`을 추가했습니다.
- active version과 release registry는 변경하지 않았습니다.

## 검증
- `python3 -m json.tool .byungskerlab/branch-policy.json`
- policy/registry active version 일치 확인
- `git diff --check`

## 관련 작업
- BOK-396 / REL-102-34 production Edge Function 배포 경계

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local
