### PR TITLE
chore(governance): register Web 1.0.2 promotion source

### DIFF
--- a/.byungskerlab/release-lines.json
+++ b/.byungskerlab/release-lines.json
@@ -34,7 +34,12 @@
         "docs/product-roadmap.md"
       ],
       "promotion_sources": {
-        "release": {},
+        "release": {
+          "1.0.2": {
+            "branch": "version/web/1.0.2",
+            "sha": "f3db1a83dc55eaaec9587dfa370530496981d30c"
+          }
+        },
         "hotfix": {}
       }
     },

--- a/.byungskerlab/release-lines.json
+++ b/.byungskerlab/release-lines.json
@@ -37,7 +37,7 @@
         "release": {
           "1.0.2": {
             "branch": "version/web/1.0.2",
-            "sha": "f3db1a83dc55eaaec9587dfa370530496981d30c"
+            "sha": "df9db70c2311bce152498d43ac5162a850ad5239"
           }
         },
         "hotfix": {}


### PR DESCRIPTION
## 목적

Web 1.0.2 승격 전에 검증된 version line 커밋을 release registry에 등록해 Target Delivery Contract의 promotion source 검증을 활성화합니다.

## 주요 변경

- `web 1.0.2` release source를 `version/web/1.0.2`로 등록
- source SHA를 #359 merge commit(기존 #360 Web API 이후) `df9db70c2311bce152498d43ac5162a850ad5239`로 고정
- release promotion PR이 provider ancestry 비교를 통해 동일 source를 검증할 수 있게 정합화

## 배경

PR #360은 `version/web/1.0.2`에 병합되었지만 아직 `main`으로 승격되지 않았습니다. #364의 직접 읽기 권한 폐기는 Web API가 production main에 도달한 뒤에만 적용해야 하므로, 먼저 release registry에 정확한 promotion source를 기록해야 합니다.

## 검증

- governance Target Delivery preflight 통과
- `release-lines.json` JSON parse 통과
- `git diff --check` 통과
- source branch/SHA 확인: `version/web/1.0.2` @ `df9db70c2311bce152498d43ac5162a850ad5239`

## 관련 이슈

- BOK-396

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local

