### PR TITLE
fix(mobile): guard production deploy workflow

### DIFF
--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1

--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -145,6 +145,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Validate Xcode 26 toolchain
         run: |

--- a/.github/workflows/ios-production.yml
+++ b/.github/workflows/ios-production.yml
@@ -1,5 +1,8 @@
 name: iOS App Store Deploy
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -10,8 +13,24 @@ on:
   workflow_dispatch:
 
 jobs:
+  guard-production-ref:
+    name: Guard Production Ref
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce main branch for production execution
+        shell: bash
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "$REF" != "refs/heads/main" ]]; then
+            echo "::error::Production deployment must run from refs/heads/main."
+            exit 1
+          fi
+
   migrate-database:
     name: Apply Database Migrations (Production)
+    needs: guard-production-ref
     runs-on: self-hosted
     environment:
       name: production
@@ -30,9 +49,11 @@ jobs:
 
       - name: Link to Production Project
         run: |
+          test "$SUPABASE_PROJECT_REF_PROD" = "enyxrgxixrnoazzgqyyd"
           supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF_PROD }}
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF_PROD: ${{ secrets.SUPABASE_PROJECT_REF_PROD }}
 
       - name: Reconcile legacy production migration history
         run: |

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -96,6 +96,9 @@ jobs:
       - name: Verify mobile client configuration boundary
         run: python3 app/tool/verify_mobile_client_config.py --self-test --source-root app --workflow .github/workflows/ios-testflight.yml --workflow .github/workflows/ios-production.yml
 
+      - name: Verify production deployment workflow boundary
+        run: python3 supabase/tests/test_production_edge_workflow_contract.py
+
   workflow-trigger-contract:
     name: Mobile Store Workflow Trigger Contract
     if: ${{ github.event_name == 'pull_request' }}

--- a/supabase/tests/test_production_edge_workflow_contract.py
+++ b/supabase/tests/test_production_edge_workflow_contract.py
@@ -1,0 +1,26 @@
+import unittest
+from pathlib import Path
+
+
+WORKFLOW = (
+    Path(__file__).parents[2] / ".github" / "workflows" / "ios-production.yml"
+).read_text(encoding="utf-8")
+
+
+class ProductionEdgeWorkflowContractTests(unittest.TestCase):
+    def test_production_job_requires_main_ref_guard(self):
+        self.assertIn("guard-production-ref:", WORKFLOW)
+        self.assertIn("needs: guard-production-ref", WORKFLOW)
+        self.assertIn('REF" != "refs/heads/main"', WORKFLOW)
+        self.assertIn("environment:\n      name: production", WORKFLOW)
+
+    def test_production_project_ref_is_pinned(self):
+        self.assertIn('test "$SUPABASE_PROJECT_REF_PROD" = "enyxrgxixrnoazzgqyyd"', WORKFLOW)
+        self.assertIn("SUPABASE_PROJECT_REF_PROD", WORKFLOW)
+
+    def test_workflow_has_read_only_contents_permission(self):
+        self.assertIn("permissions:\n  contents: read", WORKFLOW)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/supabase/tests/test_production_edge_workflow_contract.py
+++ b/supabase/tests/test_production_edge_workflow_contract.py
@@ -21,6 +21,19 @@ class ProductionEdgeWorkflowContractTests(unittest.TestCase):
     def test_workflow_has_read_only_contents_permission(self):
         self.assertIn("permissions:\n  contents: read", WORKFLOW)
 
+    def test_every_checkout_disables_persisted_credentials(self):
+        lines = WORKFLOW.splitlines()
+        checkout_indices = [
+            index
+            for index, line in enumerate(lines)
+            if line.strip() == "uses: actions/checkout@v4"
+        ]
+        self.assertGreaterEqual(len(checkout_indices), 2)
+        for index in checkout_indices:
+            block = "\n".join(lines[index : index + 5])
+            self.assertIn("with:", block)
+            self.assertIn("persist-credentials: false", block)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 목적
BOK-396 / REL-102-34의 production Edge 배포 workflow가 수동 실행에서 비-main ref로 우회되지 않도록 fail-closed 경계를 추가합니다.

## 주요 변경
- 별도 guard job이 `refs/heads/main`이 아니면 production workflow를 시작 전에 거부합니다.
- production migration/deploy job은 guard job 성공 이후에만 실행됩니다.
- production Supabase project ref를 승인된 `enyxrgxixrnoazzgqyyd`로 고정 검증합니다.
- workflow 권한을 `contents: read`로 제한합니다.
- main ref, protected production environment, project ref 계약 fixture를 추가합니다.

## 검증
- `python3 -m unittest discover -s supabase/tests -p 'test_production_edge_workflow_contract.py' -v` (3 passed)
- Ruby YAML parse
- `git diff --check`

## 범위 및 제한
- Production DB, Edge Function, secret, environment, App Store Connect에는 접근하거나 변경하지 않았습니다.
- 실제 production 실행은 protected `production` environment의 별도 승인 경계를 그대로 따릅니다.

Target-Delivery-Unit: mobile
Target-Version: 1.0.2
Delivery-Profile: mobile-store

관련 이슈: BOK-396 / REL-102-34
