### PR TITLE
fix: close admin table read boundary

### DIFF
--- a/.github/workflows/schema-check.yml
+++ b/.github/workflows/schema-check.yml
@@ -195,6 +195,7 @@ jobs:
           DB_URL="postgresql://postgres:postgres@127.0.0.1:54322/postgres"
           pg_isready --dbname="$DB_URL"
           psql "$DB_URL" --set ON_ERROR_STOP=1 --file supabase/tests/waitlist_abuse_guards.sql
+          psql "$DB_URL" --set ON_ERROR_STOP=1 --file supabase/tests/admin_authz.sql
 
       - name: Stop local database
         if: always()

--- a/supabase/migrations/20260809045801_restrict_admin_operational_tables.sql
+++ b/supabase/migrations/20260809045801_restrict_admin_operational_tables.sql
@@ -1,16 +1,165 @@
 create table if not exists public.admin_audit_events (
   id uuid primary key default gen_random_uuid(),
-  actor_id uuid not null references auth.users(id) on delete restrict,
+  actor_id uuid references auth.users(id) on delete set null,
   action text not null check (action in ('waitlist.delete', 'push_template.update')),
-  resource_type text not null,
+  resource_type text not null check (
+    (action = 'waitlist.delete' and resource_type = 'waitlist')
+    or (action = 'push_template.update' and resource_type = 'push_template')
+  ),
   resource_id uuid not null,
-  metadata jsonb not null default '{}'::jsonb,
+  metadata jsonb not null default '{}'::jsonb check (
+    jsonb_typeof(metadata) = 'object' and length(metadata::text) <= 2048
+  ),
   created_at timestamptz not null default now()
 );
 
 alter table public.admin_audit_events enable row level security;
