### PR TITLE
fix: route admin operations through server authz

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -23,6 +23,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "resend": "^6.18.0",
+        "server-only": "^0.0.1",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -7362,6 +7363,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/web/package.json
+++ b/web/package.json
@@ -6,8 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "npm run test:waitlist-security && eslint",
-    "test:waitlist-security": "node --experimental-strip-types scripts/waitlist-security.test.mts"
+    "lint": "npm run test:waitlist-security && npm run test:admin-authz && eslint",
+    "test:waitlist-security": "node --experimental-strip-types scripts/waitlist-security.test.mts",
+    "test:admin-authz": "node --experimental-strip-types scripts/admin-authz.test.mts"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -25,6 +26,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "resend": "^6.18.0",
+    "server-only": "^0.0.1",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/web/scripts/admin-authz.test.mts
+++ b/web/scripts/admin-authz.test.mts
@@ -31,4 +31,11 @@ for (const path of routes) {
   assert.ok(authIndex < serviceIndex, `${path} must establish auth before the service-role client`);
 }
 
+const templateRoute = await readFile("src/app/api/admin/push-templates/route.ts", "utf8");
+const waitlistRoute = await readFile("src/app/api/admin/waitlist/route.ts", "utf8");
+assert.equal(templateRoute.includes('rpc("admin_update_push_template"'), true);
+assert.equal(templateRoute.includes('.from("push_templates").update'), false);
+assert.equal(waitlistRoute.includes('rpc("admin_delete_waitlist_entry"'), true);
+assert.equal(waitlistRoute.includes('.from("waitlist").delete'), false);
+
 console.log("admin authz fixtures passed");

--- a/web/scripts/admin-authz.test.mts
+++ b/web/scripts/admin-authz.test.mts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const pagePaths = [
+  "src/app/admin/page.tsx",
+  "src/app/admin/announcements/page.tsx",
+  "src/app/admin/push-logs/page.tsx",
+  "src/app/admin/push-templates/page.tsx",
+  "src/app/admin/test-push/page.tsx",
+  "src/app/admin/waitlist/page.tsx",
+];
+
+for (const path of pagePaths) {
+  const source = await readFile(path, "utf8");
+  assert.equal(source.includes(".from(\""), false, `${path} must not query Supabase from the browser`);
+}
+
+const routes = [
+  "src/app/api/admin/announcements/route.ts",
+  "src/app/api/admin/push-logs/route.ts",
+  "src/app/api/admin/push-templates/route.ts",
+  "src/app/api/admin/waitlist/route.ts",
+];
+
+for (const path of routes) {
+  const source = await readFile(path, "utf8");
+  const authIndex = source.indexOf("if (!(await requireAdminUser())");
+  const serviceIndex = source.indexOf("createServiceRoleSupabaseClient()");
+  assert.notEqual(authIndex, -1, `${path} must require an admin user`);
+  assert.notEqual(serviceIndex, -1, `${path} must use the server service-role boundary`);
+  assert.ok(authIndex < serviceIndex, `${path} must establish auth before the service-role client`);
+}
+
+console.log("admin authz fixtures passed");

