### PR TITLE
chore(governance): allow shared schema validation updates

### DIFF
--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -91,6 +91,7 @@
       "production_branch": "main",
       "allowed_paths": [
         ".github/workflows/deploy-edge-functions.yml",
+        ".github/workflows/schema-check.yml",
         "docs/**",
         "supabase/**"
       ]


### PR DESCRIPTION
## 목적
BOK-396 backend waitlist migration fixture needs to run in the shared Schema Validation workflow. This governance-only change synchronizes the backend allowlist with the existing shared workflow.

## 변경
- Add `.github/workflows/schema-check.yml` to backend 1.0.2 allowed paths.
- No active versions, release registry entries, runtime code, database, or deployment behavior change.

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local

Related: BOK-396.