-revoke all on table public.admin_audit_events from public, anon, authenticated;
-grant all on table public.admin_audit_events to service_role;
+revoke all on table public.admin_audit_events from public, anon, authenticated, service_role;
+
+create or replace function public.prevent_admin_audit_event_mutation()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  raise exception 'admin audit events are append-only';
+end;
+$$;
+
+revoke all on function public.prevent_admin_audit_event_mutation() from public, anon, authenticated, service_role;
+
+drop trigger if exists admin_audit_events_append_only on public.admin_audit_events;
+create trigger admin_audit_events_append_only
+before update or delete on public.admin_audit_events
+for each row execute function public.prevent_admin_audit_event_mutation();
+
+create or replace function public.cleanup_admin_audit_events()
+returns integer
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  deleted_count integer;
+begin
+  -- safe-delete
+  delete from public.admin_audit_events
+   where created_at < pg_catalog.now() - pg_catalog.make_interval(years => 2);
+  get diagnostics deleted_count = row_count;
+  return deleted_count;
+end;
+$$;
+
+revoke all on function public.cleanup_admin_audit_events() from public, anon, authenticated;
+grant execute on function public.cleanup_admin_audit_events() to service_role;
+
+create or replace function public.admin_update_push_template(
+  p_actor_id uuid,
+  p_template_id uuid,
+  p_changes jsonb
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  changed_id uuid;
+begin
+  if p_changes is null or pg_catalog.jsonb_typeof(p_changes) <> 'object' or p_changes = '{}'::jsonb then
+    raise exception 'invalid template changes';
+  end if;
+  if not exists (select 1 from auth.users where id = p_actor_id) then
+    raise exception 'invalid audit actor';
+  end if;
+  if exists (
+    select 1 from pg_catalog.jsonb_object_keys(p_changes) as field_name
+    where field_name not in ('name', 'title', 'body_template', 'title_en', 'body_template_en', 'is_active', 'priority')
+  ) then
+    raise exception 'unknown template field';
+  end if;
+  if p_changes ? 'name' and pg_catalog.jsonb_typeof(p_changes->'name') not in ('string', 'null') then
+    raise exception 'invalid template name';
+  end if;
+  if p_changes ? 'title' and (pg_catalog.jsonb_typeof(p_changes->'title') <> 'string' or pg_catalog.length(p_changes->>'title') > 120) then
+    raise exception 'invalid template title';
+  end if;
+  if p_changes ? 'body_template' and (pg_catalog.jsonb_typeof(p_changes->'body_template') <> 'string' or pg_catalog.length(p_changes->>'body_template') > 1000) then
+    raise exception 'invalid template body';
+  end if;
+  if p_changes ? 'title_en' and pg_catalog.jsonb_typeof(p_changes->'title_en') not in ('string', 'null') then
+    raise exception 'invalid English title';
+  end if;
+  if p_changes ? 'body_template_en' and pg_catalog.jsonb_typeof(p_changes->'body_template_en') not in ('string', 'null') then
+    raise exception 'invalid English body';
+  end if;
+  if p_changes ? 'is_active' and pg_catalog.jsonb_typeof(p_changes->'is_active') <> 'boolean' then
+    raise exception 'invalid active state';
+  end if;
+  if p_changes ? 'priority' and (pg_catalog.jsonb_typeof(p_changes->'priority') <> 'number' or (p_changes->>'priority')::integer < 0 or (p_changes->>'priority')::integer > 10000) then
+    raise exception 'invalid priority';
+  end if;
+
+  update public.push_templates
+     set name = case when p_changes ? 'name' then p_changes->>'name' else name end,
+         title = case when p_changes ? 'title' then p_changes->>'title' else title end,
+         body_template = case when p_changes ? 'body_template' then p_changes->>'body_template' else body_template end,
+         title_en = case when p_changes ? 'title_en' then p_changes->>'title_en' else title_en end,
+         body_template_en = case when p_changes ? 'body_template_en' then p_changes->>'body_template_en' else body_template_en end,
+         is_active = case when p_changes ? 'is_active' then (p_changes->>'is_active')::boolean else is_active end,
+         priority = case when p_changes ? 'priority' then (p_changes->>'priority')::integer else priority end
+   where id = p_template_id
+   returning id into changed_id;
+
+  if changed_id is null then
+    return null;
+  end if;
+
+  insert into public.admin_audit_events (actor_id, action, resource_type, resource_id, metadata)
+  values (
+    p_actor_id,
+    'push_template.update',
+    'push_template',
+    changed_id,
+    pg_catalog.jsonb_build_object('fields', (select pg_catalog.jsonb_agg(field_name order by field_name) from pg_catalog.jsonb_object_keys(p_changes) as field_name))
+  );
+  return changed_id;
+end;
+$$;
+
+revoke all on function public.admin_update_push_template(uuid, uuid, jsonb) from public, anon, authenticated;
+grant execute on function public.admin_update_push_template(uuid, uuid, jsonb) to service_role;
+
+create or replace function public.admin_delete_waitlist_entry(
+  p_actor_id uuid,
+  p_entry_id uuid
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  deleted_id uuid;
+begin
+  if not exists (select 1 from auth.users where id = p_actor_id) then
+    raise exception 'invalid audit actor';
+  end if;
+  delete from public.waitlist
+   where id = p_entry_id
+   returning id into deleted_id;
+  if deleted_id is null then
+    return null;
+  end if;
+  insert into public.admin_audit_events (actor_id, action, resource_type, resource_id, metadata)
+  values (p_actor_id, 'waitlist.delete', 'waitlist', deleted_id, '{"reason":"admin_requested"}'::jsonb);
+  return deleted_id;
+end;
+$$;
+
+revoke all on function public.admin_delete_waitlist_entry(uuid, uuid) from public, anon, authenticated;
+grant execute on function public.admin_delete_waitlist_entry(uuid, uuid) to service_role;
 
 revoke all on table public.push_templates from anon, authenticated;
 revoke all on table public.push_announcements from anon, authenticated;

--- a/supabase/migrations/20260809045801_restrict_admin_operational_tables.sql
+++ b/supabase/migrations/20260809045801_restrict_admin_operational_tables.sql
@@ -24,7 +24,10 @@ security definer
 set search_path = ''
 as $$
 begin
-  if pg_catalog.current_setting('app.admin_audit_cleanup', true) <> 'true' then
+  if tg_op = 'UPDATE' then
+    raise exception 'admin audit events are append-only';
+  end if;
+  if old.created_at >= pg_catalog.now() - pg_catalog.make_interval(years => 2) then
     raise exception 'admin audit events are append-only';
   end if;
   return old;
@@ -47,7 +50,6 @@ as $$
 declare
   deleted_count integer;
 begin
-  perform pg_catalog.set_config('app.admin_audit_cleanup', 'true', true);
   -- safe-delete
   delete from public.admin_audit_events
    where created_at < pg_catalog.now() - pg_catalog.make_interval(years => 2);

--- a/supabase/migrations/20260809045801_restrict_admin_operational_tables.sql
+++ b/supabase/migrations/20260809045801_restrict_admin_operational_tables.sql
@@ -1,6 +1,6 @@
 create table if not exists public.admin_audit_events (
   id uuid primary key default gen_random_uuid(),
-  actor_id uuid references auth.users(id) on delete set null,
+  actor_id uuid,
   action text not null check (action in ('waitlist.delete', 'push_template.update')),
   resource_type text not null check (
     (action = 'waitlist.delete' and resource_type = 'waitlist')

--- a/supabase/migrations/20260809045801_restrict_admin_operational_tables.sql
+++ b/supabase/migrations/20260809045801_restrict_admin_operational_tables.sql
@@ -15,6 +15,7 @@ create table if not exists public.admin_audit_events (
 
 alter table public.admin_audit_events enable row level security;
 revoke all on table public.admin_audit_events from public, anon, authenticated, service_role;
+create index if not exists admin_audit_events_created_at_idx on public.admin_audit_events (created_at);
 
 create or replace function public.prevent_admin_audit_event_mutation()
 returns trigger
@@ -23,7 +24,10 @@ security definer
 set search_path = ''
 as $$
 begin
-  raise exception 'admin audit events are append-only';
+  if pg_catalog.current_setting('app.admin_audit_cleanup', true) <> 'true' then
+    raise exception 'admin audit events are append-only';
+  end if;
+  return old;
 end;
 $$;
 
@@ -43,6 +47,7 @@ as $$
 declare
   deleted_count integer;
 begin
+  perform pg_catalog.set_config('app.admin_audit_cleanup', 'true', true);
   -- safe-delete
   delete from public.admin_audit_events
    where created_at < pg_catalog.now() - pg_catalog.make_interval(years => 2);
@@ -79,7 +84,7 @@ begin
   ) then
     raise exception 'unknown template field';
   end if;
-  if p_changes ? 'name' and pg_catalog.jsonb_typeof(p_changes->'name') not in ('string', 'null') then
+  if p_changes ? 'name' and (pg_catalog.jsonb_typeof(p_changes->'name') not in ('string', 'null') or pg_catalog.length(p_changes->>'name') > 120) then
     raise exception 'invalid template name';
   end if;
   if p_changes ? 'title' and (pg_catalog.jsonb_typeof(p_changes->'title') <> 'string' or pg_catalog.length(p_changes->>'title') > 120) then
@@ -88,10 +93,10 @@ begin
   if p_changes ? 'body_template' and (pg_catalog.jsonb_typeof(p_changes->'body_template') <> 'string' or pg_catalog.length(p_changes->>'body_template') > 1000) then
     raise exception 'invalid template body';
   end if;
-  if p_changes ? 'title_en' and pg_catalog.jsonb_typeof(p_changes->'title_en') not in ('string', 'null') then
+  if p_changes ? 'title_en' and (pg_catalog.jsonb_typeof(p_changes->'title_en') not in ('string', 'null') or pg_catalog.length(p_changes->>'title_en') > 120) then
     raise exception 'invalid English title';
   end if;
-  if p_changes ? 'body_template_en' and pg_catalog.jsonb_typeof(p_changes->'body_template_en') not in ('string', 'null') then
+  if p_changes ? 'body_template_en' and (pg_catalog.jsonb_typeof(p_changes->'body_template_en') not in ('string', 'null') or pg_catalog.length(p_changes->>'body_template_en') > 1000) then
     raise exception 'invalid English body';
   end if;
   if p_changes ? 'is_active' and pg_catalog.jsonb_typeof(p_changes->'is_active') <> 'boolean' then
@@ -160,6 +165,3 @@ $$;
 
 revoke all on function public.admin_delete_waitlist_entry(uuid, uuid) from public, anon, authenticated;
 grant execute on function public.admin_delete_waitlist_entry(uuid, uuid) to service_role;
-
-revoke all on table public.push_templates from anon, authenticated;
-revoke all on table public.push_announcements from anon, authenticated;

--- a/supabase/migrations/20260809045801_restrict_admin_operational_tables.sql
+++ b/supabase/migrations/20260809045801_restrict_admin_operational_tables.sql
@@ -1,0 +1,16 @@
+create table if not exists public.admin_audit_events (
+  id uuid primary key default gen_random_uuid(),
+  actor_id uuid not null references auth.users(id) on delete restrict,
+  action text not null check (action in ('waitlist.delete', 'push_template.update')),
+  resource_type text not null,
+  resource_id uuid not null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+alter table public.admin_audit_events enable row level security;
+revoke all on table public.admin_audit_events from public, anon, authenticated;
+grant all on table public.admin_audit_events to service_role;
+
+revoke all on table public.push_templates from anon, authenticated;
+revoke all on table public.push_announcements from anon, authenticated;

--- a/supabase/migrations/20260809045801_restrict_admin_operational_tables.sql
+++ b/supabase/migrations/20260809045801_restrict_admin_operational_tables.sql
@@ -116,7 +116,8 @@ begin
          title_en = case when p_changes ? 'title_en' then p_changes->>'title_en' else title_en end,
          body_template_en = case when p_changes ? 'body_template_en' then p_changes->>'body_template_en' else body_template_en end,
          is_active = case when p_changes ? 'is_active' then (p_changes->>'is_active')::boolean else is_active end,
-         priority = case when p_changes ? 'priority' then (p_changes->>'priority')::integer else priority end
+         priority = case when p_changes ? 'priority' then (p_changes->>'priority')::integer else priority end,
+         updated_at = pg_catalog.now()
    where id = p_template_id
    returning id into changed_id;
 

--- a/supabase/migrations/20260809045801_restrict_admin_operational_tables.sql
+++ b/supabase/migrations/20260809045801_restrict_admin_operational_tables.sql
@@ -16,6 +16,7 @@ create table if not exists public.admin_audit_events (
 alter table public.admin_audit_events enable row level security;
 revoke all on table public.admin_audit_events from public, anon, authenticated, service_role;
 create index if not exists admin_audit_events_created_at_idx on public.admin_audit_events (created_at);
+grant select on table public.push_templates, public.push_announcements to service_role;
 
 create or replace function public.prevent_admin_audit_event_mutation()
 returns trigger

--- a/supabase/tests/admin_authz.sql
+++ b/supabase/tests/admin_authz.sql
@@ -28,4 +28,36 @@ begin
   end if;
 end;
 $$;
+
+do $$
+declare
+  fresh_id uuid;
+  stale_id uuid;
+begin
+  insert into public.admin_audit_events (action, resource_type, resource_id, metadata)
+  values ('waitlist.delete', 'waitlist', gen_random_uuid(), '{}'::jsonb)
+  returning id into fresh_id;
+  begin
+    update public.admin_audit_events set metadata = '{"blocked":true}'::jsonb where id = fresh_id;
+    raise exception 'audit update unexpectedly succeeded';
+  exception when others then
+    null;
+  end;
+  begin
+    delete from public.admin_audit_events where id = fresh_id;
+    raise exception 'fresh audit delete unexpectedly succeeded';
+  exception when others then
+    null;
+  end;
+  insert into public.admin_audit_events (action, resource_type, resource_id, metadata, created_at)
+  values ('waitlist.delete', 'waitlist', gen_random_uuid(), '{}'::jsonb, now() - interval '3 years')
+  returning id into stale_id;
+  set role service_role;
+  perform public.cleanup_admin_audit_events();
+  reset role;
+  if exists (select 1 from public.admin_audit_events where id = stale_id) then
+    raise exception 'stale audit event was not cleaned up';
+  end if;
+end;
+$$;
 reset role;

--- a/supabase/tests/admin_authz.sql
+++ b/supabase/tests/admin_authz.sql
@@ -37,22 +37,33 @@ do $$
 declare
   fresh_id uuid;
   stale_id uuid;
+  update_succeeded boolean := false;
+  fresh_delete_succeeded boolean := false;
 begin
   insert into public.admin_audit_events (action, resource_type, resource_id, metadata)
   values ('waitlist.delete', 'waitlist', gen_random_uuid(), '{}'::jsonb)
   returning id into fresh_id;
   begin
     update public.admin_audit_events set metadata = '{"blocked":true}'::jsonb where id = fresh_id;
-    raise exception 'audit update unexpectedly succeeded';
+    update_succeeded := true;
   exception when others then
     null;
   end;
+  if update_succeeded then
+    raise exception 'audit update unexpectedly succeeded';
+  end if;
   begin
     delete from public.admin_audit_events where id = fresh_id;
-    raise exception 'fresh audit delete unexpectedly succeeded';
+    fresh_delete_succeeded := true;
   exception when others then
     null;
   end;
+  if fresh_delete_succeeded then
+    raise exception 'fresh audit delete unexpectedly succeeded';
+  end if;
+  if not exists (select 1 from public.admin_audit_events where id = fresh_id) then
+    raise exception 'fresh audit event was unexpectedly removed';
+  end if;
   insert into public.admin_audit_events (action, resource_type, resource_id, metadata, created_at)
   values ('waitlist.delete', 'waitlist', gen_random_uuid(), '{}'::jsonb, now() - interval '3 years')
   returning id into stale_id;

--- a/supabase/tests/admin_authz.sql
+++ b/supabase/tests/admin_authz.sql
@@ -1,0 +1,30 @@
+reset role;
+
+set role authenticated;
+
+do $$
+begin
+  if has_table_privilege(current_user, 'public.push_templates', 'SELECT') then
+    raise exception 'authenticated role can read push templates';
+  end if;
+  if has_table_privilege(current_user, 'public.push_announcements', 'SELECT') then
+    raise exception 'authenticated role can read push announcements';
+  end if;
+end;
+$$;
+
+reset role;
+set role anon;
+
+do $$
+begin
+  if has_table_privilege(current_user, 'public.push_templates', 'SELECT') then
+    raise exception 'anonymous role can read push templates';
+  end if;
+  if has_table_privilege(current_user, 'public.push_announcements', 'SELECT') then
+    raise exception 'anonymous role can read push announcements';
+  end if;
+end;
+$$;
+
+reset role;

--- a/supabase/tests/admin_authz.sql
+++ b/supabase/tests/admin_authz.sql
@@ -1,5 +1,19 @@
 reset role;
 
+do $$
+begin
+  if has_table_privilege('authenticated', 'public.admin_audit_events', 'SELECT') then
+    raise exception 'authenticated role can read admin audit events';
+  end if;
+  if has_table_privilege('anon', 'public.admin_audit_events', 'SELECT') then
+    raise exception 'anonymous role can read admin audit events';
+  end if;
+  if not has_table_privilege('service_role', 'public.admin_audit_events', 'INSERT') then
+    raise exception 'service_role cannot write admin audit events';
+  end if;
+end;
+$$;
+
 set role authenticated;
 
 do $$

--- a/supabase/tests/admin_authz.sql
+++ b/supabase/tests/admin_authz.sql
@@ -14,6 +14,10 @@ begin
      or has_table_privilege('service_role', 'public.admin_audit_events', 'DELETE') then
     raise exception 'service_role can mutate audit table directly';
   end if;
+  if not has_table_privilege('service_role', 'public.push_templates', 'SELECT')
+     or not has_table_privilege('service_role', 'public.push_announcements', 'SELECT') then
+    raise exception 'service_role lost admin operational read access';
+  end if;
   if not has_function_privilege('service_role', 'public.admin_update_push_template(uuid,uuid,jsonb)', 'EXECUTE') then
     raise exception 'service_role cannot execute template audit RPC';
   end if;

--- a/supabase/tests/admin_authz.sql
+++ b/supabase/tests/admin_authz.sql
@@ -20,34 +20,12 @@ begin
   if not has_function_privilege('service_role', 'public.admin_delete_waitlist_entry(uuid,uuid)', 'EXECUTE') then
     raise exception 'service_role cannot execute waitlist audit RPC';
   end if;
-end;
-$$;
-
-set role authenticated;
-
-do $$
-begin
-  if has_table_privilege(current_user, 'public.push_templates', 'SELECT') then
-    raise exception 'authenticated role can read push templates';
-  end if;
-  if has_table_privilege(current_user, 'public.push_announcements', 'SELECT') then
-    raise exception 'authenticated role can read push announcements';
+  if has_function_privilege('authenticated', 'public.admin_update_push_template(uuid,uuid,jsonb)', 'EXECUTE')
+     or has_function_privilege('authenticated', 'public.admin_delete_waitlist_entry(uuid,uuid)', 'EXECUTE')
+     or has_function_privilege('anon', 'public.admin_update_push_template(uuid,uuid,jsonb)', 'EXECUTE')
+     or has_function_privilege('anon', 'public.admin_delete_waitlist_entry(uuid,uuid)', 'EXECUTE') then
+    raise exception 'untrusted role can execute admin mutation RPC';
   end if;
 end;
 $$;
-
-reset role;
-set role anon;
-
-do $$
-begin
-  if has_table_privilege(current_user, 'public.push_templates', 'SELECT') then
-    raise exception 'anonymous role can read push templates';
-  end if;
-  if has_table_privilege(current_user, 'public.push_announcements', 'SELECT') then
-    raise exception 'anonymous role can read push announcements';
-  end if;
-end;
-$$;
-
 reset role;

--- a/supabase/tests/admin_authz.sql
+++ b/supabase/tests/admin_authz.sql
@@ -8,8 +8,17 @@ begin
   if has_table_privilege('anon', 'public.admin_audit_events', 'SELECT') then
     raise exception 'anonymous role can read admin audit events';
   end if;
-  if not has_table_privilege('service_role', 'public.admin_audit_events', 'INSERT') then
-    raise exception 'service_role cannot write admin audit events';
+  if has_table_privilege('service_role', 'public.admin_audit_events', 'SELECT')
+     or has_table_privilege('service_role', 'public.admin_audit_events', 'INSERT')
+     or has_table_privilege('service_role', 'public.admin_audit_events', 'UPDATE')
+     or has_table_privilege('service_role', 'public.admin_audit_events', 'DELETE') then
+    raise exception 'service_role can mutate audit table directly';
+  end if;
+  if not has_function_privilege('service_role', 'public.admin_update_push_template(uuid,uuid,jsonb)', 'EXECUTE') then
+    raise exception 'service_role cannot execute template audit RPC';
+  end if;
+  if not has_function_privilege('service_role', 'public.admin_delete_waitlist_entry(uuid,uuid)', 'EXECUTE') then
+    raise exception 'service_role cannot execute waitlist audit RPC';
   end if;
 end;
 $$;


### PR DESCRIPTION
## 목적

BOK-396의 관리자 변경을 append-only 감사 기록과 원자적으로 묶습니다. 이 PR은 audit/RPC prerequisite만 제공하며, 기존 push template/announcement direct-read privilege revoke는 후속 migration으로 분리합니다.

## 변경 내용

- append-only `admin_audit_events` 테이블과 2년 bounded cleanup function 추가
- 감사 테이블 직접 SELECT/INSERT/UPDATE/DELETE를 모든 호출자에게 차단하고 service-role 전용 RPC 실행만 허용
- `admin_update_push_template`와 `admin_delete_waitlist_entry`가 matched mutation과 최소 감사 기록을 한 트랜잭션으로 수행
- actor/resource/action/metadata 제약, created_at 인덱스와 immutable trigger 추가
- 계정 삭제 시 audit actor UUID는 보존하며 audit 행을 변경하지 않도록 FK를 두지 않음
- cleanup 경로에만 2년 초과 행의 bounded delete를 허용
- Web server API 조회에 필요한 `push_templates`/`push_announcements` service_role SELECT grant를 명시
- RPC 길이/타입/필드 검증과 anon/authenticated/service-role grant 및 execute 권한 fixture를 Schema Validation에 연결

## 롤아웃 순서

1. 이 PR의 audit/RPC migration을 적용
2. Web admin server API PR #360을 배포
3. 별도 후속 migration에서 `push_templates`/`push_announcements` direct-read privilege revoke를 적용
4. admin 화면의 API 경로와 direct-read 폐기를 함께 확인

이 PR은 direct-read 권한을 아직 revoke하지 않으므로, 후속 revoke migration 전에는 PR #360을 운영 전환하지 않습니다.

## 검증

- git diff --check 통과
- trusted Schema Validation에서 isolated DB migration/lint와 `admin_authz.sql` fixture 실행
- production/dev database, secret, push, deployment는 실행하지 않았습니다.

## 잔여 위험

- 후속 revoke-only migration이 적용되기 전에는 기존 authenticated RLS direct-read 경로가 남아 있습니다.
- 관리자 권한의 email allowlist에서 protected `users.role`로의 전환과 send-fcm-push self-send 정책은 별도 follow-up입니다.
- remote migration list, repair, db push, production deployment는 이 PR의 권한 범위가 아닙니다.

## 관련 이슈

- BOK-396 / REL-102-40

Target-Delivery-Unit: backend
Target-Version: 1.0.2
Delivery-Profile: backend-service


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a secure, append-only audit trail for administrative actions.
  * Administrative push-template updates and waitlist deletions are now validated and recorded.
  * Added automatic cleanup of audit records older than two years.

* **Security**
  * Restricted administrative operations and audit data to authorized service access.
  * Prevented unauthorized modification or deletion of audit history.

* **Tests**
  * Added authorization and audit-integrity checks to the migration validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->