--- a/web/scripts/admin-authz.test.mts
+++ b/web/scripts/admin-authz.test.mts
@@ -24,18 +24,25 @@ const routes = [
 
 for (const path of routes) {
   const source = await readFile(path, "utf8");
-  const authIndex = source.indexOf("requireAdminUser");
-  const serviceIndex = source.indexOf("createServiceRoleSupabaseClient()");
-  assert.notEqual(authIndex, -1, `${path} must require an admin user`);
+  const executable = source.replace(/^import .*?;$/gm, "");
+  const authIndex = executable.indexOf("requireAdminUser");
+  const serviceIndex = executable.indexOf("createServiceRoleSupabaseClient()");
+  assert.notEqual(authIndex, -1, `${path} must invoke requireAdminUser`);
   assert.notEqual(serviceIndex, -1, `${path} must use the server service-role boundary`);
   assert.ok(authIndex < serviceIndex, `${path} must establish auth before the service-role client`);
+  assert.match(executable, /status:\s*401/);
+  assert.match(executable, /status:\s*500/);
 }
 
 const templateRoute = await readFile("src/app/api/admin/push-templates/route.ts", "utf8");
 const waitlistRoute = await readFile("src/app/api/admin/waitlist/route.ts", "utf8");
 assert.equal(templateRoute.includes('rpc("admin_update_push_template"'), true);
 assert.equal(templateRoute.includes('.from("push_templates").update'), false);
+assert.match(templateRoute, /UUID\.test\(id\)/);
+assert.match(templateRoute, /status:\s*404/);
 assert.equal(waitlistRoute.includes('rpc("admin_delete_waitlist_entry"'), true);
 assert.equal(waitlistRoute.includes('.from("waitlist").delete'), false);
+assert.match(waitlistRoute, /UUID\.test\(id\)/);
+assert.match(waitlistRoute, /status:\s*404/);
 
 console.log("admin authz fixtures passed");

--- a/web/scripts/admin-authz.test.mts
+++ b/web/scripts/admin-authz.test.mts
@@ -24,7 +24,7 @@ const routes = [
 
 for (const path of routes) {
   const source = await readFile(path, "utf8");
-  const authIndex = source.indexOf("if (!(await requireAdminUser())");
+  const authIndex = Math.max(source.indexOf("if (!(await requireAdminUser())"), source.indexOf("const admin = await requireAdminUser()"));
   const serviceIndex = source.indexOf("createServiceRoleSupabaseClient()");
   assert.notEqual(authIndex, -1, `${path} must require an admin user`);
   assert.notEqual(serviceIndex, -1, `${path} must use the server service-role boundary`);

--- a/web/scripts/admin-authz.test.mts
+++ b/web/scripts/admin-authz.test.mts
@@ -24,7 +24,7 @@ const routes = [
 
 for (const path of routes) {
   const source = await readFile(path, "utf8");
-  const authIndex = Math.max(source.indexOf("if (!(await requireAdminUser())"), source.indexOf("const admin = await requireAdminUser()"));
+  const authIndex = source.indexOf("requireAdminUser");
   const serviceIndex = source.indexOf("createServiceRoleSupabaseClient()");
   assert.notEqual(authIndex, -1, `${path} must require an admin user`);
   assert.notEqual(serviceIndex, -1, `${path} must use the server service-role boundary`);

--- a/web/src/app/admin/announcements/page.tsx
+++ b/web/src/app/admin/announcements/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
-import { supabase } from "@/lib/supabase";
 import type { PushAnnouncement } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import {
@@ -36,12 +35,9 @@ export default function AnnouncementsPage() {
   const [loading, setLoading] = useState(true);
 
   const loadAnnouncements = useCallback(async () => {
-    const { data } = await supabase
-      .from("push_announcements")
-      .select("*")
-      .order("created_at", { ascending: false })
-      .limit(50);
-    setAnnouncements(data || []);
+    const response = await fetch("/api/admin/announcements");
+    const data = await response.json();
+    setAnnouncements(response.ok ? data.announcements || [] : []);
     setLoading(false);
   }, []);
 

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { supabase, PushLog } from "@/lib/supabase";
+import type { PushLog } from "@/lib/supabase";
 
 type DashboardStats = {
   todaySent: number;
@@ -39,12 +39,10 @@ export default function AdminDashboard() {
 
   async function fetchDashboardData() {
     try {
-      const today = new Date().toISOString().split("T")[0];
-
-      const { data: todayLogs } = await supabase
-        .from("push_logs")
-        .select("*")
-        .gte("sent_at", today);
+      const response = await fetch("/api/admin/push-logs?dashboard=1");
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || "Failed to fetch dashboard logs");
+      const todayLogs = data.todayLogs as PushLog[];
 
       if (todayLogs) {
         const sent = todayLogs.length;
@@ -78,15 +76,7 @@ export default function AdminDashboard() {
         );
       }
 
-      const { data: recent } = await supabase
-        .from("push_logs")
-        .select("*")
-        .order("sent_at", { ascending: false })
-        .limit(10);
-
-      if (recent) {
-        setRecentLogs(recent);
-      }
+      setRecentLogs((data.recentLogs || []) as PushLog[]);
     } catch (error) {
       console.error("Failed to fetch dashboard data:", error);
     } finally {

--- a/web/src/app/admin/push-logs/page.tsx
+++ b/web/src/app/admin/push-logs/page.tsx
@@ -19,7 +19,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { supabase, PushLog } from "@/lib/supabase";
+import type { PushLog } from "@/lib/supabase";
 
 const PUSH_TYPES = [
   { value: "all", label: "전체" },
@@ -31,8 +31,6 @@ const PUSH_TYPES = [
   { value: "announcement", label: "Announcement" },
   { value: "test", label: "Test" },
 ];
-
-const PAGE_SIZE = 20;
 
 export default function PushLogsPage() {
   const [logs, setLogs] = useState<PushLog[]>([]);
@@ -65,22 +63,12 @@ export default function PushLogsPage() {
   const fetchLogs = useCallback(async () => {
     try {
       setLoading(true);
-      let query = supabase
-        .from("push_logs")
-        .select("*")
-        .order("sent_at", { ascending: false })
-        .range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1);
-
-      if (typeFilter !== "all") {
-        query = query.eq("push_type", typeFilter);
-      }
-
-      const { data, error } = await query;
-
-      if (error) throw error;
-
-      setLogs(data || []);
-      setHasMore((data?.length || 0) === PAGE_SIZE);
+      const params = new URLSearchParams({ page: String(page), type: typeFilter });
+      const response = await fetch(`/api/admin/push-logs?${params}`);
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || "Failed to fetch logs");
+      setLogs(data.logs || []);
+      setHasMore(Boolean(data.hasMore));
     } catch (error) {
       console.error("Failed to fetch logs:", error);
     } finally {

--- a/web/src/app/admin/push-templates/page.tsx
+++ b/web/src/app/admin/push-templates/page.tsx
@@ -22,7 +22,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { supabase, PushTemplate } from "@/lib/supabase";
+import type { PushTemplate } from "@/lib/supabase";
 
 export default function PushTemplatesPage() {
   const [templates, setTemplates] = useState<PushTemplate[]>([]);
@@ -38,13 +38,10 @@ export default function PushTemplatesPage() {
 
   async function fetchTemplates() {
     try {
-      const { data, error } = await supabase
-        .from("push_templates")
-        .select("*")
-        .order("priority", { ascending: true });
-
-      if (error) throw error;
-      setTemplates(data || []);
+      const response = await fetch("/api/admin/push-templates");
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || "Failed to fetch templates");
+      setTemplates(data.templates || []);
     } catch (error) {
       console.error("Failed to fetch templates:", error);
     } finally {
@@ -56,9 +53,11 @@ export default function PushTemplatesPage() {
     if (!editingTemplate) return;
 
     try {
-      const { error } = await supabase
-        .from("push_templates")
-        .update({
+      const response = await fetch("/api/admin/push-templates", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: editingTemplate.id,
           name: editingTemplate.name,
           title: editingTemplate.title,
           body_template: editingTemplate.body_template,
@@ -66,10 +65,9 @@ export default function PushTemplatesPage() {
           body_template_en: editingTemplate.body_template_en,
           is_active: editingTemplate.is_active,
           priority: editingTemplate.priority,
-        })
-        .eq("id", editingTemplate.id);
-
-      if (error) throw error;
+        }),
+      });
+      if (!response.ok) throw new Error("Failed to update template");
 
       setIsDialogOpen(false);
       fetchTemplates();
@@ -81,12 +79,12 @@ export default function PushTemplatesPage() {
 
   async function toggleActive(template: PushTemplate) {
     try {
-      const { error } = await supabase
-        .from("push_templates")
-        .update({ is_active: !template.is_active })
-        .eq("id", template.id);
-
-      if (error) throw error;
+      const response = await fetch("/api/admin/push-templates", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: template.id, is_active: !template.is_active }),
+      });
+      if (!response.ok) throw new Error("Failed to update template");
       fetchTemplates();
     } catch (error) {
       console.error("Failed to toggle active:", error);

--- a/web/src/app/admin/test-push/page.tsx
+++ b/web/src/app/admin/test-push/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react";
 import Image from "next/image";
-import { supabase } from "@/lib/supabase";
 import type { PushTemplate } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -51,17 +50,9 @@ export default function TestPushPage() {
   async function fetchData() {
     setLoading(true);
 
-    const { data: templatesData, error: templatesError } = await supabase
-      .from("push_templates")
-      .select("*")
-      .eq("is_active", true)
-      .order("priority");
-
-    console.log("Templates:", templatesData, templatesError);
-
-    if (templatesData) {
-      setTemplates(templatesData);
-    }
+    const templatesResponse = await fetch("/api/admin/push-templates");
+    const templatesData = await templatesResponse.json();
+    if (templatesResponse.ok) setTemplates((templatesData.templates || []).filter((template: PushTemplate) => template.is_active));
 
     try {
       const response = await fetch("/api/admin/fcm-tokens");

--- a/web/src/app/admin/waitlist/page.tsx
+++ b/web/src/app/admin/waitlist/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { supabase } from "@/lib/supabase";
 import { csvEscape } from "@/lib/csv";
 import { Button } from "@/components/ui/button";
 import {
@@ -53,17 +52,13 @@ export default function WaitlistAdminPage() {
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
-    const { data, error: fetchError } = await supabase
-      .from("waitlist")
-      .select("id, email, locale, source, created_at")
-      .order("created_at", { ascending: false })
-      .limit(1000);
-
-    if (fetchError) {
-      setError(fetchError.message);
+    const response = await fetch("/api/admin/waitlist");
+    const data = await response.json();
+    if (!response.ok) {
+      setError(data.error || "명단을 불러오지 못했습니다.");
       setEntries([]);
     } else {
-      setEntries((data ?? []) as WaitlistEntry[]);
+      setEntries((data.entries ?? []) as WaitlistEntry[]);
     }
     setLoading(false);
   }, []);
@@ -107,13 +102,15 @@ export default function WaitlistAdminPage() {
   async function handleDelete(id: string, email: string) {
     if (!confirm(`${email} 을(를) 명단에서 삭제할까요?`)) return;
     setDeletingId(id);
-    const { error: deleteError } = await supabase
-      .from("waitlist")
-      .delete()
-      .eq("id", id);
+    const response = await fetch("/api/admin/waitlist", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
     setDeletingId(null);
-    if (deleteError) {
-      alert("삭제 실패: " + deleteError.message);
+    if (!response.ok) {
+      const data = await response.json();
+      alert("삭제 실패: " + (data.error || "알 수 없는 오류"));
       return;
     }
     setEntries((prev) => prev.filter((entry) => entry.id !== id));

--- a/web/src/app/api/admin/announcements/route.ts
+++ b/web/src/app/api/admin/announcements/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { createServiceRoleSupabaseClient, requireAdminUser } from "@/lib/supabase-server";
+
+export async function GET() {
+  if (!(await requireAdminUser())) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { data, error } = await createServiceRoleSupabaseClient()
+    .from("push_announcements")
+    .select("*")
+    .order("created_at", { ascending: false })
+    .limit(50);
+  if (error) return NextResponse.json({ error: "Failed to load announcements" }, { status: 500 });
+  return NextResponse.json({ announcements: data ?? [] });
+}

--- a/web/src/app/api/admin/push-logs/route.ts
+++ b/web/src/app/api/admin/push-logs/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceRoleSupabaseClient, requireAdminUser } from "@/lib/supabase-server";
+
+const PAGE_SIZE = 20;
+
+export async function GET(request: NextRequest) {
+  if (!(await requireAdminUser())) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (request.nextUrl.searchParams.get("dashboard") === "1") {
+    const today = new Date().toISOString().split("T")[0];
+    const client = createServiceRoleSupabaseClient();
+    const [todayResult, recentResult] = await Promise.all([
+      client.from("push_logs").select("*").gte("sent_at", today),
+      client.from("push_logs").select("*").order("sent_at", { ascending: false }).limit(10),
+    ]);
+    if (todayResult.error || recentResult.error) return NextResponse.json({ error: "Failed to load dashboard logs" }, { status: 500 });
+    return NextResponse.json({ todayLogs: todayResult.data ?? [], recentLogs: recentResult.data ?? [] });
+  }
+  const page = Math.max(0, Number(request.nextUrl.searchParams.get("page") ?? "0") || 0);
+  const type = request.nextUrl.searchParams.get("type") ?? "all";
+  let query = createServiceRoleSupabaseClient()
+    .from("push_logs")
+    .select("*")
+    .order("sent_at", { ascending: false });
+  if (type !== "all") query = query.eq("push_type", type);
+  const { data, error } = await query.range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1);
+  if (error) return NextResponse.json({ error: "Failed to load logs" }, { status: 500 });
+  return NextResponse.json({ logs: data ?? [], hasMore: (data?.length ?? 0) === PAGE_SIZE });
+}

--- a/web/src/app/api/admin/push-templates/route.ts
+++ b/web/src/app/api/admin/push-templates/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceRoleSupabaseClient, requireAdminUser } from "@/lib/supabase-server";
+
+const EDITABLE_FIELDS = [
+  "name",
+  "title",
+  "body_template",
+  "title_en",
+  "body_template_en",
+  "is_active",
+  "priority",
+] as const;
+
+export async function GET() {
+  if (!(await requireAdminUser())) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { data, error } = await createServiceRoleSupabaseClient()
+    .from("push_templates")
+    .select("*")
+    .order("priority", { ascending: true });
+  if (error) return NextResponse.json({ error: "Failed to load templates" }, { status: 500 });
+  return NextResponse.json({ templates: data ?? [] });
+}
+
+export async function PATCH(request: NextRequest) {
+  if (!(await requireAdminUser())) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const body = await request.json().catch(() => null);
+  const id = typeof body?.id === "string" ? body.id : "";
+  if (!id) return NextResponse.json({ error: "Invalid template" }, { status: 400 });
+  const updates = Object.fromEntries(
+    EDITABLE_FIELDS.filter((field) => Object.prototype.hasOwnProperty.call(body, field)).map((field) => [field, body[field]])
+  );
+  if (Object.keys(updates).length === 0) return NextResponse.json({ error: "No changes" }, { status: 400 });
+  const { error } = await createServiceRoleSupabaseClient().from("push_templates").update(updates).eq("id", id);
+  if (error) return NextResponse.json({ error: "Failed to update template" }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/web/src/app/api/admin/push-templates/route.ts
+++ b/web/src/app/api/admin/push-templates/route.ts
@@ -10,6 +10,11 @@ const EDITABLE_FIELDS = [
   "is_active",
   "priority",
 ] as const;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function validText(value: unknown, max: number, nullable = false): boolean {
+  return (nullable && value === null) || (typeof value === "string" && value.length <= max);
+}
 
 export async function GET() {
   if (!(await requireAdminUser())) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -22,15 +27,28 @@ export async function GET() {
 }
 
 export async function PATCH(request: NextRequest) {
-  if (!(await requireAdminUser())) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const admin = await requireAdminUser();
+  if (!admin) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const body = await request.json().catch(() => null);
   const id = typeof body?.id === "string" ? body.id : "";
-  if (!id) return NextResponse.json({ error: "Invalid template" }, { status: 400 });
+  if (!UUID.test(id)) return NextResponse.json({ error: "Invalid template" }, { status: 400 });
+  const unknown = Object.keys(body ?? {}).filter((key) => key !== "id" && !EDITABLE_FIELDS.includes(key as (typeof EDITABLE_FIELDS)[number]));
+  if (unknown.length > 0) return NextResponse.json({ error: "Unknown template fields" }, { status: 400 });
   const updates = Object.fromEntries(
     EDITABLE_FIELDS.filter((field) => Object.prototype.hasOwnProperty.call(body, field)).map((field) => [field, body[field]])
   );
   if (Object.keys(updates).length === 0) return NextResponse.json({ error: "No changes" }, { status: 400 });
-  const { error } = await createServiceRoleSupabaseClient().from("push_templates").update(updates).eq("id", id);
+  if ("name" in updates && !validText(updates.name, 120, true)) return NextResponse.json({ error: "Invalid name" }, { status: 400 });
+  if ("title" in updates && !validText(updates.title, 120)) return NextResponse.json({ error: "Invalid title" }, { status: 400 });
+  if ("body_template" in updates && !validText(updates.body_template, 1000)) return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  if ("title_en" in updates && !validText(updates.title_en, 120, true)) return NextResponse.json({ error: "Invalid English title" }, { status: 400 });
+  if ("body_template_en" in updates && !validText(updates.body_template_en, 1000, true)) return NextResponse.json({ error: "Invalid English body" }, { status: 400 });
+  if ("is_active" in updates && typeof updates.is_active !== "boolean") return NextResponse.json({ error: "Invalid active state" }, { status: 400 });
+  if ("priority" in updates && (!Number.isInteger(updates.priority) || updates.priority < 0 || updates.priority > 10000)) return NextResponse.json({ error: "Invalid priority" }, { status: 400 });
+  const client = createServiceRoleSupabaseClient();
+  const { data, error } = await client.from("push_templates").update(updates).eq("id", id).select("id").maybeSingle();
   if (error) return NextResponse.json({ error: "Failed to update template" }, { status: 500 });
+  if (!data) return NextResponse.json({ error: "Template not found" }, { status: 404 });
+  await client.from("admin_audit_events").insert({ actor_id: admin.id, action: "push_template.update", resource_type: "push_template", resource_id: id, metadata: { fields: Object.keys(updates) } });
   return NextResponse.json({ ok: true });
 }

--- a/web/src/app/api/admin/push-templates/route.ts
+++ b/web/src/app/api/admin/push-templates/route.ts
@@ -46,9 +46,12 @@ export async function PATCH(request: NextRequest) {
   if ("is_active" in updates && typeof updates.is_active !== "boolean") return NextResponse.json({ error: "Invalid active state" }, { status: 400 });
   if ("priority" in updates && (!Number.isInteger(updates.priority) || updates.priority < 0 || updates.priority > 10000)) return NextResponse.json({ error: "Invalid priority" }, { status: 400 });
   const client = createServiceRoleSupabaseClient();
-  const { data, error } = await client.from("push_templates").update(updates).eq("id", id).select("id").maybeSingle();
+  const { data, error } = await client.rpc("admin_update_push_template", {
+    p_actor_id: admin.id,
+    p_template_id: id,
+    p_changes: updates,
+  });
   if (error) return NextResponse.json({ error: "Failed to update template" }, { status: 500 });
   if (!data) return NextResponse.json({ error: "Template not found" }, { status: 404 });
-  await client.from("admin_audit_events").insert({ actor_id: admin.id, action: "push_template.update", resource_type: "push_template", resource_id: id, metadata: { fields: Object.keys(updates) } });
   return NextResponse.json({ ok: true });
 }

--- a/web/src/app/api/admin/waitlist/route.ts
+++ b/web/src/app/api/admin/waitlist/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServiceRoleSupabaseClient, requireAdminUser } from "@/lib/supabase-server";
 
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export async function GET() {
   if (!(await requireAdminUser())) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const { data, error } = await createServiceRoleSupabaseClient()
@@ -13,11 +15,15 @@ export async function GET() {
 }
 
 export async function DELETE(request: NextRequest) {
-  if (!(await requireAdminUser())) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const admin = await requireAdminUser();
+  if (!admin) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const body = await request.json().catch(() => null);
   const id = typeof body?.id === "string" ? body.id : "";
-  if (!id) return NextResponse.json({ error: "Invalid entry" }, { status: 400 });
-  const { error } = await createServiceRoleSupabaseClient().from("waitlist").delete().eq("id", id);
+  if (!UUID.test(id)) return NextResponse.json({ error: "Invalid entry" }, { status: 400 });
+  const client = createServiceRoleSupabaseClient();
+  const { data, error } = await client.from("waitlist").delete().eq("id", id).select("id").maybeSingle();
   if (error) return NextResponse.json({ error: "Failed to delete waitlist entry" }, { status: 500 });
+  if (!data) return NextResponse.json({ error: "Waitlist entry not found" }, { status: 404 });
+  await client.from("admin_audit_events").insert({ actor_id: admin.id, action: "waitlist.delete", resource_type: "waitlist", resource_id: id, metadata: { reason: "admin_requested" } });
   return NextResponse.json({ ok: true });
 }

--- a/web/src/app/api/admin/waitlist/route.ts
+++ b/web/src/app/api/admin/waitlist/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceRoleSupabaseClient, requireAdminUser } from "@/lib/supabase-server";
+
+export async function GET() {
+  if (!(await requireAdminUser())) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { data, error } = await createServiceRoleSupabaseClient()
+    .from("waitlist")
+    .select("id, email, locale, source, created_at")
+    .order("created_at", { ascending: false })
+    .limit(1000);
+  if (error) return NextResponse.json({ error: "Failed to load waitlist" }, { status: 500 });
+  return NextResponse.json({ entries: data ?? [] });
+}
+
+export async function DELETE(request: NextRequest) {
+  if (!(await requireAdminUser())) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const body = await request.json().catch(() => null);
+  const id = typeof body?.id === "string" ? body.id : "";
+  if (!id) return NextResponse.json({ error: "Invalid entry" }, { status: 400 });
+  const { error } = await createServiceRoleSupabaseClient().from("waitlist").delete().eq("id", id);
+  if (error) return NextResponse.json({ error: "Failed to delete waitlist entry" }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/web/src/app/api/admin/waitlist/route.ts
+++ b/web/src/app/api/admin/waitlist/route.ts
@@ -21,9 +21,11 @@ export async function DELETE(request: NextRequest) {
   const id = typeof body?.id === "string" ? body.id : "";
   if (!UUID.test(id)) return NextResponse.json({ error: "Invalid entry" }, { status: 400 });
   const client = createServiceRoleSupabaseClient();
-  const { data, error } = await client.from("waitlist").delete().eq("id", id).select("id").maybeSingle();
+  const { data, error } = await client.rpc("admin_delete_waitlist_entry", {
+    p_actor_id: admin.id,
+    p_entry_id: id,
+  });
   if (error) return NextResponse.json({ error: "Failed to delete waitlist entry" }, { status: 500 });
   if (!data) return NextResponse.json({ error: "Waitlist entry not found" }, { status: 404 });
-  await client.from("admin_audit_events").insert({ actor_id: admin.id, action: "waitlist.delete", resource_type: "waitlist", resource_id: id, metadata: { reason: "admin_requested" } });
   return NextResponse.json({ ok: true });
 }

--- a/web/src/lib/supabase-server.ts
+++ b/web/src/lib/supabase-server.ts
@@ -1,4 +1,7 @@
+import "server-only";
+
 import { createServerClient } from "@supabase/ssr";
+import { createClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 import { isAdminEmail } from "@/lib/admin-auth";
 
@@ -34,4 +37,13 @@ export async function requireAdminUser() {
 
   if (error || !user || !isAdminEmail(user.email)) return null;
   return user;
+}
+
+export function createServiceRoleSupabaseClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+  if (!url || !key) throw new Error("Supabase service role configuration is missing");
+  return createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
 }


### PR DESCRIPTION
## 목적

BOK-396의 관리자 push/template 조회·수정과 운영 데이터 조회가 브라우저 anon client/RLS에 의존해 비관리자에게 읽기 경로를 노출하고, 관리자 화면이 전체 운영 데이터를 안정적으로 얻지 못하던 문제를 해결합니다.

## 변경 내용

- push template GET/PATCH, push logs/dashboard, announcements, waitlist GET/DELETE server API 추가
- 모든 API가 `requireAdminUser()`를 먼저 통과한 뒤 세션 없는 service-role client를 사용
- 관리자 페이지와 test-push가 직접 Supabase table query를 하지 않고 API만 호출
- waitlist API는 `user_agent`를 반환하지 않음
- template PATCH와 waitlist DELETE는 strict input validation, matched-row 404, service-role atomic RPC 호출을 사용
- admin authz regression fixture와 trusted Web lint 선행 실행 연결

## 검증

- npm ci (0 vulnerabilities)
- npm run test:waitlist-security 통과
- npm run test:admin-authz 통과
- npm run lint 통과
- npm run build 통과
- git diff --check 통과

## 범위 및 롤아웃 순서

1. PR #363의 audit/RPC prerequisite를 먼저 적용합니다.
2. 이 PR의 Web API와 관리자 화면을 배포합니다.
3. 별도 후속 revoke-only migration에서 `push_templates`/`push_announcements` direct-read privileges를 차단합니다.
4. 관리자 화면에서 API 경로와 direct-read 폐기를 확인합니다.

후속 revoke migration 전에는 기존 authenticated RLS direct-read 경로가 남으므로, 이 PR만으로 REL-102-40 완료로 간주하지 않습니다.

## 잔여 위험

- send-fcm-push Edge Function의 일반 authenticated self-send 정책과 `users.role` 기반 authority 통합은 별도 follow-up입니다.
- production data, push send, secret, deployment는 실행하지 않았습니다.

## 관련 이슈

- BOK-396 / REL-102-40

Target-Delivery-Unit: web
Target-Version: 1.0.2
Delivery-Profile: web-release-train
