### PR TITLE
chore(governance): sync backend schema workflow policy

### DIFF
--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -91,6 +91,7 @@
       "production_branch": "main",
       "allowed_paths": [
         ".github/workflows/deploy-edge-functions.yml",
+        ".github/workflows/schema-check.yml",
         "docs/**",
         "supabase/**"
       ]

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,5 @@
 /.github/PULL_REQUEST_TEMPLATE.md @byungsker
 /.github/scripts/validate_target_version_pr.py @byungsker
 /.github/workflows/target-version-gate.yml @byungsker
+/.github/workflows/schema-check.yml @byungsker
 /AGENTS.md @byungsker


### PR DESCRIPTION
## 목적
BOK-396 백엔드 검증 PR이 저장소 기본 브랜치(`dev`)의 trusted Target Version Gate에서도 동일한 backend allowlist를 사용하도록 정책을 동기화합니다.

## 변경
- `.github/workflows/schema-check.yml`을 dev의 backend delivery unit 허용 경로에 추가했습니다.
- active version 목록과 release registry는 변경하지 않았습니다.

## 검증
- policy/registry active version 배열 일치 확인
- `git diff --check`

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local

관련 이슈: BOK-396
