### PR TITLE
chore(governance): activate web 1.1.0 and agent discovery 0.1.0

### DIFF
--- a/.byungskerlab/branch-policy.json
+++ b/.byungskerlab/branch-policy.json
@@ -67,7 +67,8 @@
       "profile": "web-release-train",
       "mode": "version-line",
       "active_versions": [
-        "1.0.2"
+        "1.0.2",
+        "1.1.0"
       ],
       "target_version_source": ".byungskerlab/release-lines.json",
       "production_branch": "main",
@@ -94,6 +95,20 @@
         ".github/workflows/schema-check.yml",
         "docs/**",
         "supabase/**"
+      ]
+    },
+    "agent_api_cli": {
+      "profile": "package-or-local",
+      "mode": "continuous",
+      "active_versions": [
+        "0.1.0"
+      ],
+      "target_version_source": ".byungskerlab/release-lines.json",
+      "production_branch": "main",
+      "allowed_paths": [
+        "agent-api/**",
+        "cli/**",
+        "docs/agent/**"
       ]
     }
   }

--- a/.byungskerlab/release-lines.json
+++ b/.byungskerlab/release-lines.json
@@ -27,7 +27,8 @@
     },
     "web": {
       "active_versions": [
-        "1.0.2"
+        "1.0.2",
+        "1.1.0"
       ],
       "evidence_refs": [
         "AGENTS.md",
@@ -46,6 +47,18 @@
     "backend": {
       "active_versions": [
         "1.0.2"
+      ],
+      "evidence_refs": [
+        "docs/product-roadmap.md"
+      ],
+      "promotion_sources": {
+        "release": {},
+        "hotfix": {}
+      }
+    },
+    "agent_api_cli": {
+      "active_versions": [
+        "0.1.0"
       ],
       "evidence_refs": [
         "docs/product-roadmap.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,7 @@ UI (lib/ui/) → ViewModel → Repository → Service
 | `app/` iOS/Android 앱 | `mobile-store` |
 | `web/` Next.js Admin | `web-release-train` |
 | `supabase/` Functions 및 DB | 모바일 결합 시 `mobile-store`, 독립 배포 시 `backend-service` |
+| `agent-api/`, `cli/` | `package-or-local` |
 
 ### Repository-Specific Rules
 
@@ -152,8 +153,9 @@ UI (lib/ui/) → ViewModel → Repository → Service
 - 기계 검증 가능한 활성 버전 원본은 `release-lines.json`이며, 현재
   승인된 모바일 타깃 `1.0.2`의 근거는 `docs/product-roadmap.md`이다.
   현재 앱 매니페스트 버전은 후속 모바일 작업에서 타깃 버전에 맞춘다.
-  독립 Web admin의 승인된 parallel release train은 `1.0.2`이며,
+  독립 Web admin의 승인된 parallel release train은 `1.0.2`와 `1.1.0`이며,
   독립 backend service도 `1.0.2` release line을 사용하며,
+  Agent API/CLI contract-first bundle은 `agent_api_cli 0.1.0`을 사용하며,
   `docs/product-roadmap.md`가 그 evidence를 기록한다. `AGENTS.md`와 각
   delivery unit의
   active version이 일치하지 않으면 브랜치나 PR을 만들 수 없다.
@@ -165,6 +167,10 @@ UI (lib/ui/) → ViewModel → Repository → Service
 - `web/`은 승인된 버전마다 운영 `main`에서
   `version/web/x.y.z`를 열고 같은 버전 작업만 받은 뒤
   `release/web/x.y.z` QA를 거쳐 `main`으로 승격한다.
+- `agent_api_cli 0.1.0`은 API contract와 CLI companion을 함께 다루는
+  contract-first implementation line이다. 초기 구현은 인증·사용자 범위·read-only와
+  구조화된 CLI 계약을 우선하며, API와 CLI의 promotion path가 독립되면
+  공개·배포 전에 delivery unit을 분리한다.
 - 현재 `ios-testflight.yml`과 `ios-production.yml`이 Supabase migration과
   Functions 배포를 함께 수행한다. 이 결합을 제거하기 전까지 자동
   Supabase 배포는 `mobile-store` 흐름을 따른다.

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -1,6 +1,6 @@
 # Bookgolas Product Roadmap
 
-Last updated: 2026-08-05
+Last updated: 2026-08-12
 
 ## Target Delivery Contract
 
@@ -12,9 +12,17 @@ Target-Delivery-Unit: web
 Target-Version: 1.0.2
 Delivery-Profile: web-release-train
 
+Target-Delivery-Unit: web
+Target-Version: 1.1.0
+Delivery-Profile: web-release-train
+
 Target-Delivery-Unit: backend
 Target-Version: 1.0.2
 Delivery-Profile: backend-service
+
+Target-Delivery-Unit: agent_api_cli
+Target-Version: 0.1.0
+Delivery-Profile: package-or-local
 
 ## Priority order
 
@@ -24,8 +32,18 @@ Bookgolas follows this release order:
 2. Prepare and validate the Android / Google Play release.
 3. Publish the Android release to Google Play after the test and policy gates pass.
 
+Owner-approved sequencing override (2026-08-12): byungsker approved starting
+the P3 and P4 discovery issues in parallel with unfinished P0–P2 delivery work.
+This changes discovery sequencing only; it does not change the release
+priority, authorize production deployment, public package publication,
+subscription reactivation, or destructive data access.
+
 The independently delivered web admin has an approved parallel release train:
 **web 1.0.2**. It does not change the mobile 1.0.2 binary scope.
+
+The consumer web parity surface has an approved discovery and implementation
+target of **web 1.1.0**. It is a separate web release line from the web 1.0.2
+admin train and remains separately gated for consumer production launch.
 
 ## P0 — 1.0.2 patch release
 
@@ -96,6 +114,70 @@ Exit gate:
   unavailable rather than appearing as zero.
 - Admin and non-admin authorization checks, lint, build, and browser smoke
   checks pass on the approved web release line.
+
+## P3 — Consumer Web Parity Discovery
+
+Bookgolas will provide the mobile app's supported reading experience through an
+authenticated consumer web surface. The web surface shares the mobile account,
+data, domain states, permissions, and product language. Only platform-native
+capabilities are excluded or replaced with an equivalent browser interaction.
+
+Initial discovery scope:
+
+- Build the app-to-web parity matrix and native-exception policy.
+- Audit Supabase Auth, RLS, Storage, Edge Functions, and cross-surface sync in
+  the Development environment using read-only checks.
+- Establish the BLab/Figma visual baseline and responsive/accessibility
+  contract, or record an explicit exception to BOK-376.
+- Define and validate the M0 vertical slice: sign-in, home, book detail, page
+  update, reload, and mobile/web synchronization.
+- Confirm the web route tree and the release acceptance gates for M1 core
+  parity.
+
+Target implementation line: approved `web 1.1.0` with `web-release-train`.
+The discovery issue is evidence-only and does not authorize consumer
+implementation, branch creation, deployment, publication, or a consumer
+production launch.
+
+Start gate: P0 patch, P1 Android readiness, and P2 Google Play launch remain
+ahead in product release priority. The owner-approved 2026-08-12 sequencing
+override permits this bounded discovery to run in parallel.
+
+Success gate: the parity matrix, exception policy, data/security audit, M0
+acceptance checks, and owner decisions are recorded and ready for a separate
+implementation work package.
+
+Executable issue: BOK-411.
+
+## P4 — Agent access surface discovery
+
+Bookgolas will expose its existing reading capabilities to AI agents through a
+versioned Agent API and a CLI-first companion surface. The CLI is an
+independently versioned client of the Bookgolas product, not a separate product
+at this stage.
+
+Initial target delivery contract: `agent_api_cli 0.1.0` with the
+`package-or-local` profile. This is a bounded discovery bundle for the API
+contract and CLI companion. Before either surface is independently deployed or
+published, the delivery contract must be re-evaluated and split into an API
+backend unit and a CLI package unit if their promotion paths differ.
+
+Initial scope:
+
+- Define the repeated agent job and capability catalog.
+- Establish the authenticated, user-scoped Agent API contract.
+- Build a deterministic `bookgolas` CLI with JSON output and stable exit codes.
+- Start with read-only commands for book search, library, reading progress,
+  Recall, and reading insights.
+- Redesign the Bookgolas Pro package and AI usage economics before subscription
+  reactivation or public CLI access.
+
+Start gate: P0, P1, P2, and P3 remain the product release priority. The
+owner-approved 2026-08-12 sequencing override permits bounded discovery in
+parallel. This lane does not authorize production deployment, public package
+publication, subscription reactivation, or destructive data access.
+
+Executable issue: BOK-406.
 
 ## Current evidence and unknowns
 

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -166,7 +166,8 @@ Initial scope:
 
 - Define the repeated agent job and capability catalog.
 - Establish the authenticated, user-scoped Agent API contract.
-- Build a deterministic `bookgolas` CLI with JSON output and stable exit codes.
+- Define the deterministic `bookgolas` CLI contract, including JSON output and
+  stable exit codes, for a separately authorized implementation work package.
 - Start with read-only commands for book search, library, reading progress,
   Recall, and reading insights.
 - Redesign the Bookgolas Pro package and AI usage economics before subscription

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -149,7 +149,7 @@ implementation work package.
 
 Executable issue: BOK-411.
 
-## P4 — Agent access surface discovery
+## P4 — Agent access surface discovery and implementation
 
 Bookgolas will expose its existing reading capabilities to AI agents through a
 versioned Agent API and a CLI-first companion surface. The CLI is an
@@ -157,26 +157,29 @@ independently versioned client of the Bookgolas product, not a separate product
 at this stage.
 
 Initial target delivery contract: `agent_api_cli 0.1.0` with the
-`package-or-local` profile. This is a bounded discovery bundle for the API
-contract and CLI companion. Before either surface is independently deployed or
-published, the delivery contract must be re-evaluated and split into an API
-backend unit and a CLI package unit if their promotion paths differ.
+`package-or-local` profile. This is a contract-first implementation line for
+BOK-406: the first work package defines and verifies the authenticated,
+read-only API and CLI contracts before expanding behavior. Before either
+surface is independently deployed or published, the delivery contract must be
+re-evaluated and split into an API backend unit and a CLI package unit if their
+promotion paths differ.
 
 Initial scope:
 
 - Define the repeated agent job and capability catalog.
 - Establish the authenticated, user-scoped Agent API contract.
-- Define the deterministic `bookgolas` CLI contract, including JSON output and
-  stable exit codes, for a separately authorized implementation work package.
+- Build the deterministic `bookgolas` CLI with JSON output and stable exit
+  codes, beginning with a contract-first, read-only implementation.
 - Start with read-only commands for book search, library, reading progress,
   Recall, and reading insights.
 - Redesign the Bookgolas Pro package and AI usage economics before subscription
   reactivation or public CLI access.
 
 Start gate: P0, P1, P2, and P3 remain the product release priority. The
-owner-approved 2026-08-12 sequencing override permits bounded discovery in
-parallel. This lane does not authorize production deployment, public package
-publication, subscription reactivation, or destructive data access.
+owner-approved 2026-08-12 sequencing override permits BOK-406's bounded,
+contract-first implementation in parallel. This lane does not authorize
+production deployment, public package publication, subscription reactivation,
+or destructive data access.
 
 Executable issue: BOK-406.
 


### PR DESCRIPTION
Target-Delivery-Unit: governance
Target-Version: 1.0.0
Delivery-Profile: package-or-local

## 목적
Web 1.1.0 소비자 웹 parity work와 Agent API/CLI 0.1.0 contract-first implementation line을 승인된 로드맵·활성 버전 계약으로 등록합니다.

## 주요 변경
- branch-policy와 release-lines의 Web active versions에 1.1.0을 추가했습니다.
- agent_api_cli 0.1.0 delivery unit과 package-or-local 계약을 추가했습니다.
- AGENTS.md에 새 active target과 API/CLI contract-first promotion 경계를 반영했습니다.
- P3/P4 owner-approved parallel start와 API·CLI 독립 배포 전 delivery unit 재평가 조건을 로드맵에 기록했습니다.

## 배경
byungsker가 2026-08-12 두 이슈의 버전을 지정하고 시작하도록 승인했습니다. 이 PR은 target governance와 contract-first work line만 등록하며, 실제 웹/API/CLI 구현은 해당 이슈의 후속 work PR에서 검증합니다. production deployment, public package publication, subscription reactivation, consumer launch는 승인하지 않습니다.

## 검증
- JSON syntax validation passed for branch policy and release registry.
- Target delivery preflight passed for governance 1.0.0, web 1.1.0, and agent_api_cli 0.1.0.
- Target-version validator passed with governance branch, dev base, and governance-allowlisted changed paths.
- git diff --check passed.

## 관련 이슈
- BOK-411 — Consumer Web Parity Discovery
- BOK-406 — Agent API 및 CLI surface 구축

## 제한
This PR does not implement web, API, or CLI behavior and does not publish or deploy any product surface.