### PR TITLE
chore(governance): sync Web 1.0.2 source to dev

### DIFF
--- a/.byungskerlab/release-lines.json
+++ b/.byungskerlab/release-lines.json
@@ -34,7 +34,12 @@
         "docs/product-roadmap.md"
       ],
       "promotion_sources": {
-        "release": {},
+        "release": {
+          "1.0.2": {
+            "branch": "version/web/1.0.2",
+            "sha": "df9db70c2311bce152498d43ac5162a850ad5239"
+          }
+        },
         "hotfix": {}
       }
     },


### PR DESCRIPTION
## 목적

Trusted Target Version validator가 사용하는 `dev` governance registry에 Web 1.0.2 promotion source를 동기화합니다.

## 주요 변경

- `web 1.0.2` source branch를 `version/web/1.0.2`로 등록
- source SHA를 PR #359 merge commit `df9db70c2311bce152498d43ac5162a850ad5239`로 고정
- `main`과 `dev`의 release promotion evidence 정합화

## 배경

`main` registry에는 source가 등록되어 있지만 trusted validator의 기준 branch인 `dev`에는 비어 있어 Web release promotion PR이 fail-closed 되었습니다. 이 PR은 governance registry만 동기화하며 Web promotion이나 production 배포를 수행하지 않습니다.

## 검증

- governance Target Delivery preflight
- JSON parse
- `git diff --check`
- source branch/SHA 확인: `version/web/1.0.2` @ `df9db70c2311bce152498d43ac5162a850ad5239`

## 관련 이슈

- BOK-396

Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local
